### PR TITLE
[design] 경기 일정 아이템 팀명 세로 가운데 정렬 적용

### DIFF
--- a/src/pages/home/ui/GameSchedule.tsx
+++ b/src/pages/home/ui/GameSchedule.tsx
@@ -1,16 +1,9 @@
 import { useMemo, useState } from "react";
 import { ChevronLeft, ChevronRight, TicketX } from "lucide-react";
 
-<<<<<<< HEAD
-import { cn } from '@/shared/lib/utils';
-import { Badge } from '@/shared/ui/badge';
-import { Button } from '@/shared/ui/button';
-import { teams } from '@/entities/team/model/teams';
-=======
 import { cn } from "@/shared/lib/utils";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
->>>>>>> 093eae2 ([design] 팀명 세로 가운데 정렬 적용 #55)
 
 import {
   CURRENT_MONTH,
@@ -198,26 +191,6 @@ const GameSchedule = () => {
           있습니다.
         </p>
 
-<<<<<<< HEAD
-            <div className="flex items-center justify-between">
-               {teamOrder.map(team => {
-                  const teamId = teamIds[team];
-                  const isEnabled = teams.find(t => t.id === teamId)?.isEnabled ?? false;
-                  return (
-                     <button
-                        key={team}
-                        onClick={() => isEnabled && navigate(`/teams/${teamId}`)}
-                        disabled={!isEnabled}
-                        className={cn(
-                           'flex items-center justify-center size-20 p-2.5 rounded-xl transition-colors overflow-hidden',
-                           isEnabled ? 'hover:bg-fill-hoveraccent cursor-pointer' : 'opacity-30 cursor-not-allowed',
-                        )}
-                     >
-                        <img src={teamLogos[team]} alt={team} className="w-full h-full object-contain" />
-                     </button>
-                  );
-               })}
-=======
         <div className="flex items-center justify-between">
           {teamOrder.map((team) => (
             <button
@@ -311,7 +284,6 @@ const GameSchedule = () => {
                   onClose={() => setShowWeekPicker(false)}
                 />
               )}
->>>>>>> 093eae2 ([design] 팀명 세로 가운데 정렬 적용 #55)
             </div>
 
             <div className="flex gap-[30px] justify-center">

--- a/src/pages/home/ui/GameSchedule.tsx
+++ b/src/pages/home/ui/GameSchedule.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useState } from "react";
 import { ChevronLeft, ChevronRight, TicketX } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 import { cn } from "@/shared/lib/utils";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
+import { teams } from "@/entities/team/model/teams";
 
 import {
   CURRENT_MONTH,
@@ -26,6 +28,19 @@ import {
 import type { GameRow } from "./game-schedule/types";
 import { filterScheduleData, getGameResultTexts } from "./game-schedule/utils";
 import YearMonthPicker from "./game-schedule/YearMonthPicker";
+
+const teamIds: Record<string, string> = {
+  LG: "lg",
+  한화: "hanwha",
+  SSG: "ssg",
+  삼성: "samsung",
+  NC: "nc",
+  KT: "kt",
+  롯데: "lotte",
+  두산: "doosan",
+  키움: "kiwoom",
+  KIA: "kia",
+};
 
 // 종료 경기 스코어: 패한 팀 점수는 회색, 이긴 팀 점수는 빨강
 function ScoreDisplay({ game }: { game: GameRow }) {
@@ -132,8 +147,8 @@ function ActionButtons({ game, isEnded }: { game: GameRow; isEnded: boolean }) {
 }
 
 const GameSchedule = () => {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState(TAB_TODAY);
-  const [selectedTeam, setSelectedTeam] = useState<string | null>(null);
 
   // 주간 일정 state
   const [weekYear, setWeekYear] = useState(CURRENT_YEAR);
@@ -153,9 +168,8 @@ const GameSchedule = () => {
         weekMonth,
         selectedWeek,
         allMonth,
-        selectedTeam,
       }),
-    [activeTab, weekMonth, selectedWeek, allMonth, selectedTeam],
+    [activeTab, weekMonth, selectedWeek, allMonth],
   );
 
   const prevWeekMonth = () => {
@@ -192,25 +206,28 @@ const GameSchedule = () => {
         </p>
 
         <div className="flex items-center justify-between">
-          {teamOrder.map((team) => (
-            <button
-              key={team}
-              onClick={() =>
-                setSelectedTeam(selectedTeam === team ? null : team)
-              }
-              className={cn(
-                "flex items-center justify-center size-[80px] p-[10px] rounded-xl transition-colors overflow-hidden",
-                selectedTeam === team &&
-                  "bg-(--fill-hoveraccent) ring-2 ring-primary",
-              )}
-            >
-              <img
-                src={teamLogos[team]}
-                alt={team}
-                className="w-full h-full object-contain"
-              />
-            </button>
-          ))}
+          {teamOrder.map((team) => {
+            const teamId = teamIds[team];
+            const isEnabled = teams.find((candidate) => candidate.id === teamId)?.isEnabled ?? false;
+
+            return (
+              <button
+                key={team}
+                onClick={() => isEnabled && navigate(`/teams/${teamId}`)}
+                disabled={!isEnabled}
+                className={cn(
+                  "flex items-center justify-center size-[80px] p-[10px] rounded-xl transition-colors overflow-hidden",
+                  isEnabled ? "hover:bg-fill-hoveraccent cursor-pointer" : "opacity-30 cursor-not-allowed",
+                )}
+              >
+                <img
+                  src={teamLogos[team]}
+                  alt={team}
+                  className="w-full h-full object-contain"
+                />
+              </button>
+            );
+          })}
         </div>
 
         <div className="flex gap-5 border-b border-(--border-normal)">

--- a/src/pages/home/ui/GameSchedule.tsx
+++ b/src/pages/home/ui/GameSchedule.tsx
@@ -1,155 +1,41 @@
+import { useMemo, useState } from 'react';
+import { ChevronLeft, ChevronRight, TicketX } from 'lucide-react';
+
 import { cn } from '@/shared/lib/utils';
-import { useState, useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, ChevronUp, ChevronDown, TicketX } from 'lucide-react';
 import { Badge } from '@/shared/ui/badge';
 import { Button } from '@/shared/ui/button';
 import { teams } from '@/entities/team/model/teams';
 
-const teamIds: Record<string, string> = {
-   LG: 'lg',
-   한화: 'hanwha',
-   SSG: 'ssg',
-   삼성: 'samsung',
-   NC: 'nc',
-   KT: 'kt',
-   롯데: 'lotte',
-   두산: 'doosan',
-   키움: 'kiwoom',
-   KIA: 'kia',
-};
-const teamOrder = ['LG', '한화', 'SSG', '삼성', 'NC', 'KT', '롯데', '두산', '키움', 'KIA'];
-
-// 팀 로고 이미지 (Figma asset)
-const teamLogos: Record<string, string> = {
-   LG: '/baseball/logos/lg.png',
-   한화: '/baseball/logos/hanwha.png',
-   SSG: '/baseball/logos/ssg.png',
-   삼성: '/baseball/logos/samsung.png',
-   NC: '/baseball/logos/nc.png',
-   KT: '/baseball/logos/kt.png',
-   롯데: '/baseball/logos/lotte.png',
-   두산: '/baseball/logos/doosan.png',
-   키움: '/baseball/logos/kiwoom.png',
-   KIA: '/baseball/logos/kia.png',
-};
-
-type GameStatus = '경기중' | '예정' | '종료' | '취소';
-type TicketStatus = '예매하기' | '매진' | '판매예정';
-type ReselStatus = '리셀예매' | '리셀매진' | '리셀예정';
-
-type GameRow = {
-   time: string;
-   venue: string;
-   away: string;
-   home: string;
-   score: string | null;
-   status: GameStatus;
-   ticket: TicketStatus;
-   resell: ReselStatus;
-   ticketInfo?: string;
-   reselInfo?: string;
-};
-
-type DaySchedule = { date: string; isToday?: boolean; games: GameRow[] };
-
-const scheduleData: DaySchedule[] = [
-   {
-      date: '7월 1일 (수)',
-      games: [
-         {
-            time: '18:30',
-            venue: '잠실',
-            away: 'KIA',
-            home: 'LG',
-            score: '5:3',
-            status: '종료',
-            ticket: '매진',
-            resell: '리셀매진',
-         },
-      ],
-   },
-   {
-      date: '7월 3일 (금)',
-      isToday: true,
-      games: [
-         {
-            time: '18:30',
-            venue: '잠실',
-            away: 'KIA',
-            home: 'LG',
-            score: '2:1',
-            status: '경기중',
-            ticket: '예매하기',
-            resell: '리셀매진',
-         },
-         {
-            time: '18:30',
-            venue: '대구',
-            away: '두산',
-            home: '삼성',
-            score: null,
-            status: '예정',
-            ticket: '예매하기',
-            resell: '리셀예매',
-         },
-      ],
-   },
-   {
-      date: '7월 5일 (일)',
-      games: [
-         {
-            time: '17:00',
-            venue: '잠실',
-            away: 'KIA',
-            home: 'LG',
-            score: null,
-            status: '예정',
-            ticket: '판매예정',
-            resell: '리셀예정',
-            ticketInfo: '6월 25일\n오전 11시 오픈',
-            reselInfo: '정식 예매 오픈\n2시간 후',
-         },
-      ],
-   },
-];
-
-const statusColor: Record<GameStatus, string> = {
-   경기중: 'text-[#38c976]',
-   예정: 'text-primary',
-   종료: 'text-[#ef4444]',
-   취소: 'text-[#acb4bb]',
-};
-
-const TODAY = '7월 3일 (금)';
-const CURRENT_YEAR = 2025;
-const CURRENT_MONTH = 7;
-const CURRENT_WEEK = 1;
-
-// 시즌 월 순서: 3월~12월, 1월, 2월
-const SEASON_MONTHS = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2];
-const DISABLED_MONTHS = [10, 11, 12, 1, 2];
-const AVAILABLE_YEARS = [2021, 2022, 2023, 2024, 2025, 2026];
-
-const tabs = ['오늘 일정', '주간 일정', '전체 일정'];
-
-function parseDate(dateStr: string): { month: number; day: number } {
-   const match = dateStr.match(/(\d+)월 (\d+)일/);
-   if (!match) return { month: 0, day: 0 };
-   return { month: parseInt(match[1]), day: parseInt(match[2]) };
-}
-
-function getWeekOfMonth(day: number): number {
-   return Math.ceil(day / 7);
-}
+import {
+   CURRENT_MONTH,
+   CURRENT_WEEK,
+   CURRENT_YEAR,
+   DISABLED_MONTHS,
+   SEASON_MONTHS,
+   TAB_ALL,
+   TAB_TODAY,
+   TAB_WEEK,
+   TODAY,
+   WEEK_OPTIONS,
+   AVAILABLE_YEARS,
+   scheduleData,
+   statusColor,
+   tabs,
+   teamLogos,
+   teamOrder,
+} from './game-schedule/constants';
+import type { GameRow } from './game-schedule/types';
+import { filterScheduleData, getGameResultTexts } from './game-schedule/utils';
+import YearMonthPicker from './game-schedule/YearMonthPicker';
 
 // 종료 경기 스코어: 패한 팀 점수는 회색, 이긴 팀 점수는 빨강
 function ScoreDisplay({ game }: { game: GameRow }) {
-   const scoreStr = game.score ?? 'VS';
+   const scoreText = game.score ?? 'VS';
 
    if (game.status === '종료' && game.score) {
       const [awayScore, homeScore] = game.score.split(':').map(Number);
       const awayLost = awayScore < homeScore;
+
       return (
          <span className="text-[24px] font-bold text-center leading-[1.5] whitespace-nowrap text-[#ef4444]">
             <span className={awayLost ? 'text-[#acb4bb]' : ''}>{awayScore}:</span>
@@ -160,7 +46,7 @@ function ScoreDisplay({ game }: { game: GameRow }) {
 
    return (
       <span className="text-[24px] font-bold text-(--text-primary) text-center leading-[1.5] whitespace-nowrap">
-         {scoreStr}
+         {scoreText}
       </span>
    );
 }
@@ -178,130 +64,72 @@ function EmptyState() {
    );
 }
 
-// Year-Month 피커 드롭다운
-function YearMonthPicker({
-   year,
-   month,
-   onConfirm,
-   onClose,
+function TeamName({
+   name,
+   isEnded,
+   result,
+   textDisabled,
 }: {
-   year: number;
-   month: number;
-   onConfirm: (year: number, month: number) => void;
-   onClose: () => void;
+   name: string;
+   isEnded: boolean;
+   result: string;
+   textDisabled: string;
 }) {
-   const [localYear, setLocalYear] = useState(year);
-   const [localMonth, setLocalMonth] = useState(month);
-   const pickerRef = useRef<HTMLDivElement>(null);
-
-   useEffect(() => {
-      function handleClickOutside(e: MouseEvent) {
-         if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
-            onClose();
-         }
-      }
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
-   }, [onClose]);
-
-   const yearIdx = AVAILABLE_YEARS.indexOf(localYear);
-   const canPrevYear = yearIdx > 0;
-   const canNextYear = yearIdx < AVAILABLE_YEARS.length - 1;
+   if (isEnded) {
+      return (
+         <div className="flex flex-col items-center shrink-0">
+            <span
+               className={cn(
+                  'text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap',
+                  textDisabled,
+               )}
+            >
+               {name}
+            </span>
+            <span className="text-[12px] font-medium text-(--text-tertiary) leading-[1.5]">{result}</span>
+         </div>
+      );
+   }
 
    return (
-      <div
-         ref={pickerRef}
-         className="absolute top-10 left-1/2 -translate-x-1/2 z-50 bg-white rounded-[12px] shadow-xl border border-(--border-normal) overflow-hidden"
-      >
-         <div className="flex">
-            {/* 연도 컬럼 */}
-            <div className="flex flex-col items-center w-[100px] border-r border-(--border-normal)">
-               <button
-                  onClick={() => canPrevYear && setLocalYear(AVAILABLE_YEARS[yearIdx - 1])}
-                  disabled={!canPrevYear}
-                  className="flex items-center justify-center w-full py-[10px] text-[#646f7c] hover:bg-gray-50 disabled:opacity-30"
-               >
-                  <ChevronUp className="size-5" />
-               </button>
-               <div className="flex flex-col items-center w-full py-[6px]">
-                  {AVAILABLE_YEARS.map(y => (
-                     <button
-                        key={y}
-                        onClick={() => setLocalYear(y)}
-                        className={cn(
-                           'w-full py-[8px] text-center text-[16px] leading-[1.5] transition-colors',
-                           y === localYear
-                              ? 'font-bold text-(--text-primary)'
-                              : 'font-medium text-[#acb4bb] hover:text-(--text-primary)',
-                        )}
-                     >
-                        {y}
-                     </button>
-                  ))}
-               </div>
-               <button
-                  onClick={() => canNextYear && setLocalYear(AVAILABLE_YEARS[yearIdx + 1])}
-                  disabled={!canNextYear}
-                  className="flex items-center justify-center w-full py-[10px] text-[#646f7c] hover:bg-gray-50 disabled:opacity-30"
-               >
-                  <ChevronDown className="size-5" />
-               </button>
-            </div>
+      <div className="flex flex-col h-full items-center justify-between shrink-0">
+         <div className="h-[18px] w-full shrink-0" />
+         <span className="text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap text-(--text-primary)">
+            {name}
+         </span>
+         <div />
+      </div>
+   );
+}
 
-            {/* 월 컬럼 */}
-            <div className="flex flex-col items-center w-[80px]">
-               <button
-                  onClick={() => setLocalMonth(m => (m === 1 ? 12 : m - 1))}
-                  className="flex items-center justify-center w-full py-[10px] text-[#646f7c] hover:bg-gray-50"
-               >
-                  <ChevronUp className="size-5" />
-               </button>
-               <div className="flex flex-col items-center w-full py-[6px]">
-                  {Array.from({ length: 12 }, (_, i) => i + 1).map(m => (
-                     <button
-                        key={m}
-                        onClick={() => setLocalMonth(m)}
-                        className={cn(
-                           'w-full py-[8px] text-center text-[16px] leading-[1.5] transition-colors',
-                           m === localMonth
-                              ? 'font-bold text-(--text-primary)'
-                              : 'font-medium text-[#acb4bb] hover:text-(--text-primary)',
-                        )}
-                     >
-                        {String(m).padStart(2, '0')}
-                     </button>
-                  ))}
-               </div>
-               <button
-                  onClick={() => setLocalMonth(m => (m === 12 ? 1 : m + 1))}
-                  className="flex items-center justify-center w-full py-[10px] text-[#646f7c] hover:bg-gray-50"
-               >
-                  <ChevronDown className="size-5" />
-               </button>
-            </div>
-         </div>
-
-         <div className="flex border-t border-(--border-normal)">
-            <button
-               onClick={onClose}
-               className="flex-1 py-[12px] text-[14px] font-medium text-[#646f7c] hover:bg-gray-50"
-            >
-               취소
-            </button>
-            <button
-               onClick={() => onConfirm(localYear, localMonth)}
-               className="flex-1 py-[12px] text-[14px] font-semibold text-primary border-l border-(--border-normal) hover:bg-blue-50"
-            >
-               확인
-            </button>
-         </div>
+function ActionButtons({ game, isEnded }: { game: GameRow; isEnded: boolean }) {
+   return (
+      <div className={cn('flex gap-[10px] h-[66px] items-center shrink-0', isEnded && 'opacity-0')}>
+         <button
+            className={cn(
+               'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] text-white',
+               game.ticket === '예매하기' ? 'bg-primary' : 'bg-[#acb4bb] w-[88px]',
+            )}
+         >
+            {game.ticket}
+         </button>
+         <button
+            className={cn(
+               'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] border',
+               game.resell === '리셀예매'
+                  ? 'bg-background border-primary text-primary'
+                  : 'bg-background border-[#acb4bb] text-[#acb4bb] w-[88px] whitespace-nowrap',
+            )}
+         >
+            {game.resell}
+         </button>
       </div>
    );
 }
 
 const GameSchedule = () => {
-   const navigate = useNavigate();
-   const [activeTab, setActiveTab] = useState(0);
+   const [activeTab, setActiveTab] = useState(TAB_TODAY);
+   const [selectedTeam, setSelectedTeam] = useState<string | null>(null);
 
    // 주간 일정 state
    const [weekYear, setWeekYear] = useState(CURRENT_YEAR);
@@ -314,28 +142,24 @@ const GameSchedule = () => {
    const [allMonth, setAllMonth] = useState(CURRENT_MONTH);
    const [showAllPicker, setShowAllPicker] = useState(false);
 
-   const filteredData = scheduleData
-      .filter(day => {
-         if (activeTab === 0) return day.date === TODAY;
-         if (activeTab === 1) {
-            const { month, day: dayNum } = parseDate(day.date);
-            const week = getWeekOfMonth(dayNum);
-            return month === weekMonth && week === selectedWeek;
-         }
-         if (activeTab === 2) {
-            const { month } = parseDate(day.date);
-            return month === allMonth;
-         }
-         return true;
-      })
-      .filter(day => day.games.length > 0);
+   const filteredData = useMemo(
+      () =>
+         filterScheduleData(scheduleData, {
+            activeTab,
+            weekMonth,
+            selectedWeek,
+            allMonth,
+            selectedTeam,
+         }),
+      [activeTab, weekMonth, selectedWeek, allMonth, selectedTeam],
+   );
 
    const prevWeekMonth = () => {
       if (weekMonth === 1) {
          setWeekMonth(12);
-         setWeekYear(y => y - 1);
+         setWeekYear(year => year - 1);
       } else {
-         setWeekMonth(m => m - 1);
+         setWeekMonth(month => month - 1);
       }
       setSelectedWeek(1);
    };
@@ -343,27 +167,24 @@ const GameSchedule = () => {
    const nextWeekMonth = () => {
       if (weekMonth === 12) {
          setWeekMonth(1);
-         setWeekYear(y => y + 1);
+         setWeekYear(year => year + 1);
       } else {
-         setWeekMonth(m => m + 1);
+         setWeekMonth(month => month + 1);
       }
       setSelectedWeek(1);
    };
 
    return (
       <section className="flex flex-col gap-5 w-full">
-         {/* 헤더 */}
          <h2 className="text-[length:var(--typo---heading\/h3,24px)] font-bold text-(--text-primary) leading-[1.5]">
             경기 일정
          </h2>
 
          <div className="flex flex-col gap-5">
-            {/* 안내 문구 */}
             <p className="text-[length:var(--typo---heading\/h5,16px)] font-medium text-(--text-secondary)">
                각 구단을 선택하시면 <span className="text-red-500">구단별 경기일정</span>을 확인할 수 있습니다.
             </p>
 
-            {/* 팀 로고 */}
             <div className="flex items-center justify-between">
                {teamOrder.map(team => {
                   const teamId = teamIds[team];
@@ -384,15 +205,14 @@ const GameSchedule = () => {
                })}
             </div>
 
-            {/* 탭 네비게이션 */}
             <div className="flex gap-5 border-b border-(--border-normal)">
-               {tabs.map((tab, i) => (
+               {tabs.map((tab, index) => (
                   <button
                      key={tab}
-                     onClick={() => setActiveTab(i)}
+                     onClick={() => setActiveTab(index)}
                      className={cn(
                         'px-2.5 py-[10px] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5] transition-colors',
-                        i === activeTab
+                        index === activeTab
                            ? 'text-(--text-primary) border-b-[3px] border-primary -mb-px'
                            : 'text-(--text-tertiary)',
                      )}
@@ -402,11 +222,9 @@ const GameSchedule = () => {
                ))}
             </div>
 
-            {/* 주간 일정 네비게이터 */}
-            {activeTab === 1 && (
+            {activeTab === TAB_WEEK && (
                <div className="flex flex-col gap-3">
                   <div className="relative flex items-center gap-3.5 justify-center">
-                     {/* 최근 버튼 */}
                      <Badge asChild variant="chipDestructive" className="opacity-50">
                         <button
                            onClick={() => {
@@ -419,7 +237,6 @@ const GameSchedule = () => {
                         </button>
                      </Badge>
 
-                     {/* Year-Month 네비게이션 */}
                      <div className="flex items-center gap-2">
                         <button
                            onClick={prevWeekMonth}
@@ -444,17 +261,15 @@ const GameSchedule = () => {
                         </button>
                      </div>
 
-                     {/* 빈 공간 (최근 버튼 균형) */}
                      <div className="w-[56px]" />
 
-                     {/* 피커 드롭다운 */}
                      {showWeekPicker && (
                         <YearMonthPicker
                            year={weekYear}
                            month={weekMonth}
-                           onConfirm={(y, m) => {
-                              setWeekYear(y);
-                              setWeekMonth(m);
+                           onConfirm={(year, month) => {
+                              setWeekYear(year);
+                              setWeekMonth(month);
                               setSelectedWeek(1);
                               setShowWeekPicker(false);
                            }}
@@ -463,9 +278,8 @@ const GameSchedule = () => {
                      )}
                   </div>
 
-                  {/* 주차 선택 버튼 */}
                   <div className="flex gap-[30px] justify-center">
-                     {[1, 2, 3, 4, 5].map(week => (
+                     {WEEK_OPTIONS.map(week => (
                         <Button
                            key={week}
                            onClick={() => setSelectedWeek(week)}
@@ -482,11 +296,9 @@ const GameSchedule = () => {
                </div>
             )}
 
-            {/* 전체 일정 네비게이터 */}
-            {activeTab === 2 && (
+            {activeTab === TAB_ALL && (
                <div className="flex flex-col gap-3">
                   <div className="relative flex items-center gap-3.5 justify-center">
-                     {/* 최근 버튼 */}
                      <Badge asChild variant="chipDestructive" className="opacity-50">
                         <button
                            onClick={() => {
@@ -498,10 +310,9 @@ const GameSchedule = () => {
                         </button>
                      </Badge>
 
-                     {/* 연도 네비게이션 */}
                      <div className="flex items-center gap-2">
                         <button
-                           onClick={() => setAllYear(y => Math.max(y - 1, AVAILABLE_YEARS[0]))}
+                           onClick={() => setAllYear(year => Math.max(year - 1, AVAILABLE_YEARS[0]))}
                            className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
                         >
                            <ChevronLeft className="size-5" />
@@ -516,24 +327,24 @@ const GameSchedule = () => {
                            {allYear}
                         </button>
                         <button
-                           onClick={() => setAllYear(y => Math.min(y + 1, AVAILABLE_YEARS[AVAILABLE_YEARS.length - 1]))}
+                           onClick={() =>
+                              setAllYear(year => Math.min(year + 1, AVAILABLE_YEARS[AVAILABLE_YEARS.length - 1]))
+                           }
                            className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
                         >
                            <ChevronRight className="size-5" />
                         </button>
                      </div>
 
-                     {/* 빈 공간 */}
                      <div className="w-[56px]" />
 
-                     {/* 피커 드롭다운 */}
                      {showAllPicker && (
                         <YearMonthPicker
                            year={allYear}
                            month={allMonth}
-                           onConfirm={(y, m) => {
-                              setAllYear(y);
-                              setAllMonth(m);
+                           onConfirm={(year, month) => {
+                              setAllYear(year);
+                              setAllMonth(month);
                               setShowAllPicker(false);
                            }}
                            onClose={() => setShowAllPicker(false)}
@@ -541,15 +352,15 @@ const GameSchedule = () => {
                      )}
                   </div>
 
-                  {/* 월 탭 (시즌 순서: 3월~12월, 1월, 2월, 포스트시즌) */}
                   <div className="flex w-full">
-                     {SEASON_MONTHS.map(m => {
-                        const isDisabled = DISABLED_MONTHS.includes(m);
-                        const isSelected = m === allMonth;
+                     {SEASON_MONTHS.map(month => {
+                        const isDisabled = DISABLED_MONTHS.includes(month);
+                        const isSelected = month === allMonth;
+
                         return (
                            <Button
-                              key={m}
-                              onClick={() => !isDisabled && setAllMonth(m)}
+                              key={month}
+                              onClick={() => !isDisabled && setAllMonth(month)}
                               disabled={isDisabled}
                               variant={isSelected ? 'primaryline' : 'outline'}
                               className={cn(
@@ -560,7 +371,7 @@ const GameSchedule = () => {
                            >
                               <span className="flex items-end">
                                  <span className="text-[length:var(--typo---heading\/h3,24px)] font-bold leading-[1.5]">
-                                    {m}
+                                    {month}
                                  </span>
                                  <span className="text-[length:var(--typo---paragraph\/p1,14px)] font-medium leading-[1.5]">
                                     월
@@ -580,16 +391,15 @@ const GameSchedule = () => {
                </div>
             )}
 
-            {/* 경기 일정 테이블 또는 빈 상태 */}
             {filteredData.length === 0 ? (
                <EmptyState />
             ) : (
-               <div className={cn('flex flex-col', activeTab !== 0 && 'gap-[25px]')}>
+               <div className={cn('flex flex-col', activeTab !== TAB_TODAY && 'gap-[25px]')}>
                   {filteredData.map(day => {
                      const isToday = day.isToday ?? day.date === TODAY;
+
                      return (
                         <div key={day.date}>
-                           {/* 날짜 헤더 */}
                            <div className="bg-[#f1f2f4] border border-(--border-normal) px-[30px] py-[10px] rounded-tl-[20px] rounded-tr-[20px] flex items-center gap-2">
                               <span className="text-[length:var(--typo---heading\/h4,20px)] font-semibold text-(--text-primary) leading-[1.5]">
                                  {day.date}
@@ -597,30 +407,21 @@ const GameSchedule = () => {
                               {isToday && <Badge variant="chipDestructive">오늘</Badge>}
                            </div>
 
-                           {/* 경기 행 */}
-                           {day.games.map((game, idx) => {
-                              const isLast = idx === day.games.length - 1;
+                           {day.games.map((game, index) => {
+                              const isLast = index === day.games.length - 1;
                               const isEnded = game.status === '종료';
                               const textDisabled = isEnded ? 'text-[#acb4bb]' : 'text-(--text-primary)';
-
-                              let awayResult = '';
-                              let homeResult = '';
-                              if (isEnded && game.score) {
-                                 const [awayScore, homeScore] = game.score.split(':').map(Number);
-                                 awayResult = awayScore < homeScore ? '패' : '승';
-                                 homeResult = homeScore > awayScore ? '승' : '패';
-                              }
+                              const resultText = getGameResultTexts(game.score, isEnded);
 
                               return (
                                  <div
-                                    key={idx}
+                                    key={`${day.date}-${game.time}-${game.away}-${game.home}-${index}`}
                                     className={cn(
                                        'border border-t-0 border-(--border-normal) px-[20px] py-[6px] flex items-center justify-between',
                                        isLast && 'rounded-bl-[20px] rounded-br-[20px]',
                                        isEnded ? 'bg-[#f7f8f9]' : 'bg-background',
                                     )}
                                  >
-                                    {/* 시간 + 장소 */}
                                     <div className="flex gap-[30px] items-center shrink-0">
                                        <div className="flex items-center justify-center w-[60px]">
                                           <span
@@ -644,35 +445,16 @@ const GameSchedule = () => {
                                        </div>
                                     </div>
 
-                                    {/* 경기 매치업 */}
                                     <div className="flex gap-[50px] items-center shrink-0">
-                                       {/* 원정팀 */}
                                        <div className="flex items-center justify-center w-[150px]">
                                           <div className="flex h-[75px] items-center justify-end w-[70px] shrink-0">
                                              <div className="w-[30px] h-[75px] shrink-0" />
-                                             {isEnded ? (
-                                                <div className="flex flex-col items-center shrink-0">
-                                                   <span
-                                                      className={cn(
-                                                         'text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap',
-                                                         textDisabled,
-                                                      )}
-                                                   >
-                                                      {game.away}
-                                                   </span>
-                                                   <span className="text-[12px] font-medium text-(--text-tertiary) leading-[1.5]">
-                                                      {awayResult}
-                                                   </span>
-                                                </div>
-                                             ) : (
-                                                <div className="flex flex-col h-full items-center justify-between shrink-0">
-                                                   <div className="h-[18px] w-full shrink-0" />
-                                                   <span className="text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap text-(--text-primary)">
-                                                      {game.away}
-                                                   </span>
-                                                   <div />
-                                                </div>
-                                             )}
+                                             <TeamName
+                                                name={game.away}
+                                                isEnded={isEnded}
+                                                result={resultText.away}
+                                                textDisabled={textDisabled}
+                                             />
                                           </div>
                                           <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
                                              <img
@@ -683,7 +465,6 @@ const GameSchedule = () => {
                                           </div>
                                        </div>
 
-                                       {/* 스코어 / VS */}
                                        <div className="flex flex-col items-center justify-center w-[40px] shrink-0">
                                           <ScoreDisplay game={game} />
                                           <span
@@ -696,7 +477,6 @@ const GameSchedule = () => {
                                           </span>
                                        </div>
 
-                                       {/* 홈팀 */}
                                        <div className="flex items-center justify-center w-[150px]">
                                           <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
                                              <img
@@ -706,29 +486,12 @@ const GameSchedule = () => {
                                              />
                                           </div>
                                           <div className="flex h-[75px] items-center justify-between w-[70px] shrink-0">
-                                             {isEnded ? (
-                                                <div className="flex flex-col items-center shrink-0">
-                                                   <span
-                                                      className={cn(
-                                                         'text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap',
-                                                         textDisabled,
-                                                      )}
-                                                   >
-                                                      {game.home}
-                                                   </span>
-                                                   <span className="text-[12px] font-medium text-(--text-tertiary) leading-[1.5]">
-                                                      {homeResult}
-                                                   </span>
-                                                </div>
-                                             ) : (
-                                                <div className="flex flex-col h-full items-center justify-between shrink-0">
-                                                   <div className="h-[18px] w-full shrink-0" />
-                                                   <span className="text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap text-(--text-primary)">
-                                                      {game.home}
-                                                   </span>
-                                                   <div />
-                                                </div>
-                                             )}
+                                             <TeamName
+                                                name={game.home}
+                                                isEnded={isEnded}
+                                                result={resultText.home}
+                                                textDisabled={textDisabled}
+                                             />
                                              <div className="flex h-[75px] items-center justify-end w-[30px] shrink-0">
                                                 <div className="bg-[#acb4bb] flex flex-col items-center justify-center px-[4px] rounded-[2px] w-[22px]">
                                                    <span className="text-white text-[16px] font-medium text-center leading-[1.5]">
@@ -740,32 +503,7 @@ const GameSchedule = () => {
                                        </div>
                                     </div>
 
-                                    {/* 액션 버튼 */}
-                                    <div
-                                       className={cn(
-                                          'flex gap-[10px] h-[66px] items-center shrink-0',
-                                          isEnded && 'opacity-0',
-                                       )}
-                                    >
-                                       <button
-                                          className={cn(
-                                             'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] text-white',
-                                             game.ticket === '예매하기' ? 'bg-primary' : 'bg-[#acb4bb] w-[88px]',
-                                          )}
-                                       >
-                                          {game.ticket}
-                                       </button>
-                                       <button
-                                          className={cn(
-                                             'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] border',
-                                             game.resell === '리셀예매'
-                                                ? 'bg-background border-primary text-primary'
-                                                : 'bg-background border-[#acb4bb] text-[#acb4bb] w-[88px] whitespace-nowrap',
-                                          )}
-                                       >
-                                          {game.resell}
-                                       </button>
-                                    </div>
+                                    <ActionButtons game={game} isEnded={isEnded} />
                                  </div>
                               );
                            })}

--- a/src/pages/home/ui/GameSchedule.tsx
+++ b/src/pages/home/ui/GameSchedule.tsx
@@ -1,162 +1,32 @@
-import { useMemo, useState } from "react";
-import { ChevronLeft, ChevronRight, TicketX } from "lucide-react";
-import { useNavigate } from "react-router-dom";
-
-import { cn } from "@/shared/lib/utils";
-import { Badge } from "@/shared/ui/badge";
-import { Button } from "@/shared/ui/button";
-import { teams } from "@/entities/team/model/teams";
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import {
+  AVAILABLE_YEARS,
   CURRENT_MONTH,
   CURRENT_WEEK,
   CURRENT_YEAR,
-  DISABLED_MONTHS,
-  SEASON_MONTHS,
   TAB_ALL,
   TAB_TODAY,
   TAB_WEEK,
-  TODAY,
-  WEEK_OPTIONS,
-  AVAILABLE_YEARS,
   scheduleData,
-  statusColor,
   tabs,
-  teamLogos,
-  teamOrder,
-} from "./game-schedule/constants";
-import type { GameRow } from "./game-schedule/types";
-import { filterScheduleData, getGameResultTexts } from "./game-schedule/utils";
-import YearMonthPicker from "./game-schedule/YearMonthPicker";
-
-const teamIds: Record<string, string> = {
-  LG: "lg",
-  한화: "hanwha",
-  SSG: "ssg",
-  삼성: "samsung",
-  NC: "nc",
-  KT: "kt",
-  롯데: "lotte",
-  두산: "doosan",
-  키움: "kiwoom",
-  KIA: "kia",
-};
-
-// 종료 경기 스코어: 패한 팀 점수는 회색, 이긴 팀 점수는 빨강
-function ScoreDisplay({ game }: { game: GameRow }) {
-  const scoreText = game.score ?? "VS";
-
-  if (game.status === "종료" && game.score) {
-    const [awayScore, homeScore] = game.score.split(":").map(Number);
-    const awayLost = awayScore < homeScore;
-
-    return (
-      <span className="text-[24px] font-bold text-center leading-[1.5] whitespace-nowrap text-[#ef4444]">
-        <span className={awayLost ? "text-[#acb4bb]" : ""}>{awayScore}:</span>
-        <span className={!awayLost ? "text-[#acb4bb]" : ""}>{homeScore}</span>
-      </span>
-    );
-  }
-
-  return (
-    <span className="text-[24px] font-bold text-(--text-primary) text-center leading-[1.5] whitespace-nowrap">
-      {scoreText}
-    </span>
-  );
-}
-
-function EmptyState() {
-  return (
-    <div className="bg-[#f7f8f9] flex h-[400px] items-center justify-center overflow-hidden px-5 py-[100px] rounded-[10px] w-full">
-      <div className="flex flex-col gap-[10px] items-center justify-center">
-        <TicketX className="size-[75px] text-[#acb4bb]" strokeWidth={1.2} />
-        <p className="text-[22px] font-semibold text-[#646f7c] text-center leading-[1.55]">
-          현재 예매 가능한 경기가 없습니다.
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function TeamName({
-  name,
-  isEnded,
-  result,
-  textDisabled,
-}: {
-  name: string;
-  isEnded: boolean;
-  result: string;
-  textDisabled: string;
-}) {
-  if (isEnded) {
-    return (
-      <div className="flex flex-col items-center shrink-0">
-        <span
-          className={cn(
-            "text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap",
-            textDisabled,
-          )}
-        >
-          {name}
-        </span>
-        <span className="text-[12px] font-medium text-(--text-tertiary) leading-[1.5]">
-          {result}
-        </span>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex h-full items-center justify-center shrink-0">
-      <span className="text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap text-(--text-primary)">
-        {name}
-      </span>
-    </div>
-  );
-}
-
-function ActionButtons({ game, isEnded }: { game: GameRow; isEnded: boolean }) {
-  return (
-    <div
-      className={cn(
-        "flex gap-[10px] h-[66px] items-center shrink-0",
-        isEnded && "opacity-0",
-      )}
-    >
-      <button
-        className={cn(
-          "h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] text-white",
-          game.ticket === "예매하기" ? "bg-primary" : "bg-[#acb4bb] w-[88px]",
-        )}
-      >
-        {game.ticket}
-      </button>
-      <button
-        className={cn(
-          "h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] border",
-          game.resell === "리셀예매"
-            ? "bg-background border-primary text-primary"
-            : "bg-background border-[#acb4bb] text-[#acb4bb] w-[88px] whitespace-nowrap",
-        )}
-      >
-        {game.resell}
-      </button>
-    </div>
-  );
-}
+} from './game-schedule/constants';
+import TeamLogoNav from './game-schedule/TeamLogoNav';
+import WeekNavigator from './game-schedule/WeekNavigator';
+import AllNavigator from './game-schedule/AllNavigator';
+import ScheduleList from './game-schedule/ScheduleList';
+import { filterScheduleData } from './game-schedule/utils';
 
 const GameSchedule = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState(TAB_TODAY);
 
-  // 주간 일정 state
   const [weekYear, setWeekYear] = useState(CURRENT_YEAR);
   const [weekMonth, setWeekMonth] = useState(CURRENT_MONTH);
   const [selectedWeek, setSelectedWeek] = useState(CURRENT_WEEK);
   const [showWeekPicker, setShowWeekPicker] = useState(false);
 
-  // 전체 일정 state
   const [allYear, setAllYear] = useState(CURRENT_YEAR);
   const [allMonth, setAllMonth] = useState(CURRENT_MONTH);
   const [showAllPicker, setShowAllPicker] = useState(false);
@@ -194,53 +64,25 @@ const GameSchedule = () => {
 
   return (
     <section className="flex flex-col gap-5 w-full">
-      <h2 className="text-[length:var(--typo---heading\/h3,24px)] font-bold text-(--text-primary) leading-[1.5]">
-        경기 일정
-      </h2>
+      <h2 className="text-[length:var(--typo---heading\/h3,24px)] font-bold text-(--text-primary) leading-[1.5]">경기 일정</h2>
 
       <div className="flex flex-col gap-5">
         <p className="text-[length:var(--typo---heading\/h5,16px)] font-medium text-(--text-secondary)">
-          각 구단을 선택하시면{" "}
-          <span className="text-red-500">구단별 경기일정</span>을 확인할 수
-          있습니다.
+          각 구단을 선택하시면 <span className="text-red-500">구단별 경기일정</span>을 확인할 수 있습니다.
         </p>
 
-        <div className="flex items-center justify-between">
-          {teamOrder.map((team) => {
-            const teamId = teamIds[team];
-            const isEnabled = teams.find((candidate) => candidate.id === teamId)?.isEnabled ?? false;
-
-            return (
-              <button
-                key={team}
-                onClick={() => isEnabled && navigate(`/teams/${teamId}`)}
-                disabled={!isEnabled}
-                className={cn(
-                  "flex items-center justify-center size-[80px] p-[10px] rounded-xl transition-colors overflow-hidden",
-                  isEnabled ? "hover:bg-fill-hoveraccent cursor-pointer" : "opacity-30 cursor-not-allowed",
-                )}
-              >
-                <img
-                  src={teamLogos[team]}
-                  alt={team}
-                  className="w-full h-full object-contain"
-                />
-              </button>
-            );
-          })}
-        </div>
+        <TeamLogoNav onNavigateTeam={(teamId) => navigate(`/teams/${teamId}`)} />
 
         <div className="flex gap-5 border-b border-(--border-normal)">
           {tabs.map((tab, index) => (
             <button
               key={tab}
               onClick={() => setActiveTab(index)}
-              className={cn(
-                "px-2.5 py-[10px] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5] transition-colors",
+              className={
                 index === activeTab
-                  ? "text-(--text-primary) border-b-[3px] border-primary -mb-px"
-                  : "text-(--text-tertiary)",
-              )}
+                  ? 'px-2.5 py-[10px] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5] transition-colors text-(--text-primary) border-b-[3px] border-primary -mb-px'
+                  : 'px-2.5 py-[10px] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5] transition-colors text-(--text-tertiary)'
+              }
             >
               {tab}
             </button>
@@ -248,313 +90,61 @@ const GameSchedule = () => {
         </div>
 
         {activeTab === TAB_WEEK && (
-          <div className="flex flex-col gap-3">
-            <div className="relative flex items-center gap-3.5 justify-center">
-              <Badge asChild variant="chipDestructive" className="opacity-50">
-                <button
-                  onClick={() => {
-                    setWeekYear(CURRENT_YEAR);
-                    setWeekMonth(CURRENT_MONTH);
-                    setSelectedWeek(CURRENT_WEEK);
-                  }}
-                >
-                  최근
-                </button>
-              </Badge>
-
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={prevWeekMonth}
-                  className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
-                >
-                  <ChevronLeft className="size-5" />
-                </button>
-                <button
-                  onClick={() => {
-                    setShowWeekPicker(true);
-                    setShowAllPicker(false);
-                  }}
-                  className="text-[18px] font-bold text-(--text-primary) leading-[1.5] min-w-[110px] text-center"
-                >
-                  {weekYear}-{String(weekMonth).padStart(2, "0")}
-                </button>
-                <button
-                  onClick={nextWeekMonth}
-                  className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
-                >
-                  <ChevronRight className="size-5" />
-                </button>
-              </div>
-
-              <div className="w-[56px]" />
-
-              {showWeekPicker && (
-                <YearMonthPicker
-                  year={weekYear}
-                  month={weekMonth}
-                  onConfirm={(year, month) => {
-                    setWeekYear(year);
-                    setWeekMonth(month);
-                    setSelectedWeek(1);
-                    setShowWeekPicker(false);
-                  }}
-                  onClose={() => setShowWeekPicker(false)}
-                />
-              )}
-            </div>
-
-            <div className="flex gap-[30px] justify-center">
-              {WEEK_OPTIONS.map((week) => (
-                <Button
-                  key={week}
-                  onClick={() => setSelectedWeek(week)}
-                  variant={week === selectedWeek ? "primaryline" : "outline"}
-                  className={cn(
-                    "px-[22px] py-[9px] rounded-[10px] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5]",
-                    week !== selectedWeek &&
-                      "shadow-[inset_0_0_0_1px_#161d24] text-[#161d24]",
-                  )}
-                >
-                  {week}주차
-                </Button>
-              ))}
-            </div>
-          </div>
+          <WeekNavigator
+            weekYear={weekYear}
+            weekMonth={weekMonth}
+            selectedWeek={selectedWeek}
+            showWeekPicker={showWeekPicker}
+            onReset={() => {
+              setWeekYear(CURRENT_YEAR);
+              setWeekMonth(CURRENT_MONTH);
+              setSelectedWeek(CURRENT_WEEK);
+            }}
+            onPrevMonth={prevWeekMonth}
+            onNextMonth={nextWeekMonth}
+            onOpenPicker={() => {
+              setShowWeekPicker(true);
+              setShowAllPicker(false);
+            }}
+            onClosePicker={() => setShowWeekPicker(false)}
+            onConfirmPicker={(year, month) => {
+              setWeekYear(year);
+              setWeekMonth(month);
+              setSelectedWeek(1);
+              setShowWeekPicker(false);
+            }}
+            onSelectWeek={setSelectedWeek}
+          />
         )}
 
         {activeTab === TAB_ALL && (
-          <div className="flex flex-col gap-3">
-            <div className="relative flex items-center gap-3.5 justify-center">
-              <Badge asChild variant="chipDestructive" className="opacity-50">
-                <button
-                  onClick={() => {
-                    setAllYear(CURRENT_YEAR);
-                    setAllMonth(CURRENT_MONTH);
-                  }}
-                >
-                  최근
-                </button>
-              </Badge>
-
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() =>
-                    setAllYear((year) => Math.max(year - 1, AVAILABLE_YEARS[0]))
-                  }
-                  className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
-                >
-                  <ChevronLeft className="size-5" />
-                </button>
-                <button
-                  onClick={() => {
-                    setShowAllPicker(true);
-                    setShowWeekPicker(false);
-                  }}
-                  className="text-[18px] font-bold text-(--text-primary) leading-[1.5] min-w-[60px] text-center"
-                >
-                  {allYear}
-                </button>
-                <button
-                  onClick={() =>
-                    setAllYear((year) =>
-                      Math.min(
-                        year + 1,
-                        AVAILABLE_YEARS[AVAILABLE_YEARS.length - 1],
-                      ),
-                    )
-                  }
-                  className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
-                >
-                  <ChevronRight className="size-5" />
-                </button>
-              </div>
-
-              <div className="w-[56px]" />
-
-              {showAllPicker && (
-                <YearMonthPicker
-                  year={allYear}
-                  month={allMonth}
-                  onConfirm={(year, month) => {
-                    setAllYear(year);
-                    setAllMonth(month);
-                    setShowAllPicker(false);
-                  }}
-                  onClose={() => setShowAllPicker(false)}
-                />
-              )}
-            </div>
-
-            <div className="flex w-full">
-              {SEASON_MONTHS.map((month) => {
-                const isDisabled = DISABLED_MONTHS.includes(month);
-                const isSelected = month === allMonth;
-
-                return (
-                  <Button
-                    key={month}
-                    onClick={() => !isDisabled && setAllMonth(month)}
-                    disabled={isDisabled}
-                    variant={isSelected ? "primaryline" : "outline"}
-                    className={cn(
-                      "flex-1 h-[48px] px-[22px] py-[9px] rounded-tl-[10px] rounded-tr-[10px] rounded-bl-none rounded-br-none",
-                      !isSelected &&
-                        !isDisabled &&
-                        "shadow-[inset_0_0_0_1px_#161d24] text-[#161d24]",
-                      isDisabled &&
-                        "shadow-[inset_0_0_0_1px_#acb4bb] text-[#acb4bb]",
-                    )}
-                  >
-                    <span className="flex items-end">
-                      <span className="text-[length:var(--typo---heading\/h3,24px)] font-bold leading-[1.5]">
-                        {month}
-                      </span>
-                      <span className="text-[length:var(--typo---paragraph\/p1,14px)] font-medium leading-[1.5]">
-                        월
-                      </span>
-                    </span>
-                  </Button>
-                );
-              })}
-              <Button
-                disabled
-                variant="outline"
-                className="h-[48px] px-[22px] py-[9px] rounded-tl-[10px] rounded-tr-[10px] rounded-bl-none rounded-br-none w-[120px] shrink-0 shadow-[inset_0_0_0_1px_#acb4bb] text-[#acb4bb] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5]"
-              >
-                포스트 시즌
-              </Button>
-            </div>
-          </div>
+          <AllNavigator
+            allYear={allYear}
+            allMonth={allMonth}
+            showAllPicker={showAllPicker}
+            onReset={() => {
+              setAllYear(CURRENT_YEAR);
+              setAllMonth(CURRENT_MONTH);
+            }}
+            onPrevYear={() => setAllYear((year) => Math.max(year - 1, AVAILABLE_YEARS[0]))}
+            onNextYear={() =>
+              setAllYear((year) => Math.min(year + 1, AVAILABLE_YEARS[AVAILABLE_YEARS.length - 1]))
+            }
+            onOpenPicker={() => {
+              setShowAllPicker(true);
+              setShowWeekPicker(false);
+            }}
+            onClosePicker={() => setShowAllPicker(false)}
+            onConfirmPicker={(year, month) => {
+              setAllYear(year);
+              setAllMonth(month);
+              setShowAllPicker(false);
+            }}
+            onSelectMonth={setAllMonth}
+          />
         )}
 
-        {filteredData.length === 0 ? (
-          <EmptyState />
-        ) : (
-          <div
-            className={cn(
-              "flex flex-col",
-              activeTab !== TAB_TODAY && "gap-[25px]",
-            )}
-          >
-            {filteredData.map((day) => {
-              const isToday = day.isToday ?? day.date === TODAY;
-
-              return (
-                <div key={day.date}>
-                  <div className="bg-[#f1f2f4] border border-(--border-normal) px-[30px] py-[10px] rounded-tl-[20px] rounded-tr-[20px] flex items-center gap-2">
-                    <span className="text-[length:var(--typo---heading\/h4,20px)] font-semibold text-(--text-primary) leading-[1.5]">
-                      {day.date}
-                    </span>
-                    {isToday && <Badge variant="chipDestructive">오늘</Badge>}
-                  </div>
-
-                  {day.games.map((game, index) => {
-                    const isLast = index === day.games.length - 1;
-                    const isEnded = game.status === "종료";
-                    const textDisabled = isEnded
-                      ? "text-[#acb4bb]"
-                      : "text-(--text-primary)";
-                    const resultText = getGameResultTexts(game.score, isEnded);
-
-                    return (
-                      <div
-                        key={`${day.date}-${game.time}-${game.away}-${game.home}-${index}`}
-                        className={cn(
-                          "border border-t-0 border-(--border-normal) px-[20px] py-[6px] flex items-center justify-between",
-                          isLast && "rounded-bl-[20px] rounded-br-[20px]",
-                          isEnded ? "bg-[#f7f8f9]" : "bg-background",
-                        )}
-                      >
-                        <div className="flex gap-[30px] items-center shrink-0">
-                          <div className="flex items-center justify-center w-[60px]">
-                            <span
-                              className={cn(
-                                "text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap",
-                                textDisabled,
-                              )}
-                            >
-                              {game.time}
-                            </span>
-                          </div>
-                          <div className="flex items-center justify-center w-[40px]">
-                            <span
-                              className={cn(
-                                "text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap",
-                                textDisabled,
-                              )}
-                            >
-                              {game.venue}
-                            </span>
-                          </div>
-                        </div>
-
-                        <div className="flex gap-[50px] items-center shrink-0">
-                          <div className="flex items-center justify-center w-[150px]">
-                            <div className="flex h-[75px] items-center justify-end w-[70px] shrink-0">
-                              <div className="w-[30px] h-[75px] shrink-0" />
-                              <TeamName
-                                name={game.away}
-                                isEnded={isEnded}
-                                result={resultText.away}
-                                textDisabled={textDisabled}
-                              />
-                            </div>
-                            <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
-                              <img
-                                src={teamLogos[game.away]}
-                                alt={game.away}
-                                className="w-full h-full object-contain"
-                              />
-                            </div>
-                          </div>
-
-                          <div className="flex flex-col items-center justify-center w-[40px] shrink-0">
-                            <ScoreDisplay game={game} />
-                            <span
-                              className={cn(
-                                "text-[12px] font-medium text-center leading-[1.5]",
-                                statusColor[game.status],
-                              )}
-                            >
-                              {game.status}
-                            </span>
-                          </div>
-
-                          <div className="flex items-center justify-center w-[150px]">
-                            <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
-                              <img
-                                src={teamLogos[game.home]}
-                                alt={game.home}
-                                className="w-full h-full object-contain"
-                              />
-                            </div>
-                            <div className="flex h-[75px] items-center justify-between w-[70px] shrink-0">
-                              <TeamName
-                                name={game.home}
-                                isEnded={isEnded}
-                                result={resultText.home}
-                                textDisabled={textDisabled}
-                              />
-                              <div className="flex h-[75px] items-center justify-end w-[30px] shrink-0">
-                                <div className="bg-[#acb4bb] flex flex-col items-center justify-center px-[4px] rounded-[2px] w-[22px]">
-                                  <span className="text-white text-[16px] font-medium text-center leading-[1.5]">
-                                    홈
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-
-                        <ActionButtons game={game} isEnded={isEnded} />
-                      </div>
-                    );
-                  })}
-                </div>
-              );
-            })}
-          </div>
-        )}
+        <ScheduleList activeTab={activeTab} filteredData={filteredData} />
       </div>
     </section>
   );

--- a/src/pages/home/ui/GameSchedule.tsx
+++ b/src/pages/home/ui/GameSchedule.tsx
@@ -1,190 +1,204 @@
-import { useMemo, useState } from 'react';
-import { ChevronLeft, ChevronRight, TicketX } from 'lucide-react';
+import { useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight, TicketX } from "lucide-react";
 
+<<<<<<< HEAD
 import { cn } from '@/shared/lib/utils';
 import { Badge } from '@/shared/ui/badge';
 import { Button } from '@/shared/ui/button';
 import { teams } from '@/entities/team/model/teams';
+=======
+import { cn } from "@/shared/lib/utils";
+import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
+>>>>>>> 093eae2 ([design] 팀명 세로 가운데 정렬 적용 #55)
 
 import {
-   CURRENT_MONTH,
-   CURRENT_WEEK,
-   CURRENT_YEAR,
-   DISABLED_MONTHS,
-   SEASON_MONTHS,
-   TAB_ALL,
-   TAB_TODAY,
-   TAB_WEEK,
-   TODAY,
-   WEEK_OPTIONS,
-   AVAILABLE_YEARS,
-   scheduleData,
-   statusColor,
-   tabs,
-   teamLogos,
-   teamOrder,
-} from './game-schedule/constants';
-import type { GameRow } from './game-schedule/types';
-import { filterScheduleData, getGameResultTexts } from './game-schedule/utils';
-import YearMonthPicker from './game-schedule/YearMonthPicker';
+  CURRENT_MONTH,
+  CURRENT_WEEK,
+  CURRENT_YEAR,
+  DISABLED_MONTHS,
+  SEASON_MONTHS,
+  TAB_ALL,
+  TAB_TODAY,
+  TAB_WEEK,
+  TODAY,
+  WEEK_OPTIONS,
+  AVAILABLE_YEARS,
+  scheduleData,
+  statusColor,
+  tabs,
+  teamLogos,
+  teamOrder,
+} from "./game-schedule/constants";
+import type { GameRow } from "./game-schedule/types";
+import { filterScheduleData, getGameResultTexts } from "./game-schedule/utils";
+import YearMonthPicker from "./game-schedule/YearMonthPicker";
 
 // 종료 경기 스코어: 패한 팀 점수는 회색, 이긴 팀 점수는 빨강
 function ScoreDisplay({ game }: { game: GameRow }) {
-   const scoreText = game.score ?? 'VS';
+  const scoreText = game.score ?? "VS";
 
-   if (game.status === '종료' && game.score) {
-      const [awayScore, homeScore] = game.score.split(':').map(Number);
-      const awayLost = awayScore < homeScore;
+  if (game.status === "종료" && game.score) {
+    const [awayScore, homeScore] = game.score.split(":").map(Number);
+    const awayLost = awayScore < homeScore;
 
-      return (
-         <span className="text-[24px] font-bold text-center leading-[1.5] whitespace-nowrap text-[#ef4444]">
-            <span className={awayLost ? 'text-[#acb4bb]' : ''}>{awayScore}:</span>
-            <span className={!awayLost ? 'text-[#acb4bb]' : ''}>{homeScore}</span>
-         </span>
-      );
-   }
-
-   return (
-      <span className="text-[24px] font-bold text-(--text-primary) text-center leading-[1.5] whitespace-nowrap">
-         {scoreText}
+    return (
+      <span className="text-[24px] font-bold text-center leading-[1.5] whitespace-nowrap text-[#ef4444]">
+        <span className={awayLost ? "text-[#acb4bb]" : ""}>{awayScore}:</span>
+        <span className={!awayLost ? "text-[#acb4bb]" : ""}>{homeScore}</span>
       </span>
-   );
+    );
+  }
+
+  return (
+    <span className="text-[24px] font-bold text-(--text-primary) text-center leading-[1.5] whitespace-nowrap">
+      {scoreText}
+    </span>
+  );
 }
 
 function EmptyState() {
-   return (
-      <div className="bg-[#f7f8f9] flex h-[400px] items-center justify-center overflow-hidden px-5 py-[100px] rounded-[10px] w-full">
-         <div className="flex flex-col gap-[10px] items-center justify-center">
-            <TicketX className="size-[75px] text-[#acb4bb]" strokeWidth={1.2} />
-            <p className="text-[22px] font-semibold text-[#646f7c] text-center leading-[1.55]">
-               현재 예매 가능한 경기가 없습니다.
-            </p>
-         </div>
+  return (
+    <div className="bg-[#f7f8f9] flex h-[400px] items-center justify-center overflow-hidden px-5 py-[100px] rounded-[10px] w-full">
+      <div className="flex flex-col gap-[10px] items-center justify-center">
+        <TicketX className="size-[75px] text-[#acb4bb]" strokeWidth={1.2} />
+        <p className="text-[22px] font-semibold text-[#646f7c] text-center leading-[1.55]">
+          현재 예매 가능한 경기가 없습니다.
+        </p>
       </div>
-   );
+    </div>
+  );
 }
 
 function TeamName({
-   name,
-   isEnded,
-   result,
-   textDisabled,
+  name,
+  isEnded,
+  result,
+  textDisabled,
 }: {
-   name: string;
-   isEnded: boolean;
-   result: string;
-   textDisabled: string;
+  name: string;
+  isEnded: boolean;
+  result: string;
+  textDisabled: string;
 }) {
-   if (isEnded) {
-      return (
-         <div className="flex flex-col items-center shrink-0">
-            <span
-               className={cn(
-                  'text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap',
-                  textDisabled,
-               )}
-            >
-               {name}
-            </span>
-            <span className="text-[12px] font-medium text-(--text-tertiary) leading-[1.5]">{result}</span>
-         </div>
-      );
-   }
-
-   return (
-      <div className="flex flex-col h-full items-center justify-between shrink-0">
-         <div className="h-[18px] w-full shrink-0" />
-         <span className="text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap text-(--text-primary)">
-            {name}
-         </span>
-         <div />
+  if (isEnded) {
+    return (
+      <div className="flex flex-col items-center shrink-0">
+        <span
+          className={cn(
+            "text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap",
+            textDisabled,
+          )}
+        >
+          {name}
+        </span>
+        <span className="text-[12px] font-medium text-(--text-tertiary) leading-[1.5]">
+          {result}
+        </span>
       </div>
-   );
+    );
+  }
+
+  return (
+    <div className="flex h-full items-center justify-center shrink-0">
+      <span className="text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap text-(--text-primary)">
+        {name}
+      </span>
+    </div>
+  );
 }
 
 function ActionButtons({ game, isEnded }: { game: GameRow; isEnded: boolean }) {
-   return (
-      <div className={cn('flex gap-[10px] h-[66px] items-center shrink-0', isEnded && 'opacity-0')}>
-         <button
-            className={cn(
-               'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] text-white',
-               game.ticket === '예매하기' ? 'bg-primary' : 'bg-[#acb4bb] w-[88px]',
-            )}
-         >
-            {game.ticket}
-         </button>
-         <button
-            className={cn(
-               'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] border',
-               game.resell === '리셀예매'
-                  ? 'bg-background border-primary text-primary'
-                  : 'bg-background border-[#acb4bb] text-[#acb4bb] w-[88px] whitespace-nowrap',
-            )}
-         >
-            {game.resell}
-         </button>
-      </div>
-   );
+  return (
+    <div
+      className={cn(
+        "flex gap-[10px] h-[66px] items-center shrink-0",
+        isEnded && "opacity-0",
+      )}
+    >
+      <button
+        className={cn(
+          "h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] text-white",
+          game.ticket === "예매하기" ? "bg-primary" : "bg-[#acb4bb] w-[88px]",
+        )}
+      >
+        {game.ticket}
+      </button>
+      <button
+        className={cn(
+          "h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] border",
+          game.resell === "리셀예매"
+            ? "bg-background border-primary text-primary"
+            : "bg-background border-[#acb4bb] text-[#acb4bb] w-[88px] whitespace-nowrap",
+        )}
+      >
+        {game.resell}
+      </button>
+    </div>
+  );
 }
 
 const GameSchedule = () => {
-   const [activeTab, setActiveTab] = useState(TAB_TODAY);
-   const [selectedTeam, setSelectedTeam] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState(TAB_TODAY);
+  const [selectedTeam, setSelectedTeam] = useState<string | null>(null);
 
-   // 주간 일정 state
-   const [weekYear, setWeekYear] = useState(CURRENT_YEAR);
-   const [weekMonth, setWeekMonth] = useState(CURRENT_MONTH);
-   const [selectedWeek, setSelectedWeek] = useState(CURRENT_WEEK);
-   const [showWeekPicker, setShowWeekPicker] = useState(false);
+  // 주간 일정 state
+  const [weekYear, setWeekYear] = useState(CURRENT_YEAR);
+  const [weekMonth, setWeekMonth] = useState(CURRENT_MONTH);
+  const [selectedWeek, setSelectedWeek] = useState(CURRENT_WEEK);
+  const [showWeekPicker, setShowWeekPicker] = useState(false);
 
-   // 전체 일정 state
-   const [allYear, setAllYear] = useState(CURRENT_YEAR);
-   const [allMonth, setAllMonth] = useState(CURRENT_MONTH);
-   const [showAllPicker, setShowAllPicker] = useState(false);
+  // 전체 일정 state
+  const [allYear, setAllYear] = useState(CURRENT_YEAR);
+  const [allMonth, setAllMonth] = useState(CURRENT_MONTH);
+  const [showAllPicker, setShowAllPicker] = useState(false);
 
-   const filteredData = useMemo(
-      () =>
-         filterScheduleData(scheduleData, {
-            activeTab,
-            weekMonth,
-            selectedWeek,
-            allMonth,
-            selectedTeam,
-         }),
-      [activeTab, weekMonth, selectedWeek, allMonth, selectedTeam],
-   );
+  const filteredData = useMemo(
+    () =>
+      filterScheduleData(scheduleData, {
+        activeTab,
+        weekMonth,
+        selectedWeek,
+        allMonth,
+        selectedTeam,
+      }),
+    [activeTab, weekMonth, selectedWeek, allMonth, selectedTeam],
+  );
 
-   const prevWeekMonth = () => {
-      if (weekMonth === 1) {
-         setWeekMonth(12);
-         setWeekYear(year => year - 1);
-      } else {
-         setWeekMonth(month => month - 1);
-      }
-      setSelectedWeek(1);
-   };
+  const prevWeekMonth = () => {
+    if (weekMonth === 1) {
+      setWeekMonth(12);
+      setWeekYear((year) => year - 1);
+    } else {
+      setWeekMonth((month) => month - 1);
+    }
+    setSelectedWeek(1);
+  };
 
-   const nextWeekMonth = () => {
-      if (weekMonth === 12) {
-         setWeekMonth(1);
-         setWeekYear(year => year + 1);
-      } else {
-         setWeekMonth(month => month + 1);
-      }
-      setSelectedWeek(1);
-   };
+  const nextWeekMonth = () => {
+    if (weekMonth === 12) {
+      setWeekMonth(1);
+      setWeekYear((year) => year + 1);
+    } else {
+      setWeekMonth((month) => month + 1);
+    }
+    setSelectedWeek(1);
+  };
 
-   return (
-      <section className="flex flex-col gap-5 w-full">
-         <h2 className="text-[length:var(--typo---heading\/h3,24px)] font-bold text-(--text-primary) leading-[1.5]">
-            경기 일정
-         </h2>
+  return (
+    <section className="flex flex-col gap-5 w-full">
+      <h2 className="text-[length:var(--typo---heading\/h3,24px)] font-bold text-(--text-primary) leading-[1.5]">
+        경기 일정
+      </h2>
 
-         <div className="flex flex-col gap-5">
-            <p className="text-[length:var(--typo---heading\/h5,16px)] font-medium text-(--text-secondary)">
-               각 구단을 선택하시면 <span className="text-red-500">구단별 경기일정</span>을 확인할 수 있습니다.
-            </p>
+      <div className="flex flex-col gap-5">
+        <p className="text-[length:var(--typo---heading\/h5,16px)] font-medium text-(--text-secondary)">
+          각 구단을 선택하시면{" "}
+          <span className="text-red-500">구단별 경기일정</span>을 확인할 수
+          있습니다.
+        </p>
 
+<<<<<<< HEAD
             <div className="flex items-center justify-between">
                {teamOrder.map(team => {
                   const teamId = teamIds[team];
@@ -203,318 +217,358 @@ const GameSchedule = () => {
                      </button>
                   );
                })}
+=======
+        <div className="flex items-center justify-between">
+          {teamOrder.map((team) => (
+            <button
+              key={team}
+              onClick={() =>
+                setSelectedTeam(selectedTeam === team ? null : team)
+              }
+              className={cn(
+                "flex items-center justify-center size-[80px] p-[10px] rounded-xl transition-colors overflow-hidden",
+                selectedTeam === team &&
+                  "bg-(--fill-hoveraccent) ring-2 ring-primary",
+              )}
+            >
+              <img
+                src={teamLogos[team]}
+                alt={team}
+                className="w-full h-full object-contain"
+              />
+            </button>
+          ))}
+        </div>
+
+        <div className="flex gap-5 border-b border-(--border-normal)">
+          {tabs.map((tab, index) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(index)}
+              className={cn(
+                "px-2.5 py-[10px] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5] transition-colors",
+                index === activeTab
+                  ? "text-(--text-primary) border-b-[3px] border-primary -mb-px"
+                  : "text-(--text-tertiary)",
+              )}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+
+        {activeTab === TAB_WEEK && (
+          <div className="flex flex-col gap-3">
+            <div className="relative flex items-center gap-3.5 justify-center">
+              <Badge asChild variant="chipDestructive" className="opacity-50">
+                <button
+                  onClick={() => {
+                    setWeekYear(CURRENT_YEAR);
+                    setWeekMonth(CURRENT_MONTH);
+                    setSelectedWeek(CURRENT_WEEK);
+                  }}
+                >
+                  최근
+                </button>
+              </Badge>
+
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={prevWeekMonth}
+                  className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
+                >
+                  <ChevronLeft className="size-5" />
+                </button>
+                <button
+                  onClick={() => {
+                    setShowWeekPicker(true);
+                    setShowAllPicker(false);
+                  }}
+                  className="text-[18px] font-bold text-(--text-primary) leading-[1.5] min-w-[110px] text-center"
+                >
+                  {weekYear}-{String(weekMonth).padStart(2, "0")}
+                </button>
+                <button
+                  onClick={nextWeekMonth}
+                  className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
+                >
+                  <ChevronRight className="size-5" />
+                </button>
+              </div>
+
+              <div className="w-[56px]" />
+
+              {showWeekPicker && (
+                <YearMonthPicker
+                  year={weekYear}
+                  month={weekMonth}
+                  onConfirm={(year, month) => {
+                    setWeekYear(year);
+                    setWeekMonth(month);
+                    setSelectedWeek(1);
+                    setShowWeekPicker(false);
+                  }}
+                  onClose={() => setShowWeekPicker(false)}
+                />
+              )}
+>>>>>>> 093eae2 ([design] 팀명 세로 가운데 정렬 적용 #55)
             </div>
 
-            <div className="flex gap-5 border-b border-(--border-normal)">
-               {tabs.map((tab, index) => (
-                  <button
-                     key={tab}
-                     onClick={() => setActiveTab(index)}
-                     className={cn(
-                        'px-2.5 py-[10px] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5] transition-colors',
-                        index === activeTab
-                           ? 'text-(--text-primary) border-b-[3px] border-primary -mb-px'
-                           : 'text-(--text-tertiary)',
-                     )}
+            <div className="flex gap-[30px] justify-center">
+              {WEEK_OPTIONS.map((week) => (
+                <Button
+                  key={week}
+                  onClick={() => setSelectedWeek(week)}
+                  variant={week === selectedWeek ? "primaryline" : "outline"}
+                  className={cn(
+                    "px-[22px] py-[9px] rounded-[10px] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5]",
+                    week !== selectedWeek &&
+                      "shadow-[inset_0_0_0_1px_#161d24] text-[#161d24]",
+                  )}
+                >
+                  {week}주차
+                </Button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {activeTab === TAB_ALL && (
+          <div className="flex flex-col gap-3">
+            <div className="relative flex items-center gap-3.5 justify-center">
+              <Badge asChild variant="chipDestructive" className="opacity-50">
+                <button
+                  onClick={() => {
+                    setAllYear(CURRENT_YEAR);
+                    setAllMonth(CURRENT_MONTH);
+                  }}
+                >
+                  최근
+                </button>
+              </Badge>
+
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() =>
+                    setAllYear((year) => Math.max(year - 1, AVAILABLE_YEARS[0]))
+                  }
+                  className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
+                >
+                  <ChevronLeft className="size-5" />
+                </button>
+                <button
+                  onClick={() => {
+                    setShowAllPicker(true);
+                    setShowWeekPicker(false);
+                  }}
+                  className="text-[18px] font-bold text-(--text-primary) leading-[1.5] min-w-[60px] text-center"
+                >
+                  {allYear}
+                </button>
+                <button
+                  onClick={() =>
+                    setAllYear((year) =>
+                      Math.min(
+                        year + 1,
+                        AVAILABLE_YEARS[AVAILABLE_YEARS.length - 1],
+                      ),
+                    )
+                  }
+                  className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
+                >
+                  <ChevronRight className="size-5" />
+                </button>
+              </div>
+
+              <div className="w-[56px]" />
+
+              {showAllPicker && (
+                <YearMonthPicker
+                  year={allYear}
+                  month={allMonth}
+                  onConfirm={(year, month) => {
+                    setAllYear(year);
+                    setAllMonth(month);
+                    setShowAllPicker(false);
+                  }}
+                  onClose={() => setShowAllPicker(false)}
+                />
+              )}
+            </div>
+
+            <div className="flex w-full">
+              {SEASON_MONTHS.map((month) => {
+                const isDisabled = DISABLED_MONTHS.includes(month);
+                const isSelected = month === allMonth;
+
+                return (
+                  <Button
+                    key={month}
+                    onClick={() => !isDisabled && setAllMonth(month)}
+                    disabled={isDisabled}
+                    variant={isSelected ? "primaryline" : "outline"}
+                    className={cn(
+                      "flex-1 h-[48px] px-[22px] py-[9px] rounded-tl-[10px] rounded-tr-[10px] rounded-bl-none rounded-br-none",
+                      !isSelected &&
+                        !isDisabled &&
+                        "shadow-[inset_0_0_0_1px_#161d24] text-[#161d24]",
+                      isDisabled &&
+                        "shadow-[inset_0_0_0_1px_#acb4bb] text-[#acb4bb]",
+                    )}
                   >
-                     {tab}
-                  </button>
-               ))}
+                    <span className="flex items-end">
+                      <span className="text-[length:var(--typo---heading\/h3,24px)] font-bold leading-[1.5]">
+                        {month}
+                      </span>
+                      <span className="text-[length:var(--typo---paragraph\/p1,14px)] font-medium leading-[1.5]">
+                        월
+                      </span>
+                    </span>
+                  </Button>
+                );
+              })}
+              <Button
+                disabled
+                variant="outline"
+                className="h-[48px] px-[22px] py-[9px] rounded-tl-[10px] rounded-tr-[10px] rounded-bl-none rounded-br-none w-[120px] shrink-0 shadow-[inset_0_0_0_1px_#acb4bb] text-[#acb4bb] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5]"
+              >
+                포스트 시즌
+              </Button>
             </div>
+          </div>
+        )}
 
-            {activeTab === TAB_WEEK && (
-               <div className="flex flex-col gap-3">
-                  <div className="relative flex items-center gap-3.5 justify-center">
-                     <Badge asChild variant="chipDestructive" className="opacity-50">
-                        <button
-                           onClick={() => {
-                              setWeekYear(CURRENT_YEAR);
-                              setWeekMonth(CURRENT_MONTH);
-                              setSelectedWeek(CURRENT_WEEK);
-                           }}
-                        >
-                           최근
-                        </button>
-                     </Badge>
-
-                     <div className="flex items-center gap-2">
-                        <button
-                           onClick={prevWeekMonth}
-                           className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
-                        >
-                           <ChevronLeft className="size-5" />
-                        </button>
-                        <button
-                           onClick={() => {
-                              setShowWeekPicker(true);
-                              setShowAllPicker(false);
-                           }}
-                           className="text-[18px] font-bold text-(--text-primary) leading-[1.5] min-w-[110px] text-center"
-                        >
-                           {weekYear}-{String(weekMonth).padStart(2, '0')}
-                        </button>
-                        <button
-                           onClick={nextWeekMonth}
-                           className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
-                        >
-                           <ChevronRight className="size-5" />
-                        </button>
-                     </div>
-
-                     <div className="w-[56px]" />
-
-                     {showWeekPicker && (
-                        <YearMonthPicker
-                           year={weekYear}
-                           month={weekMonth}
-                           onConfirm={(year, month) => {
-                              setWeekYear(year);
-                              setWeekMonth(month);
-                              setSelectedWeek(1);
-                              setShowWeekPicker(false);
-                           }}
-                           onClose={() => setShowWeekPicker(false)}
-                        />
-                     )}
-                  </div>
-
-                  <div className="flex gap-[30px] justify-center">
-                     {WEEK_OPTIONS.map(week => (
-                        <Button
-                           key={week}
-                           onClick={() => setSelectedWeek(week)}
-                           variant={week === selectedWeek ? 'primaryline' : 'outline'}
-                           className={cn(
-                              'px-[22px] py-[9px] rounded-[10px] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5]',
-                              week !== selectedWeek && 'shadow-[inset_0_0_0_1px_#161d24] text-[#161d24]',
-                           )}
-                        >
-                           {week}주차
-                        </Button>
-                     ))}
-                  </div>
-               </div>
+        {filteredData.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <div
+            className={cn(
+              "flex flex-col",
+              activeTab !== TAB_TODAY && "gap-[25px]",
             )}
+          >
+            {filteredData.map((day) => {
+              const isToday = day.isToday ?? day.date === TODAY;
 
-            {activeTab === TAB_ALL && (
-               <div className="flex flex-col gap-3">
-                  <div className="relative flex items-center gap-3.5 justify-center">
-                     <Badge asChild variant="chipDestructive" className="opacity-50">
-                        <button
-                           onClick={() => {
-                              setAllYear(CURRENT_YEAR);
-                              setAllMonth(CURRENT_MONTH);
-                           }}
-                        >
-                           최근
-                        </button>
-                     </Badge>
-
-                     <div className="flex items-center gap-2">
-                        <button
-                           onClick={() => setAllYear(year => Math.max(year - 1, AVAILABLE_YEARS[0]))}
-                           className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
-                        >
-                           <ChevronLeft className="size-5" />
-                        </button>
-                        <button
-                           onClick={() => {
-                              setShowAllPicker(true);
-                              setShowWeekPicker(false);
-                           }}
-                           className="text-[18px] font-bold text-(--text-primary) leading-[1.5] min-w-[60px] text-center"
-                        >
-                           {allYear}
-                        </button>
-                        <button
-                           onClick={() =>
-                              setAllYear(year => Math.min(year + 1, AVAILABLE_YEARS[AVAILABLE_YEARS.length - 1]))
-                           }
-                           className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
-                        >
-                           <ChevronRight className="size-5" />
-                        </button>
-                     </div>
-
-                     <div className="w-[56px]" />
-
-                     {showAllPicker && (
-                        <YearMonthPicker
-                           year={allYear}
-                           month={allMonth}
-                           onConfirm={(year, month) => {
-                              setAllYear(year);
-                              setAllMonth(month);
-                              setShowAllPicker(false);
-                           }}
-                           onClose={() => setShowAllPicker(false)}
-                        />
-                     )}
+              return (
+                <div key={day.date}>
+                  <div className="bg-[#f1f2f4] border border-(--border-normal) px-[30px] py-[10px] rounded-tl-[20px] rounded-tr-[20px] flex items-center gap-2">
+                    <span className="text-[length:var(--typo---heading\/h4,20px)] font-semibold text-(--text-primary) leading-[1.5]">
+                      {day.date}
+                    </span>
+                    {isToday && <Badge variant="chipDestructive">오늘</Badge>}
                   </div>
 
-                  <div className="flex w-full">
-                     {SEASON_MONTHS.map(month => {
-                        const isDisabled = DISABLED_MONTHS.includes(month);
-                        const isSelected = month === allMonth;
+                  {day.games.map((game, index) => {
+                    const isLast = index === day.games.length - 1;
+                    const isEnded = game.status === "종료";
+                    const textDisabled = isEnded
+                      ? "text-[#acb4bb]"
+                      : "text-(--text-primary)";
+                    const resultText = getGameResultTexts(game.score, isEnded);
 
-                        return (
-                           <Button
-                              key={month}
-                              onClick={() => !isDisabled && setAllMonth(month)}
-                              disabled={isDisabled}
-                              variant={isSelected ? 'primaryline' : 'outline'}
+                    return (
+                      <div
+                        key={`${day.date}-${game.time}-${game.away}-${game.home}-${index}`}
+                        className={cn(
+                          "border border-t-0 border-(--border-normal) px-[20px] py-[6px] flex items-center justify-between",
+                          isLast && "rounded-bl-[20px] rounded-br-[20px]",
+                          isEnded ? "bg-[#f7f8f9]" : "bg-background",
+                        )}
+                      >
+                        <div className="flex gap-[30px] items-center shrink-0">
+                          <div className="flex items-center justify-center w-[60px]">
+                            <span
                               className={cn(
-                                 'flex-1 h-[48px] px-[22px] py-[9px] rounded-tl-[10px] rounded-tr-[10px] rounded-bl-none rounded-br-none',
-                                 !isSelected && !isDisabled && 'shadow-[inset_0_0_0_1px_#161d24] text-[#161d24]',
-                                 isDisabled && 'shadow-[inset_0_0_0_1px_#acb4bb] text-[#acb4bb]',
+                                "text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap",
+                                textDisabled,
                               )}
-                           >
-                              <span className="flex items-end">
-                                 <span className="text-[length:var(--typo---heading\/h3,24px)] font-bold leading-[1.5]">
-                                    {month}
-                                 </span>
-                                 <span className="text-[length:var(--typo---paragraph\/p1,14px)] font-medium leading-[1.5]">
-                                    월
-                                 </span>
-                              </span>
-                           </Button>
-                        );
-                     })}
-                     <Button
-                        disabled
-                        variant="outline"
-                        className="h-[48px] px-[22px] py-[9px] rounded-tl-[10px] rounded-tr-[10px] rounded-bl-none rounded-br-none w-[120px] shrink-0 shadow-[inset_0_0_0_1px_#acb4bb] text-[#acb4bb] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5]"
-                     >
-                        포스트 시즌
-                     </Button>
-                  </div>
-               </div>
-            )}
-
-            {filteredData.length === 0 ? (
-               <EmptyState />
-            ) : (
-               <div className={cn('flex flex-col', activeTab !== TAB_TODAY && 'gap-[25px]')}>
-                  {filteredData.map(day => {
-                     const isToday = day.isToday ?? day.date === TODAY;
-
-                     return (
-                        <div key={day.date}>
-                           <div className="bg-[#f1f2f4] border border-(--border-normal) px-[30px] py-[10px] rounded-tl-[20px] rounded-tr-[20px] flex items-center gap-2">
-                              <span className="text-[length:var(--typo---heading\/h4,20px)] font-semibold text-(--text-primary) leading-[1.5]">
-                                 {day.date}
-                              </span>
-                              {isToday && <Badge variant="chipDestructive">오늘</Badge>}
-                           </div>
-
-                           {day.games.map((game, index) => {
-                              const isLast = index === day.games.length - 1;
-                              const isEnded = game.status === '종료';
-                              const textDisabled = isEnded ? 'text-[#acb4bb]' : 'text-(--text-primary)';
-                              const resultText = getGameResultTexts(game.score, isEnded);
-
-                              return (
-                                 <div
-                                    key={`${day.date}-${game.time}-${game.away}-${game.home}-${index}`}
-                                    className={cn(
-                                       'border border-t-0 border-(--border-normal) px-[20px] py-[6px] flex items-center justify-between',
-                                       isLast && 'rounded-bl-[20px] rounded-br-[20px]',
-                                       isEnded ? 'bg-[#f7f8f9]' : 'bg-background',
-                                    )}
-                                 >
-                                    <div className="flex gap-[30px] items-center shrink-0">
-                                       <div className="flex items-center justify-center w-[60px]">
-                                          <span
-                                             className={cn(
-                                                'text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap',
-                                                textDisabled,
-                                             )}
-                                          >
-                                             {game.time}
-                                          </span>
-                                       </div>
-                                       <div className="flex items-center justify-center w-[40px]">
-                                          <span
-                                             className={cn(
-                                                'text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap',
-                                                textDisabled,
-                                             )}
-                                          >
-                                             {game.venue}
-                                          </span>
-                                       </div>
-                                    </div>
-
-                                    <div className="flex gap-[50px] items-center shrink-0">
-                                       <div className="flex items-center justify-center w-[150px]">
-                                          <div className="flex h-[75px] items-center justify-end w-[70px] shrink-0">
-                                             <div className="w-[30px] h-[75px] shrink-0" />
-                                             <TeamName
-                                                name={game.away}
-                                                isEnded={isEnded}
-                                                result={resultText.away}
-                                                textDisabled={textDisabled}
-                                             />
-                                          </div>
-                                          <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
-                                             <img
-                                                src={teamLogos[game.away]}
-                                                alt={game.away}
-                                                className="w-full h-full object-contain"
-                                             />
-                                          </div>
-                                       </div>
-
-                                       <div className="flex flex-col items-center justify-center w-[40px] shrink-0">
-                                          <ScoreDisplay game={game} />
-                                          <span
-                                             className={cn(
-                                                'text-[12px] font-medium text-center leading-[1.5]',
-                                                statusColor[game.status],
-                                             )}
-                                          >
-                                             {game.status}
-                                          </span>
-                                       </div>
-
-                                       <div className="flex items-center justify-center w-[150px]">
-                                          <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
-                                             <img
-                                                src={teamLogos[game.home]}
-                                                alt={game.home}
-                                                className="w-full h-full object-contain"
-                                             />
-                                          </div>
-                                          <div className="flex h-[75px] items-center justify-between w-[70px] shrink-0">
-                                             <TeamName
-                                                name={game.home}
-                                                isEnded={isEnded}
-                                                result={resultText.home}
-                                                textDisabled={textDisabled}
-                                             />
-                                             <div className="flex h-[75px] items-center justify-end w-[30px] shrink-0">
-                                                <div className="bg-[#acb4bb] flex flex-col items-center justify-center px-[4px] rounded-[2px] w-[22px]">
-                                                   <span className="text-white text-[16px] font-medium text-center leading-[1.5]">
-                                                      홈
-                                                   </span>
-                                                </div>
-                                             </div>
-                                          </div>
-                                       </div>
-                                    </div>
-
-                                    <ActionButtons game={game} isEnded={isEnded} />
-                                 </div>
-                              );
-                           })}
+                            >
+                              {game.time}
+                            </span>
+                          </div>
+                          <div className="flex items-center justify-center w-[40px]">
+                            <span
+                              className={cn(
+                                "text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap",
+                                textDisabled,
+                              )}
+                            >
+                              {game.venue}
+                            </span>
+                          </div>
                         </div>
-                     );
+
+                        <div className="flex gap-[50px] items-center shrink-0">
+                          <div className="flex items-center justify-center w-[150px]">
+                            <div className="flex h-[75px] items-center justify-end w-[70px] shrink-0">
+                              <div className="w-[30px] h-[75px] shrink-0" />
+                              <TeamName
+                                name={game.away}
+                                isEnded={isEnded}
+                                result={resultText.away}
+                                textDisabled={textDisabled}
+                              />
+                            </div>
+                            <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
+                              <img
+                                src={teamLogos[game.away]}
+                                alt={game.away}
+                                className="w-full h-full object-contain"
+                              />
+                            </div>
+                          </div>
+
+                          <div className="flex flex-col items-center justify-center w-[40px] shrink-0">
+                            <ScoreDisplay game={game} />
+                            <span
+                              className={cn(
+                                "text-[12px] font-medium text-center leading-[1.5]",
+                                statusColor[game.status],
+                              )}
+                            >
+                              {game.status}
+                            </span>
+                          </div>
+
+                          <div className="flex items-center justify-center w-[150px]">
+                            <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
+                              <img
+                                src={teamLogos[game.home]}
+                                alt={game.home}
+                                className="w-full h-full object-contain"
+                              />
+                            </div>
+                            <div className="flex h-[75px] items-center justify-between w-[70px] shrink-0">
+                              <TeamName
+                                name={game.home}
+                                isEnded={isEnded}
+                                result={resultText.home}
+                                textDisabled={textDisabled}
+                              />
+                              <div className="flex h-[75px] items-center justify-end w-[30px] shrink-0">
+                                <div className="bg-[#acb4bb] flex flex-col items-center justify-center px-[4px] rounded-[2px] w-[22px]">
+                                  <span className="text-white text-[16px] font-medium text-center leading-[1.5]">
+                                    홈
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+
+                        <ActionButtons game={game} isEnded={isEnded} />
+                      </div>
+                    );
                   })}
-               </div>
-            )}
-         </div>
-      </section>
-   );
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
 };
 
 export default GameSchedule;

--- a/src/pages/home/ui/game-schedule/AllNavigator.tsx
+++ b/src/pages/home/ui/game-schedule/AllNavigator.tsx
@@ -1,0 +1,111 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { cn } from '@/shared/lib/utils';
+import { Badge } from '@/shared/ui/badge';
+import { Button } from '@/shared/ui/button';
+
+import { DISABLED_MONTHS, SEASON_MONTHS } from './constants';
+import YearMonthPicker from './YearMonthPicker';
+
+type AllNavigatorProps = {
+  allYear: number;
+  allMonth: number;
+  showAllPicker: boolean;
+  onReset: () => void;
+  onPrevYear: () => void;
+  onNextYear: () => void;
+  onOpenPicker: () => void;
+  onClosePicker: () => void;
+  onConfirmPicker: (year: number, month: number) => void;
+  onSelectMonth: (month: number) => void;
+};
+
+function AllNavigator({
+  allYear,
+  allMonth,
+  showAllPicker,
+  onReset,
+  onPrevYear,
+  onNextYear,
+  onOpenPicker,
+  onClosePicker,
+  onConfirmPicker,
+  onSelectMonth,
+}: AllNavigatorProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="relative flex items-center gap-3.5 justify-center">
+        <Badge asChild variant="chipDestructive" className="opacity-50">
+          <button onClick={onReset}>최근</button>
+        </Badge>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onPrevYear}
+            className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
+          >
+            <ChevronLeft className="size-5" />
+          </button>
+          <button
+            onClick={onOpenPicker}
+            className="text-[18px] font-bold text-(--text-primary) leading-[1.5] min-w-[60px] text-center"
+          >
+            {allYear}
+          </button>
+          <button
+            onClick={onNextYear}
+            className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
+          >
+            <ChevronRight className="size-5" />
+          </button>
+        </div>
+
+        <div className="w-[56px]" />
+
+        {showAllPicker && (
+          <YearMonthPicker
+            year={allYear}
+            month={allMonth}
+            onConfirm={onConfirmPicker}
+            onClose={onClosePicker}
+          />
+        )}
+      </div>
+
+      <div className="flex w-full">
+        {SEASON_MONTHS.map((month) => {
+          const isDisabled = DISABLED_MONTHS.includes(month);
+          const isSelected = month === allMonth;
+
+          return (
+            <Button
+              key={month}
+              onClick={() => !isDisabled && onSelectMonth(month)}
+              disabled={isDisabled}
+              variant={isSelected ? 'primaryline' : 'outline'}
+              className={cn(
+                'flex-1 h-[48px] px-[22px] py-[9px] rounded-tl-[10px] rounded-tr-[10px] rounded-bl-none rounded-br-none',
+                !isSelected && !isDisabled && 'shadow-[inset_0_0_0_1px_#161d24] text-[#161d24]',
+                isDisabled && 'shadow-[inset_0_0_0_1px_#acb4bb] text-[#acb4bb]',
+              )}
+            >
+              <span className="flex items-end">
+                <span className="text-[length:var(--typo---heading\/h3,24px)] font-bold leading-[1.5]">{month}</span>
+                <span className="text-[length:var(--typo---paragraph\/p1,14px)] font-medium leading-[1.5]">월</span>
+              </span>
+            </Button>
+          );
+        })}
+        <Button
+          disabled
+          variant="outline"
+          className="h-[48px] px-[22px] py-[9px] rounded-tl-[10px] rounded-tr-[10px] rounded-bl-none rounded-br-none w-[120px] shrink-0 shadow-[inset_0_0_0_1px_#acb4bb] text-[#acb4bb] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5]"
+        >
+          포스트 시즌
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default AllNavigator;

--- a/src/pages/home/ui/game-schedule/ScheduleList.tsx
+++ b/src/pages/home/ui/game-schedule/ScheduleList.tsx
@@ -1,0 +1,179 @@
+import { TicketX } from 'lucide-react';
+
+import { cn } from '@/shared/lib/utils';
+import { Badge } from '@/shared/ui/badge';
+
+import { TAB_TODAY, TODAY, statusColor, teamLogos } from './constants';
+import type { DaySchedule, GameRow } from './types';
+import { getGameResultTexts } from './utils';
+
+function ScoreDisplay({ game }: { game: GameRow }) {
+  const scoreText = game.score ?? 'VS';
+
+  if (game.status === '종료' && game.score) {
+    const [awayScore, homeScore] = game.score.split(':').map(Number);
+    const awayLost = awayScore < homeScore;
+
+    return (
+      <span className="text-[24px] font-bold text-center leading-[1.5] whitespace-nowrap text-[#ef4444]">
+        <span className={awayLost ? 'text-[#acb4bb]' : ''}>{awayScore}:</span>
+        <span className={!awayLost ? 'text-[#acb4bb]' : ''}>{homeScore}</span>
+      </span>
+    );
+  }
+
+  return <span className="text-[24px] font-bold text-(--text-primary) text-center leading-[1.5] whitespace-nowrap">{scoreText}</span>;
+}
+
+function EmptyState() {
+  return (
+    <div className="bg-[#f7f8f9] flex h-[400px] items-center justify-center overflow-hidden px-5 py-[100px] rounded-[10px] w-full">
+      <div className="flex flex-col gap-[10px] items-center justify-center">
+        <TicketX className="size-[75px] text-[#acb4bb]" strokeWidth={1.2} />
+        <p className="text-[22px] font-semibold text-[#646f7c] text-center leading-[1.55]">현재 예매 가능한 경기가 없습니다.</p>
+      </div>
+    </div>
+  );
+}
+
+function TeamName({
+  name,
+  isEnded,
+  result,
+  textDisabled,
+}: {
+  name: string;
+  isEnded: boolean;
+  result: string;
+  textDisabled: string;
+}) {
+  if (isEnded) {
+    return (
+      <div className="flex flex-col items-center shrink-0">
+        <span className={cn('text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap', textDisabled)}>{name}</span>
+        <span className="text-[12px] font-medium text-(--text-tertiary) leading-[1.5]">{result}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full items-center justify-center shrink-0">
+      <span className="text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap text-(--text-primary)">{name}</span>
+    </div>
+  );
+}
+
+function ActionButtons({ game, isEnded }: { game: GameRow; isEnded: boolean }) {
+  return (
+    <div className={cn('flex gap-[10px] h-[66px] items-center shrink-0', isEnded && 'opacity-0')}>
+      <button
+        className={cn(
+          'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] text-white',
+          game.ticket === '예매하기' ? 'bg-primary' : 'bg-[#acb4bb] w-[88px]',
+        )}
+      >
+        {game.ticket}
+      </button>
+      <button
+        className={cn(
+          'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] border',
+          game.resell === '리셀예매'
+            ? 'bg-background border-primary text-primary'
+            : 'bg-background border-[#acb4bb] text-[#acb4bb] w-[88px] whitespace-nowrap',
+        )}
+      >
+        {game.resell}
+      </button>
+    </div>
+  );
+}
+
+type ScheduleListProps = {
+  activeTab: number;
+  filteredData: DaySchedule[];
+};
+
+function ScheduleList({ activeTab, filteredData }: ScheduleListProps) {
+  if (filteredData.length === 0) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className={cn('flex flex-col', activeTab !== TAB_TODAY && 'gap-[25px]')}>
+      {filteredData.map((day) => {
+        const isToday = day.isToday ?? day.date === TODAY;
+
+        return (
+          <div key={day.date}>
+            <div className="bg-[#f1f2f4] border border-(--border-normal) px-[30px] py-[10px] rounded-tl-[20px] rounded-tr-[20px] flex items-center gap-2">
+              <span className="text-[length:var(--typo---heading\/h4,20px)] font-semibold text-(--text-primary) leading-[1.5]">{day.date}</span>
+              {isToday && <Badge variant="chipDestructive">오늘</Badge>}
+            </div>
+
+            {day.games.map((game, index) => {
+              const isLast = index === day.games.length - 1;
+              const isEnded = game.status === '종료';
+              const textDisabled = isEnded ? 'text-[#acb4bb]' : 'text-(--text-primary)';
+              const resultText = getGameResultTexts(game.score, isEnded);
+
+              return (
+                <div
+                  key={`${day.date}-${game.time}-${game.away}-${game.home}-${index}`}
+                  className={cn(
+                    'border border-t-0 border-(--border-normal) px-[20px] py-[6px] flex items-center justify-between',
+                    isLast && 'rounded-bl-[20px] rounded-br-[20px]',
+                    isEnded ? 'bg-[#f7f8f9]' : 'bg-background',
+                  )}
+                >
+                  <div className="flex gap-[30px] items-center shrink-0">
+                    <div className="flex items-center justify-center w-[60px]">
+                      <span className={cn('text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap', textDisabled)}>{game.time}</span>
+                    </div>
+                    <div className="flex items-center justify-center w-[40px]">
+                      <span className={cn('text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap', textDisabled)}>{game.venue}</span>
+                    </div>
+                  </div>
+
+                  <div className="flex gap-[50px] items-center shrink-0">
+                    <div className="flex items-center justify-center w-[150px]">
+                      <div className="flex h-[75px] items-center justify-end w-[70px] shrink-0">
+                        <div className="w-[30px] h-[75px] shrink-0" />
+                        <TeamName name={game.away} isEnded={isEnded} result={resultText.away} textDisabled={textDisabled} />
+                      </div>
+                      <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
+                        <img src={teamLogos[game.away]} alt={game.away} className="w-full h-full object-contain" />
+                      </div>
+                    </div>
+
+                    <div className="flex flex-col items-center justify-center w-[40px] shrink-0">
+                      <ScoreDisplay game={game} />
+                      <span className={cn('text-[12px] font-medium text-center leading-[1.5]', statusColor[game.status])}>{game.status}</span>
+                    </div>
+
+                    <div className="flex items-center justify-center w-[150px]">
+                      <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
+                        <img src={teamLogos[game.home]} alt={game.home} className="w-full h-full object-contain" />
+                      </div>
+                      <div className="flex h-[75px] items-center justify-between w-[70px] shrink-0">
+                        <TeamName name={game.home} isEnded={isEnded} result={resultText.home} textDisabled={textDisabled} />
+                        <div className="flex h-[75px] items-center justify-end w-[30px] shrink-0">
+                          <div className="bg-[#acb4bb] flex flex-col items-center justify-center px-[4px] rounded-[2px] w-[22px]">
+                            <span className="text-white text-[16px] font-medium text-center leading-[1.5]">홈</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <ActionButtons game={game} isEnded={isEnded} />
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default ScheduleList;

--- a/src/pages/home/ui/game-schedule/TeamLogoNav.tsx
+++ b/src/pages/home/ui/game-schedule/TeamLogoNav.tsx
@@ -1,0 +1,35 @@
+import { teams } from '@/entities/team/model/teams';
+import { cn } from '@/shared/lib/utils';
+
+import { TEAM_IDS, teamLogos, teamOrder } from './constants';
+
+type TeamLogoNavProps = {
+  onNavigateTeam: (teamId: string) => void;
+};
+
+function TeamLogoNav({ onNavigateTeam }: TeamLogoNavProps) {
+  return (
+    <div className="flex items-center justify-between">
+      {teamOrder.map((team) => {
+        const teamId = TEAM_IDS[team];
+        const isEnabled = teams.find((candidate) => candidate.id === teamId)?.isEnabled ?? false;
+
+        return (
+          <button
+            key={team}
+            onClick={() => isEnabled && onNavigateTeam(teamId)}
+            disabled={!isEnabled}
+            className={cn(
+              'flex items-center justify-center size-[80px] p-[10px] rounded-xl transition-colors overflow-hidden',
+              isEnabled ? 'hover:bg-fill-hoveraccent cursor-pointer' : 'opacity-30 cursor-not-allowed',
+            )}
+          >
+            <img src={teamLogos[team]} alt={team} className="w-full h-full object-contain" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default TeamLogoNav;

--- a/src/pages/home/ui/game-schedule/WeekNavigator.tsx
+++ b/src/pages/home/ui/game-schedule/WeekNavigator.tsx
@@ -1,0 +1,96 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { cn } from '@/shared/lib/utils';
+import { Badge } from '@/shared/ui/badge';
+import { Button } from '@/shared/ui/button';
+
+import { WEEK_OPTIONS } from './constants';
+import YearMonthPicker from './YearMonthPicker';
+
+type WeekNavigatorProps = {
+  weekYear: number;
+  weekMonth: number;
+  selectedWeek: number;
+  showWeekPicker: boolean;
+  onReset: () => void;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+  onOpenPicker: () => void;
+  onClosePicker: () => void;
+  onConfirmPicker: (year: number, month: number) => void;
+  onSelectWeek: (week: number) => void;
+};
+
+function WeekNavigator({
+  weekYear,
+  weekMonth,
+  selectedWeek,
+  showWeekPicker,
+  onReset,
+  onPrevMonth,
+  onNextMonth,
+  onOpenPicker,
+  onClosePicker,
+  onConfirmPicker,
+  onSelectWeek,
+}: WeekNavigatorProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="relative flex items-center gap-3.5 justify-center">
+        <Badge asChild variant="chipDestructive" className="opacity-50">
+          <button onClick={onReset}>최근</button>
+        </Badge>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onPrevMonth}
+            className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
+          >
+            <ChevronLeft className="size-5" />
+          </button>
+          <button
+            onClick={onOpenPicker}
+            className="text-[18px] font-bold text-(--text-primary) leading-[1.5] min-w-[110px] text-center"
+          >
+            {weekYear}-{String(weekMonth).padStart(2, '0')}
+          </button>
+          <button
+            onClick={onNextMonth}
+            className="flex items-center justify-center size-8 rounded-full hover:bg-gray-100 text-(--text-tertiary)"
+          >
+            <ChevronRight className="size-5" />
+          </button>
+        </div>
+
+        <div className="w-[56px]" />
+
+        {showWeekPicker && (
+          <YearMonthPicker
+            year={weekYear}
+            month={weekMonth}
+            onConfirm={onConfirmPicker}
+            onClose={onClosePicker}
+          />
+        )}
+      </div>
+
+      <div className="flex gap-[30px] justify-center">
+        {WEEK_OPTIONS.map((week) => (
+          <Button
+            key={week}
+            onClick={() => onSelectWeek(week)}
+            variant={week === selectedWeek ? 'primaryline' : 'outline'}
+            className={cn(
+              'px-[22px] py-[9px] rounded-[10px] text-[length:var(--typo---heading\/h4,20px)] font-semibold leading-[1.5]',
+              week !== selectedWeek && 'shadow-[inset_0_0_0_1px_#161d24] text-[#161d24]',
+            )}
+          >
+            {week}주차
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default WeekNavigator;

--- a/src/pages/home/ui/game-schedule/YearMonthPicker.tsx
+++ b/src/pages/home/ui/game-schedule/YearMonthPicker.tsx
@@ -1,0 +1,125 @@
+import { cn } from '@/shared/lib/utils';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { AVAILABLE_YEARS } from './constants';
+
+type YearMonthPickerProps = {
+   year: number;
+   month: number;
+   onConfirm: (year: number, month: number) => void;
+   onClose: () => void;
+};
+
+const MONTHS = Array.from({ length: 12 }, (_, index) => index + 1);
+
+function YearMonthPicker({ year, month, onConfirm, onClose }: YearMonthPickerProps) {
+   const [localYear, setLocalYear] = useState(year);
+   const [localMonth, setLocalMonth] = useState(month);
+   const pickerRef = useRef<HTMLDivElement>(null);
+
+   useEffect(() => {
+      function handleClickOutside(e: MouseEvent) {
+         if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+            onClose();
+         }
+      }
+
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+   }, [onClose]);
+
+   const yearIdx = AVAILABLE_YEARS.indexOf(localYear);
+   const canPrevYear = yearIdx > 0;
+   const canNextYear = yearIdx < AVAILABLE_YEARS.length - 1;
+
+   return (
+      <div
+         ref={pickerRef}
+         className="absolute top-10 left-1/2 -translate-x-1/2 z-50 bg-white rounded-[12px] shadow-xl border border-(--border-normal) overflow-hidden"
+      >
+         <div className="flex">
+            <div className="flex flex-col items-center w-[100px] border-r border-(--border-normal)">
+               <button
+                  onClick={() => canPrevYear && setLocalYear(AVAILABLE_YEARS[yearIdx - 1])}
+                  disabled={!canPrevYear}
+                  className="flex items-center justify-center w-full py-[10px] text-[#646f7c] hover:bg-gray-50 disabled:opacity-30"
+               >
+                  <ChevronUp className="size-5" />
+               </button>
+               <div className="flex flex-col items-center w-full py-[6px]">
+                  {AVAILABLE_YEARS.map(candidateYear => (
+                     <button
+                        key={candidateYear}
+                        onClick={() => setLocalYear(candidateYear)}
+                        className={cn(
+                           'w-full py-[8px] text-center text-[16px] leading-[1.5] transition-colors',
+                           candidateYear === localYear
+                              ? 'font-bold text-(--text-primary)'
+                              : 'font-medium text-[#acb4bb] hover:text-(--text-primary)',
+                        )}
+                     >
+                        {candidateYear}
+                     </button>
+                  ))}
+               </div>
+               <button
+                  onClick={() => canNextYear && setLocalYear(AVAILABLE_YEARS[yearIdx + 1])}
+                  disabled={!canNextYear}
+                  className="flex items-center justify-center w-full py-[10px] text-[#646f7c] hover:bg-gray-50 disabled:opacity-30"
+               >
+                  <ChevronDown className="size-5" />
+               </button>
+            </div>
+
+            <div className="flex flex-col items-center w-[80px]">
+               <button
+                  onClick={() => setLocalMonth(currentMonth => (currentMonth === 1 ? 12 : currentMonth - 1))}
+                  className="flex items-center justify-center w-full py-[10px] text-[#646f7c] hover:bg-gray-50"
+               >
+                  <ChevronUp className="size-5" />
+               </button>
+               <div className="flex flex-col items-center w-full py-[6px]">
+                  {MONTHS.map(candidateMonth => (
+                     <button
+                        key={candidateMonth}
+                        onClick={() => setLocalMonth(candidateMonth)}
+                        className={cn(
+                           'w-full py-[8px] text-center text-[16px] leading-[1.5] transition-colors',
+                           candidateMonth === localMonth
+                              ? 'font-bold text-(--text-primary)'
+                              : 'font-medium text-[#acb4bb] hover:text-(--text-primary)',
+                        )}
+                     >
+                        {String(candidateMonth).padStart(2, '0')}
+                     </button>
+                  ))}
+               </div>
+               <button
+                  onClick={() => setLocalMonth(currentMonth => (currentMonth === 12 ? 1 : currentMonth + 1))}
+                  className="flex items-center justify-center w-full py-[10px] text-[#646f7c] hover:bg-gray-50"
+               >
+                  <ChevronDown className="size-5" />
+               </button>
+            </div>
+         </div>
+
+         <div className="flex border-t border-(--border-normal)">
+            <button
+               onClick={onClose}
+               className="flex-1 py-[12px] text-[14px] font-medium text-[#646f7c] hover:bg-gray-50"
+            >
+               취소
+            </button>
+            <button
+               onClick={() => onConfirm(localYear, localMonth)}
+               className="flex-1 py-[12px] text-[14px] font-semibold text-primary border-l border-(--border-normal) hover:bg-blue-50"
+            >
+               확인
+            </button>
+         </div>
+      </div>
+   );
+}
+
+export default YearMonthPicker;

--- a/src/pages/home/ui/game-schedule/constants.ts
+++ b/src/pages/home/ui/game-schedule/constants.ts
@@ -1,0 +1,101 @@
+import type { DaySchedule, GameStatus } from './types';
+
+export const teamOrder = ['LG', '한화', 'SSG', '삼성', 'NC', 'KT', '롯데', '두산', '키움', 'KIA'];
+
+// 팀 로고 이미지 (Figma asset)
+export const teamLogos: Record<string, string> = {
+   LG: '/baseball/logos/lg.png',
+   한화: '/baseball/logos/hanwha.png',
+   SSG: '/baseball/logos/ssg.png',
+   삼성: '/baseball/logos/samsung.png',
+   NC: '/baseball/logos/nc.png',
+   KT: '/baseball/logos/kt.png',
+   롯데: '/baseball/logos/lotte.png',
+   두산: '/baseball/logos/doosan.png',
+   키움: '/baseball/logos/kiwoom.png',
+   KIA: '/baseball/logos/kia.png',
+};
+
+export const scheduleData: DaySchedule[] = [
+   {
+      date: '7월 1일 (수)',
+      games: [
+         {
+            time: '18:30',
+            venue: '잠실',
+            away: 'KIA',
+            home: 'LG',
+            score: '5:3',
+            status: '종료',
+            ticket: '매진',
+            resell: '리셀매진',
+         },
+      ],
+   },
+   {
+      date: '7월 3일 (금)',
+      isToday: true,
+      games: [
+         {
+            time: '18:30',
+            venue: '잠실',
+            away: 'KIA',
+            home: 'LG',
+            score: '2:1',
+            status: '경기중',
+            ticket: '예매하기',
+            resell: '리셀매진',
+         },
+         {
+            time: '18:30',
+            venue: '대구',
+            away: '두산',
+            home: '삼성',
+            score: null,
+            status: '예정',
+            ticket: '예매하기',
+            resell: '리셀예매',
+         },
+      ],
+   },
+   {
+      date: '7월 5일 (일)',
+      games: [
+         {
+            time: '17:00',
+            venue: '잠실',
+            away: 'KIA',
+            home: 'LG',
+            score: null,
+            status: '예정',
+            ticket: '판매예정',
+            resell: '리셀예정',
+            ticketInfo: '6월 25일\n오전 11시 오픈',
+            reselInfo: '정식 예매 오픈\n2시간 후',
+         },
+      ],
+   },
+];
+
+export const statusColor: Record<GameStatus, string> = {
+   경기중: 'text-[#38c976]',
+   예정: 'text-primary',
+   종료: 'text-[#ef4444]',
+   취소: 'text-[#acb4bb]',
+};
+
+export const TODAY = '7월 3일 (금)';
+export const CURRENT_YEAR = 2025;
+export const CURRENT_MONTH = 7;
+export const CURRENT_WEEK = 1;
+
+// 시즌 월 순서: 3월~12월, 1월, 2월
+export const SEASON_MONTHS = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2];
+export const DISABLED_MONTHS = [10, 11, 12, 1, 2];
+export const AVAILABLE_YEARS = [2021, 2022, 2023, 2024, 2025, 2026];
+
+export const tabs = ['오늘 일정', '주간 일정', '전체 일정'];
+export const TAB_TODAY = 0;
+export const TAB_WEEK = 1;
+export const TAB_ALL = 2;
+export const WEEK_OPTIONS = [1, 2, 3, 4, 5];

--- a/src/pages/home/ui/game-schedule/constants.ts
+++ b/src/pages/home/ui/game-schedule/constants.ts
@@ -1,6 +1,18 @@
 import type { DaySchedule, GameStatus } from './types';
 
 export const teamOrder = ['LG', '한화', 'SSG', '삼성', 'NC', 'KT', '롯데', '두산', '키움', 'KIA'];
+export const TEAM_IDS: Record<string, string> = {
+   LG: 'lg',
+   한화: 'hanwha',
+   SSG: 'ssg',
+   삼성: 'samsung',
+   NC: 'nc',
+   KT: 'kt',
+   롯데: 'lotte',
+   두산: 'doosan',
+   키움: 'kiwoom',
+   KIA: 'kia',
+};
 
 // 팀 로고 이미지 (Figma asset)
 export const teamLogos: Record<string, string> = {

--- a/src/pages/home/ui/game-schedule/types.ts
+++ b/src/pages/home/ui/game-schedule/types.ts
@@ -1,0 +1,22 @@
+export type GameStatus = '경기중' | '예정' | '종료' | '취소';
+export type TicketStatus = '예매하기' | '매진' | '판매예정';
+export type ReselStatus = '리셀예매' | '리셀매진' | '리셀예정';
+
+export type GameRow = {
+   time: string;
+   venue: string;
+   away: string;
+   home: string;
+   score: string | null;
+   status: GameStatus;
+   ticket: TicketStatus;
+   resell: ReselStatus;
+   ticketInfo?: string;
+   reselInfo?: string;
+};
+
+export type DaySchedule = {
+   date: string;
+   isToday?: boolean;
+   games: GameRow[];
+};

--- a/src/pages/home/ui/game-schedule/utils.ts
+++ b/src/pages/home/ui/game-schedule/utils.ts
@@ -1,0 +1,75 @@
+import {
+   TAB_ALL,
+   TAB_TODAY,
+   TAB_WEEK,
+   TODAY,
+} from './constants';
+import type { DaySchedule } from './types';
+
+type FilterParams = {
+   activeTab: number;
+   weekMonth: number;
+   selectedWeek: number;
+   allMonth: number;
+   selectedTeam: string | null;
+};
+
+function parseDate(dateStr: string): { month: number; day: number } {
+   const match = dateStr.match(/(\d+)월 (\d+)일/);
+   if (!match) return { month: 0, day: 0 };
+   return { month: parseInt(match[1]), day: parseInt(match[2]) };
+}
+
+function getWeekOfMonth(day: number): number {
+   return Math.ceil(day / 7);
+}
+
+function isDayInActiveTab(
+   day: DaySchedule,
+   activeTab: number,
+   weekMonth: number,
+   selectedWeek: number,
+   allMonth: number,
+): boolean {
+   switch (activeTab) {
+      case TAB_TODAY:
+         return day.date === TODAY;
+      case TAB_WEEK: {
+         const { month, day: dayNum } = parseDate(day.date);
+         const week = getWeekOfMonth(dayNum);
+         return month === weekMonth && week === selectedWeek;
+      }
+      case TAB_ALL: {
+         const { month } = parseDate(day.date);
+         return month === allMonth;
+      }
+      default:
+         return true;
+   }
+}
+
+export function filterScheduleData(data: DaySchedule[], params: FilterParams): DaySchedule[] {
+   const { activeTab, weekMonth, selectedWeek, allMonth, selectedTeam } = params;
+
+   return data
+      .filter(day => isDayInActiveTab(day, activeTab, weekMonth, selectedWeek, allMonth))
+      .map(day => ({
+         ...day,
+         games: selectedTeam
+            ? day.games.filter(game => game.away === selectedTeam || game.home === selectedTeam)
+            : day.games,
+      }))
+      .filter(day => day.games.length > 0);
+}
+
+export function getGameResultTexts(score: string | null, isEnded: boolean): { away: string; home: string } {
+   if (!isEnded || !score) {
+      return { away: '', home: '' };
+   }
+
+   const [awayScore, homeScore] = score.split(':').map(Number);
+   return {
+      away: awayScore < homeScore ? '패' : '승',
+      home: homeScore > awayScore ? '승' : '패',
+   };
+}

--- a/src/pages/home/ui/game-schedule/utils.ts
+++ b/src/pages/home/ui/game-schedule/utils.ts
@@ -11,7 +11,6 @@ type FilterParams = {
    weekMonth: number;
    selectedWeek: number;
    allMonth: number;
-   selectedTeam: string | null;
 };
 
 function parseDate(dateStr: string): { month: number; day: number } {
@@ -49,16 +48,10 @@ function isDayInActiveTab(
 }
 
 export function filterScheduleData(data: DaySchedule[], params: FilterParams): DaySchedule[] {
-   const { activeTab, weekMonth, selectedWeek, allMonth, selectedTeam } = params;
+   const { activeTab, weekMonth, selectedWeek, allMonth } = params;
 
    return data
       .filter(day => isDayInActiveTab(day, activeTab, weekMonth, selectedWeek, allMonth))
-      .map(day => ({
-         ...day,
-         games: selectedTeam
-            ? day.games.filter(game => game.away === selectedTeam || game.home === selectedTeam)
-            : day.games,
-      }))
       .filter(day => day.games.length > 0);
 }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #55

<br/>

## 🔎 개요
경기 일정 아이템 중 경기가 끝나지 않은 경기에 대해서 팀명이 가운데 정렬로 맞춰지지 않는 오류 수정

<br/>

## 📋 작업 내용
- `GameSchedule` 내부에 적용되어있던 중복로직 제거 및 컴포넌트 분리, util 함수 분리
- 팀명 가운데 정렬 적용

<br/>
