### PR TITLE
[bug] 머지 후 인증모듈 리스너 미호출 버그 해결

### DIFF
--- a/src/app/providers/router/ui/AppRouter.tsx
+++ b/src/app/providers/router/ui/AppRouter.tsx
@@ -22,6 +22,7 @@ import OAuthMessageListener from './OAuthMessageListener';
 const AppRouter = () => {
    return (
       <BrowserRouter>
+         <OAuthMessageListener />
          <Routes>
             <Route path="/auth" element={<AuthLayout />}>
                <Route path="login" element={<LoginPage />} />

--- a/src/shared/ui/alert.tsx
+++ b/src/shared/ui/alert.tsx
@@ -18,8 +18,8 @@ const alertVariants = cva('flex items-center gap-2 rounded-lg py-3 px-3.5 shadow
 
 const iconMap: Record<string, React.ReactNode> = {
    default: null,
-   success: <img src="/success.svg" alt="success" className="size-4" />,
-   fail: <img src="/fail.svg" alt="fail" className="size-4" />,
+   success: <img src="/Icon/Solid/success.svg" alt="success" className="size-4" />,
+   fail: <img src="/Icon/Solid/fail.svg" alt="fail" className="size-4" />,
 };
 
 type AlertProps = React.ComponentProps<'div'> & VariantProps<typeof alertVariants>;


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #7

<br/>

## 🔎 개요
- `63b830ed42b4e5a674f0fc37f5f999c50890750d` 머지 커밋 이후 `OAuthMessageListener`를 호출하지 않아 로그인이 안 되는 오류 수정

<br/>

## 📋 작업 내용
- `OAuthMessageListener` 호출 로직 추가
- 토스트 아이콘 경로 재설정

<br/>
