### PR TITLE
[feat] 로그인 실패 팝업 UI 구현

### DIFF
--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -10,7 +10,6 @@ export type SignupGender = "MALE" | "FEMALE";
 export type SocialSignupParams = {
   socialVerifyToken: string;
   name: string;
-  email: string;
   gender: SignupGender;
   mobile: string;
   birthDate: string;

--- a/src/pages/signup/model/signUpValidation.ts
+++ b/src/pages/signup/model/signUpValidation.ts
@@ -29,8 +29,6 @@ const isValidBirthDate = (value: string) => {
 };
 
 const nameSchema = z.string().trim().min(1, '이름을 입력해주세요').max(30, '이름은 30자 이내로 입력해주세요');
-const emailSchema = z.string().trim().email('이메일 형식이 올바르지 않습니다');
-
 const birthDateSchema = z
    .string()
    .trim()
@@ -54,7 +52,6 @@ export const sendCodeSchema = z.object({
 
 export const signUpSchema = z.object({
    name: nameSchema,
-   email: emailSchema,
    nationality: z.string().min(1, '국적을 선택해주세요'),
    birthDate: birthDateSchema,
    gender: z.string().min(1, '성별을 선택해주세요'),

--- a/src/pages/signup/ui/LoginRetryDialog.tsx
+++ b/src/pages/signup/ui/LoginRetryDialog.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@/shared/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+
+type LoginRetryDialogProps = {
+   open: boolean;
+   onOpenChange: (open: boolean) => void;
+   onConfirm: () => void;
+};
+
+const LoginRetryDialog = ({ open, onOpenChange, onConfirm }: LoginRetryDialogProps) => {
+   return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+         <DialogContent
+            className="w-[335px] max-w-[calc(100%-40px)] gap-0 rounded-2xl border-0 p-0 shadow-xl"
+            showCloseButton={false}
+            closeOnlyWithButton
+         >
+            <DialogHeader className="px-5 py-5 pb-0 text-left">
+               <DialogTitle align="left" className="text-[18px] leading-[1.55]">
+                  로그인이 잠시 제한되었어요
+               </DialogTitle>
+               <DialogDescription align="left" className="text-body-2-regular leading-6 text-text-secondary">
+                  5회 이상 로그인에 실패했어요. 잠시 후 다시 시도해 주세요. (5/5)
+               </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="px-5 pt-5 pb-5">
+               <Button type="button" variant="primary" className="w-full rounded-lg" onClick={onConfirm}>
+                  확인
+               </Button>
+            </DialogFooter>
+         </DialogContent>
+      </Dialog>
+   );
+};
+
+export default LoginRetryDialog;

--- a/src/pages/signup/ui/SignUpPage.tsx
+++ b/src/pages/signup/ui/SignUpPage.tsx
@@ -13,6 +13,7 @@ import {
    telecomOptions,
    type SignUpFormValues,
 } from '@/pages/signup/model/signUpValidation';
+import LoginRetryDialog from '@/pages/signup/ui/LoginRetryDialog';
 import SignUpTermsDialog from '@/pages/signup/ui/SignUpTermsDialog';
 import VerificationCodeField from '@/pages/signup/ui/VerificationCodeField';
 import { ApiError } from '@/shared/api/client';
@@ -37,6 +38,7 @@ const SignUpPage = () => {
    const [countdown, setCountdown] = useState(0);
    const [isCodeSent, setIsCodeSent] = useState(false);
    const [showAlert, setShowAlert] = useState(false);
+   const [showLoginRetryDialog, setShowLoginRetryDialog] = useState(false);
    const [submitError, setSubmitError] = useState<string | null>(null);
 
    const [detailTargetCode, setDetailTargetCode] = useState<TermSignUpCode | null>(null);
@@ -55,7 +57,6 @@ const SignUpPage = () => {
       resolver: zodResolver(signUpSchema),
       defaultValues: {
          name: '',
-         email: '',
          nationality: '',
          birthDate: '',
          gender: '',
@@ -170,8 +171,7 @@ const SignUpPage = () => {
       setSubmitError(null);
 
       if (!socialVerifyToken) {
-         setSubmitError('인증 토큰이 없습니다. 다시 로그인해 주세요.');
-         navigate('/auth/login', { replace: true });
+         setShowLoginRetryDialog(true);
          return;
       }
 
@@ -179,7 +179,6 @@ const SignUpPage = () => {
          const response = await socialSignupMutation.mutateAsync({
             socialVerifyToken,
             name: data.name,
-            email: data.email,
             gender: mapGender(data.gender),
             mobile: data.phone,
             birthDate: formatBirthDate(data.birthDate),
@@ -244,19 +243,6 @@ const SignUpPage = () => {
                   }}
                   error={Boolean(errors.name)}
                   helpText={errors.name?.message}
-               />
-
-               <Input
-                  label="이메일"
-                  required
-                  placeholder="example@ballx.com"
-                  value={values.email}
-                  onChange={e => {
-                     setValue('email', e.target.value, { shouldDirty: true });
-                     clearErrors('email');
-                  }}
-                  error={Boolean(errors.email)}
-                  helpText={errors.email?.message}
                />
 
                <div className="text-(--label-2-medium) text-[14px] flex flex-col gap-1">
@@ -444,6 +430,15 @@ const SignUpPage = () => {
                <Alert variant="success">인증번호가 전송되었어요</Alert>
             </div>
          )}
+
+         <LoginRetryDialog
+            open={showLoginRetryDialog}
+            onOpenChange={setShowLoginRetryDialog}
+            onConfirm={() => {
+               setShowLoginRetryDialog(false);
+               navigate('/auth/login', { replace: true });
+            }}
+         />
       </div>
    );
 };

--- a/src/shared/api/mocks/handlers/auth.ts
+++ b/src/shared/api/mocks/handlers/auth.ts
@@ -55,7 +55,6 @@ export const authHandlers = [
     const body = (await request.json()) as {
       socialVerifyToken?: string;
       name?: string;
-      email?: string;
       gender?: string;
       mobile?: string;
       birthDate?: string;
@@ -64,7 +63,6 @@ export const authHandlers = [
     if (
       !body?.socialVerifyToken ||
       !body?.name ||
-      !body?.email ||
       !body?.gender ||
       !body?.mobile ||
       !body?.birthDate


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #7

<br/>

## 🔎 개요
로그인 실패 관련 팝업 UI 구현 및 이메일 입력폼 삭제

<br/>

## 📋 작업 내용
- 로그인 실패 팝업창(5회 미만, 5회 이상) 구현
- 회원가입에서 이메일 입력폼 제거


<br/>
