### PR TITLE
[design] 경기일정 모바일 UI 적용

### DIFF
--- a/src/pages/home/ui/game-schedule/ScheduleList.tsx
+++ b/src/pages/home/ui/game-schedule/ScheduleList.tsx
@@ -25,6 +25,24 @@ function ScoreDisplay({ game }: { game: GameRow }) {
   return <span className="text-[24px] font-bold text-(--text-primary) text-center leading-[1.5] whitespace-nowrap">{scoreText}</span>;
 }
 
+function MobileScoreDisplay({ game }: { game: GameRow }) {
+  const scoreText = game.score ?? 'VS';
+
+  if (game.status === '종료' && game.score) {
+    const [awayScore, homeScore] = game.score.split(':').map(Number);
+    const awayLost = awayScore < homeScore;
+
+    return (
+      <span className="text-[20px] font-bold text-center leading-[1.5] whitespace-nowrap text-[#ef4444]">
+        <span className={awayLost ? 'text-[#acb4bb]' : ''}>{awayScore}:</span>
+        <span className={!awayLost ? 'text-[#acb4bb]' : ''}>{homeScore}</span>
+      </span>
+    );
+  }
+
+  return <span className="text-[20px] font-bold text-(--text-primary) text-center leading-[1.5] whitespace-nowrap">{scoreText}</span>;
+}
+
 function EmptyState() {
   return (
     <div className="bg-[#f7f8f9] flex h-[400px] items-center justify-center overflow-hidden px-5 py-[100px] rounded-[10px] w-full">
@@ -63,27 +81,200 @@ function TeamName({
   );
 }
 
+function MobileTeam({
+  name,
+  isEnded,
+  result,
+  isHome,
+}: {
+  name: string;
+  isEnded: boolean;
+  result: string;
+  isHome: boolean;
+}) {
+  const textClass = isEnded ? 'text-[#acb4bb]' : 'text-(--text-primary)';
+
+  if (isHome) {
+    return (
+      <div className="flex items-center gap-[8px] shrink-0">
+        {isEnded && <span className="text-[12px] font-normal text-[#acb4bb] leading-[1.5]">{result}</span>}
+        <span className={cn('text-[16px] font-semibold text-center leading-[1.5] whitespace-nowrap', textClass)}>{name}</span>
+        <div className="relative size-[48px] shrink-0">
+          <img src={teamLogos[name]} alt={name} className={cn('size-full object-contain', isEnded && 'opacity-50')} />
+          <div className="absolute bg-[#acb4bb] bottom-0 right-0 h-[15px] rounded-[4px] w-[17px] flex items-center justify-center">
+            <span className="text-white text-[10px] leading-[1.5]">홈</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-[8px] shrink-0">
+      <img src={teamLogos[name]} alt={name} className={cn('size-[48px] object-contain shrink-0', isEnded && 'opacity-50')} />
+      <span className={cn('text-[16px] font-semibold text-center leading-[1.5] whitespace-nowrap', textClass)}>{name}</span>
+      {isEnded && <span className="text-[12px] font-normal text-[#acb4bb] leading-[1.5]">{result}</span>}
+    </div>
+  );
+}
+
 function ActionButtons({ game, isEnded }: { game: GameRow; isEnded: boolean }) {
   return (
-    <div className={cn('flex gap-[10px] h-[66px] items-center shrink-0', isEnded && 'opacity-0')}>
-      <button
-        className={cn(
-          'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] text-white',
-          game.ticket === '예매하기' ? 'bg-primary' : 'bg-[#acb4bb] w-[88px]',
-        )}
-      >
-        {game.ticket}
-      </button>
-      <button
-        className={cn(
-          'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] border',
-          game.resell === '리셀예매'
-            ? 'bg-background border-primary text-primary'
-            : 'bg-background border-[#acb4bb] text-[#acb4bb] w-[88px] whitespace-nowrap',
-        )}
-      >
-        {game.resell}
-      </button>
+    <>
+      {!isEnded && (
+        <div className="flex md:hidden gap-[8px] h-[38px] items-center w-full">
+          <button
+            className={cn(
+              'h-full flex-1 px-[16px] py-[8px] rounded-[8px] text-[14px] font-medium leading-[1.5] text-white',
+              game.ticket === '예매하기' ? 'bg-primary' : 'bg-[#acb4bb]',
+            )}
+          >
+            {game.ticket}
+          </button>
+          <button
+            className={cn(
+              'h-full flex-1 px-[16px] py-[8px] rounded-[8px] text-[14px] font-medium leading-[1.5] border',
+              game.resell === '리셀예매'
+                ? 'bg-background border-primary text-primary'
+                : 'bg-background border-[#acb4bb] text-[#acb4bb]',
+            )}
+          >
+            {game.resell}
+          </button>
+        </div>
+      )}
+
+      <div className={cn('hidden md:flex gap-[10px] h-[66px] items-center shrink-0', isEnded && 'opacity-0')}>
+        <button
+          className={cn(
+            'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] text-white',
+            game.ticket === '예매하기' ? 'bg-primary' : 'bg-[#acb4bb] w-[88px]',
+          )}
+        >
+          {game.ticket}
+        </button>
+        <button
+          className={cn(
+            'h-full px-[16px] py-[8px] rounded-[6px] text-[16px] font-medium leading-[1.5] border',
+            game.resell === '리셀예매'
+              ? 'bg-background border-primary text-primary'
+              : 'bg-background border-[#acb4bb] text-[#acb4bb] w-[88px] whitespace-nowrap',
+          )}
+        >
+          {game.resell}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function MobileGameRow({
+  day,
+  game,
+  index,
+}: {
+  day: DaySchedule;
+  game: GameRow;
+  index: number;
+}) {
+  const isLast = index === day.games.length - 1;
+  const isEnded = game.status === '종료';
+  const textDisabled = isEnded ? 'text-[#acb4bb]' : 'text-(--text-primary)';
+  const resultText = getGameResultTexts(game.score, isEnded);
+
+  return (
+    <div
+      className={cn(
+        'md:hidden border border-t-0 border-(--border-normal) px-[17px] pt-[16px] pb-[16px] flex flex-col gap-[12px]',
+        isLast && 'rounded-bl-[16px] rounded-br-[16px]',
+        isEnded ? 'bg-[#f7f8f9]' : 'bg-background',
+      )}
+    >
+      <div className="flex items-center gap-[12px]">
+        <span className={cn('text-[14px] font-semibold leading-[1.5] whitespace-nowrap', textDisabled)}>{game.time}</span>
+        <span className="text-[14px] leading-[1.5] whitespace-nowrap text-[#acb4bb]">|</span>
+        <span className={cn('text-[14px] font-semibold leading-[1.5] whitespace-nowrap', textDisabled)}>{game.venue}</span>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <MobileTeam name={game.away} isEnded={isEnded} result={resultText.away} isHome={false} />
+
+        <div className="flex flex-col items-center justify-center shrink-0">
+          <MobileScoreDisplay game={game} />
+          <span className={cn('text-[12px] font-medium text-center leading-[1.5]', statusColor[game.status])}>{game.status}</span>
+        </div>
+
+        <MobileTeam name={game.home} isEnded={isEnded} result={resultText.home} isHome={true} />
+      </div>
+
+      <ActionButtons game={game} isEnded={isEnded} />
+    </div>
+  );
+}
+
+function DesktopGameRow({
+  day,
+  game,
+  index,
+}: {
+  day: DaySchedule;
+  game: GameRow;
+  index: number;
+}) {
+  const isLast = index === day.games.length - 1;
+  const isEnded = game.status === '종료';
+  const textDisabled = isEnded ? 'text-[#acb4bb]' : 'text-(--text-primary)';
+  const resultText = getGameResultTexts(game.score, isEnded);
+
+  return (
+    <div
+      className={cn(
+        'hidden md:flex border border-t-0 border-(--border-normal) px-[20px] py-[6px] items-center justify-between',
+        isLast && 'rounded-bl-[20px] rounded-br-[20px]',
+        isEnded ? 'bg-[#f7f8f9]' : 'bg-background',
+      )}
+    >
+      <div className="flex gap-[30px] items-center shrink-0">
+        <div className="flex items-center justify-center w-[60px]">
+          <span className={cn('text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap', textDisabled)}>{game.time}</span>
+        </div>
+        <div className="flex items-center justify-center w-[40px]">
+          <span className={cn('text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap', textDisabled)}>{game.venue}</span>
+        </div>
+      </div>
+
+      <div className="flex gap-[50px] items-center shrink-0">
+        <div className="flex items-center justify-center w-[150px]">
+          <div className="flex h-[75px] items-center justify-end w-[70px] shrink-0">
+            <div className="w-[30px] h-[75px] shrink-0" />
+            <TeamName name={game.away} isEnded={isEnded} result={resultText.away} textDisabled={textDisabled} />
+          </div>
+          <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
+            <img src={teamLogos[game.away]} alt={game.away} className="w-full h-full object-contain" />
+          </div>
+        </div>
+
+        <div className="flex flex-col items-center justify-center w-[40px] shrink-0">
+          <ScoreDisplay game={game} />
+          <span className={cn('text-[12px] font-medium text-center leading-[1.5]', statusColor[game.status])}>{game.status}</span>
+        </div>
+
+        <div className="flex items-center justify-center w-[150px]">
+          <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
+            <img src={teamLogos[game.home]} alt={game.home} className="w-full h-full object-contain" />
+          </div>
+          <div className="flex h-[75px] items-center justify-between w-[70px] shrink-0">
+            <TeamName name={game.home} isEnded={isEnded} result={resultText.home} textDisabled={textDisabled} />
+            <div className="flex h-[75px] items-center justify-end w-[30px] shrink-0">
+              <div className="bg-[#acb4bb] flex flex-col items-center justify-center px-[4px] rounded-[2px] w-[22px]">
+                <span className="text-white text-[16px] font-medium text-center leading-[1.5]">홈</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <ActionButtons game={game} isEnded={isEnded} />
     </div>
   );
 }
@@ -105,70 +296,17 @@ function ScheduleList({ activeTab, filteredData }: ScheduleListProps) {
 
         return (
           <div key={day.date}>
-            <div className="bg-[#f1f2f4] border border-(--border-normal) px-[30px] py-[10px] rounded-tl-[20px] rounded-tr-[20px] flex items-center gap-2">
-              <span className="text-[length:var(--typo---heading\/h4,20px)] font-semibold text-(--text-primary) leading-[1.5]">{day.date}</span>
+            <div className="bg-[#f1f2f4] border border-(--border-normal) h-[46px] md:h-auto px-[25px] md:px-[30px] py-[10px] rounded-tl-[16px] rounded-tr-[16px] md:rounded-tl-[20px] md:rounded-tr-[20px] flex items-center justify-center md:justify-start gap-2">
+              <span className="text-[16px] md:text-[length:var(--typo---heading\/h4,20px)] font-semibold text-(--text-primary) leading-[1.5]">{day.date}</span>
               {isToday && <Badge variant="chipDestructive">오늘</Badge>}
             </div>
 
-            {day.games.map((game, index) => {
-              const isLast = index === day.games.length - 1;
-              const isEnded = game.status === '종료';
-              const textDisabled = isEnded ? 'text-[#acb4bb]' : 'text-(--text-primary)';
-              const resultText = getGameResultTexts(game.score, isEnded);
-
-              return (
-                <div
-                  key={`${day.date}-${game.time}-${game.away}-${game.home}-${index}`}
-                  className={cn(
-                    'border border-t-0 border-(--border-normal) px-[20px] py-[6px] flex items-center justify-between',
-                    isLast && 'rounded-bl-[20px] rounded-br-[20px]',
-                    isEnded ? 'bg-[#f7f8f9]' : 'bg-background',
-                  )}
-                >
-                  <div className="flex gap-[30px] items-center shrink-0">
-                    <div className="flex items-center justify-center w-[60px]">
-                      <span className={cn('text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap', textDisabled)}>{game.time}</span>
-                    </div>
-                    <div className="flex items-center justify-center w-[40px]">
-                      <span className={cn('text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap', textDisabled)}>{game.venue}</span>
-                    </div>
-                  </div>
-
-                  <div className="flex gap-[50px] items-center shrink-0">
-                    <div className="flex items-center justify-center w-[150px]">
-                      <div className="flex h-[75px] items-center justify-end w-[70px] shrink-0">
-                        <div className="w-[30px] h-[75px] shrink-0" />
-                        <TeamName name={game.away} isEnded={isEnded} result={resultText.away} textDisabled={textDisabled} />
-                      </div>
-                      <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
-                        <img src={teamLogos[game.away]} alt={game.away} className="w-full h-full object-contain" />
-                      </div>
-                    </div>
-
-                    <div className="flex flex-col items-center justify-center w-[40px] shrink-0">
-                      <ScoreDisplay game={game} />
-                      <span className={cn('text-[12px] font-medium text-center leading-[1.5]', statusColor[game.status])}>{game.status}</span>
-                    </div>
-
-                    <div className="flex items-center justify-center w-[150px]">
-                      <div className="flex flex-col items-center justify-center overflow-hidden px-[15px] py-[10px] size-[75px] shrink-0">
-                        <img src={teamLogos[game.home]} alt={game.home} className="w-full h-full object-contain" />
-                      </div>
-                      <div className="flex h-[75px] items-center justify-between w-[70px] shrink-0">
-                        <TeamName name={game.home} isEnded={isEnded} result={resultText.home} textDisabled={textDisabled} />
-                        <div className="flex h-[75px] items-center justify-end w-[30px] shrink-0">
-                          <div className="bg-[#acb4bb] flex flex-col items-center justify-center px-[4px] rounded-[2px] w-[22px]">
-                            <span className="text-white text-[16px] font-medium text-center leading-[1.5]">홈</span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <ActionButtons game={game} isEnded={isEnded} />
-                </div>
-              );
-            })}
+            {day.games.map((game, index) => (
+              <div key={`${day.date}-${game.time}-${game.away}-${game.home}-${index}`}>
+                <MobileGameRow day={day} game={game} index={index} />
+                <DesktopGameRow day={day} game={game} index={index} />
+              </div>
+            ))}
           </div>
         );
       })}

--- a/src/pages/home/ui/game-schedule/TeamLogoNav.tsx
+++ b/src/pages/home/ui/game-schedule/TeamLogoNav.tsx
@@ -9,7 +9,7 @@ type TeamLogoNavProps = {
 
 function TeamLogoNav({ onNavigateTeam }: TeamLogoNavProps) {
   return (
-    <div className="flex items-center justify-between">
+    <div className="grid grid-cols-5 gap-y-[10px] w-full lg:grid-cols-10 lg:gap-y-0">
       {teamOrder.map((team) => {
         const teamId = TEAM_IDS[team];
         const isEnabled = teams.find((candidate) => candidate.id === teamId)?.isEnabled ?? false;
@@ -20,7 +20,7 @@ function TeamLogoNav({ onNavigateTeam }: TeamLogoNavProps) {
             onClick={() => isEnabled && onNavigateTeam(teamId)}
             disabled={!isEnabled}
             className={cn(
-              'flex items-center justify-center size-[80px] p-[10px] rounded-xl transition-colors overflow-hidden',
+              'aspect-square min-h-[60px] max-h-[100px] min-w-[60px] w-full p-[5px] lg:p-[10px] flex items-center justify-center overflow-hidden transition-colors rounded-none lg:rounded-xl',
               isEnabled ? 'hover:bg-fill-hoveraccent cursor-pointer' : 'opacity-30 cursor-not-allowed',
             )}
           >

--- a/src/shared/widgets/layout/home/HomeLayout.tsx
+++ b/src/shared/widgets/layout/home/HomeLayout.tsx
@@ -1,17 +1,15 @@
 import Header from '@/shared/widgets/layout/auth/Header';
 import Footer from './Footer';
-import BottomNav from './BottomNav';
 import { Outlet } from 'react-router-dom';
 
 const HomeLayout = () => {
    return (
       <div className="min-h-screen flex flex-col bg-slate-950">
          <Header />
-         <main className="flex-1 pb-16 lg:pb-0">
+         <main className="flex-1">
             <Outlet />
          </main>
          <Footer />
-         <BottomNav />
       </div>
    );
 };


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #58

<br/>

## 🔎 개요
메인화면에서 누락된 모바일 UI 적용

<br/>

## 📋 작업 내용
- 바텀 네비게이션 삭제
- 구단 로고 리스트 모바일 2행 형식으로 변경
- 경기일정 리스트 아이템 모바일 버전 UI 구현

<br/>
