### PR TITLE
[test] Auth API 연결 테스트

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -2,12 +2,23 @@ import path from 'path';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
+const apiTarget = (process.env.PUBLIC_API_BASE_URL ?? 'https://dev.go-ti.shop').trim();
+
 // Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginReact()],
   source: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  server: {
+    proxy: {
+      '/api': {
+        target: apiTarget,
+        changeOrigin: true,
+        secure: true,
+      },
     },
   },
 });

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -13,6 +13,12 @@ export type SocialSignupParams = {
   gender: SignupGender;
   mobile: string;
   birthDate: string;
+  authCode: string;
+};
+
+export type SendSignupSmsParams = {
+  socialVerifyToken: string;
+  mobile: string;
 };
 
 export const loginWithSocialVerifyToken = async (payload: {
@@ -31,6 +37,17 @@ export const signupWithSocialVerifyToken = async (
 ): Promise<AuthTokenResponse> => {
   const response = await apiClient.post<ApiEnvelope<AuthTokenResponse>>(
     "/api/v1/auth/signup",
+    payload,
+  );
+
+  return response.data.data;
+};
+
+export const sendSignupSmsCode = async (
+  payload: SendSignupSmsParams,
+): Promise<string> => {
+  const response = await apiClient.post<ApiEnvelope<string>>(
+    "/api/v1/auth/signup/sms/send",
     payload,
   );
 

--- a/src/features/auth/api/oauthApi.ts
+++ b/src/features/auth/api/oauthApi.ts
@@ -25,6 +25,18 @@ export type SubmitAuthCodeResponse = {
 
 const providerToPath = (provider: SocialProvider) => provider.toUpperCase();
 
+const requiresState = (provider: SocialProvider) => {
+  switch (provider) {
+    case "google":
+    case "naver":
+      return true;
+    case "kakao":
+      return false;
+    default:
+      return false;
+  }
+};
+
 export const getOAuthRedirectUri = (provider: SocialProvider): string => {
   switch (provider) {
     case "google":
@@ -71,11 +83,21 @@ export const submitAuthCode = async ({
   authCode,
   state,
 }: SubmitAuthCodeParams): Promise<SubmitAuthCodeResponse> => {
+  const requestBody: { authCode: string; state?: string } = { authCode };
+
+  if (requiresState(provider)) {
+    if (!state) {
+      throw new Error("OAuth state is required for this provider.");
+    }
+
+    requestBody.state = state;
+  }
+
   const response = await apiClient.post<
     ApiEnvelope<SubmitAuthCodeResponse> | SubmitAuthCodeResponse
   >(
     `/api/v1/auth/${providerToPath(provider)}/social/verify`,
-    { authCode, state: state ?? null },
+    requestBody,
   );
 
   const payload =

--- a/src/features/auth/api/oauthApi.ts
+++ b/src/features/auth/api/oauthApi.ts
@@ -14,8 +14,7 @@ export type SocialStateResponse = {
 
 export type SubmitAuthCodeParams = {
   provider: SocialProvider;
-  code: string;
-  redirectUri: string;
+  authCode: string;
   state?: string | null;
 };
 
@@ -69,15 +68,14 @@ export const issueSocialState = async (
 
 export const submitAuthCode = async ({
   provider,
-  code,
-  redirectUri,
+  authCode,
   state,
 }: SubmitAuthCodeParams): Promise<SubmitAuthCodeResponse> => {
   const response = await apiClient.post<
     ApiEnvelope<SubmitAuthCodeResponse> | SubmitAuthCodeResponse
   >(
     `/api/v1/auth/${providerToPath(provider)}/social/verify`,
-    { code, redirectUri, state: state ?? null },
+    { authCode, state: state ?? null },
   );
 
   const payload =

--- a/src/features/auth/kakao/model/createOAuthState.ts
+++ b/src/features/auth/kakao/model/createOAuthState.ts
@@ -1,7 +1,0 @@
-export const createOAuthState = () => {
-  if (typeof crypto?.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-
-  return Math.random().toString(36).slice(2);
-};

--- a/src/features/auth/kakao/ui/KakaoLoginButton.tsx
+++ b/src/features/auth/kakao/ui/KakaoLoginButton.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@/shared/ui/button";
 import { buildKakaoAuthUrl } from "../lib/buildKakaoAuthUrl";
-import { createOAuthState } from "../model/createOAuthState";
 import { useSocialOAuthLogin } from "@/features/auth/model/useSocialOAuthLogin";
 
 const KakaoLoginButton = () => {
@@ -8,7 +7,6 @@ const KakaoLoginButton = () => {
     provider: "kakao",
     requiresIssuedState: false,
     buildAuthUrl: buildKakaoAuthUrl,
-    createState: createOAuthState,
   });
 
   return (

--- a/src/features/auth/kakao/ui/KakaoLoginButton.tsx
+++ b/src/features/auth/kakao/ui/KakaoLoginButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/shared/ui/button";
 import { buildKakaoAuthUrl } from "../lib/buildKakaoAuthUrl";
+import { createOAuthState } from "../model/createOAuthState";
 import { useSocialOAuthLogin } from "@/features/auth/model/useSocialOAuthLogin";
 
 const KakaoLoginButton = () => {
@@ -7,6 +8,7 @@ const KakaoLoginButton = () => {
     provider: "kakao",
     requiresIssuedState: false,
     buildAuthUrl: buildKakaoAuthUrl,
+    createState: createOAuthState,
   });
 
   return (

--- a/src/features/auth/model/useSocialOAuthLogin.ts
+++ b/src/features/auth/model/useSocialOAuthLogin.ts
@@ -7,15 +7,22 @@ type UseSocialOAuthLoginParams = {
   provider: SocialProvider;
   requiresIssuedState: boolean;
   buildAuthUrl: (state?: string) => string;
+  createState?: () => string;
 };
 
 export const useSocialOAuthLogin = ({
   provider,
   requiresIssuedState,
   buildAuthUrl,
+  createState,
 }: UseSocialOAuthLoginParams) => {
   return useCallback(async () => {
     try {
+      if (createState) {
+        openOAuthPopup(buildAuthUrl(createState()));
+        return;
+      }
+
       if (requiresIssuedState) {
         const { state } = await issueSocialState(provider);
         openOAuthPopup(buildAuthUrl(state));
@@ -26,5 +33,5 @@ export const useSocialOAuthLogin = ({
     } catch (error) {
       console.error(error);
     }
-  }, [buildAuthUrl, provider, requiresIssuedState]);
+  }, [buildAuthUrl, createState, provider, requiresIssuedState]);
 };

--- a/src/features/auth/model/useSubmitAuthCode.ts
+++ b/src/features/auth/model/useSubmitAuthCode.ts
@@ -5,6 +5,7 @@ import {
 } from "../api/oauthApi";
 import {
   loginWithSocialVerifyToken,
+  sendSignupSmsCode,
   signupWithSocialVerifyToken,
 } from "../api/authApi";
 
@@ -29,5 +30,11 @@ export const useSocialLogin = () => {
 export const useSocialSignup = () => {
   return useMutation({
     mutationFn: signupWithSocialVerifyToken,
+  });
+};
+
+export const useSendSignupSmsCode = () => {
+  return useMutation({
+    mutationFn: sendSignupSmsCode,
   });
 };

--- a/src/pages/auth/callback/model/useOAuthCallbackFlow.ts
+++ b/src/pages/auth/callback/model/useOAuthCallbackFlow.ts
@@ -8,7 +8,6 @@ import type {
   SocialProvider,
   SubmitAuthCodeParams,
 } from "@/features/auth/api/oauthApi";
-import { getOAuthRedirectUri } from "@/features/auth/api/oauthApi";
 import { useAuthStore } from "@/entities/auth/model/authStore";
 import { ApiError } from "@/shared/api/client";
 import {
@@ -108,10 +107,35 @@ export const useOAuthCallbackFlow = ({ provider }: UseOAuthCallbackFlowParams) =
 
         const verifyPayload: SubmitAuthCodeParams = {
           provider: normalizedProvider,
-          code,
-          redirectUri: getOAuthRedirectUri(normalizedProvider),
+          authCode: code,
           state: params.get("state"),
         };
+
+        const testOAuthPayload = {
+          provider: normalizedProvider,
+          authCode: code,
+          state: params.get("state"),
+          verifyPayload,
+        };
+
+        // 테스트용 로그: OAuth 콜백에서 받은 실제 code/state와 verify 요청 payload를 콘솔과 sessionStorage에 남긴다.
+        console.log("[TEST] OAuth callback params", testOAuthPayload);
+        sessionStorage.setItem(
+          "test-oauth-callback-payload",
+          JSON.stringify(testOAuthPayload),
+        );
+
+        if (window.opener && !window.opener.closed) {
+          window.opener.console.log(
+            "[TEST] OAuth callback params",
+            testOAuthPayload,
+          );
+          window.opener.sessionStorage.setItem(
+            "test-oauth-callback-payload",
+            JSON.stringify(testOAuthPayload),
+          );
+        }
+
         const response = await submitAuthCodeMutation.mutateAsync(verifyPayload);
 
         setRecentLoginProvider(normalizedProvider);

--- a/src/pages/auth/callback/model/useOAuthCallbackFlow.ts
+++ b/src/pages/auth/callback/model/useOAuthCallbackFlow.ts
@@ -26,6 +26,18 @@ const isSocialProvider = (value?: string): value is SocialProvider => {
   }
 };
 
+const requiresState = (provider: SocialProvider) => {
+  switch (provider) {
+    case "google":
+    case "naver":
+      return true;
+    case "kakao":
+      return false;
+    default:
+      return false;
+  }
+};
+
 const formatErrorMessage = (error: unknown): string => {
   if (error instanceof ApiError) {
     const details =
@@ -96,6 +108,7 @@ export const useOAuthCallbackFlow = ({ provider }: UseOAuthCallbackFlowParams) =
       try {
         const params = new URLSearchParams(window.location.search);
         const code = params.get("code");
+        const state = params.get("state");
 
         if (!code) {
           throw new Error("Missing authorization code.");
@@ -105,36 +118,15 @@ export const useOAuthCallbackFlow = ({ provider }: UseOAuthCallbackFlowParams) =
           throw new Error(`Unsupported provider: ${normalizedProvider ?? "none"}`);
         }
 
+        if (requiresState(normalizedProvider) && !state) {
+          throw new Error("Missing OAuth state.");
+        }
+
         const verifyPayload: SubmitAuthCodeParams = {
           provider: normalizedProvider,
           authCode: code,
-          state: params.get("state"),
+          state,
         };
-
-        const testOAuthPayload = {
-          provider: normalizedProvider,
-          authCode: code,
-          state: params.get("state"),
-          verifyPayload,
-        };
-
-        // 테스트용 로그: OAuth 콜백에서 받은 실제 code/state와 verify 요청 payload를 콘솔과 sessionStorage에 남긴다.
-        console.log("[TEST] OAuth callback params", testOAuthPayload);
-        sessionStorage.setItem(
-          "test-oauth-callback-payload",
-          JSON.stringify(testOAuthPayload),
-        );
-
-        if (window.opener && !window.opener.closed) {
-          window.opener.console.log(
-            "[TEST] OAuth callback params",
-            testOAuthPayload,
-          );
-          window.opener.sessionStorage.setItem(
-            "test-oauth-callback-payload",
-            JSON.stringify(testOAuthPayload),
-          );
-        }
 
         const response = await submitAuthCodeMutation.mutateAsync(verifyPayload);
 

--- a/src/pages/auth/login/ui/LoginPage.tsx
+++ b/src/pages/auth/login/ui/LoginPage.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { KakaoLoginButton } from "@/features/auth/kakao";
 import { NaverLoginButton } from "@/features/auth/naver";
 import { GoogleLoginButton } from "@/features/auth/google";
@@ -20,9 +22,19 @@ const socialLoginButtons: SocialLoginButtonItem[] = [
 ];
 
 const LoginPage = () => {
+  const navigate = useNavigate();
+  const accessToken = useAuthStore((state) => state.accessToken);
   const recentLoginProvider = useAuthStore(
     (state) => state.recentLoginProvider,
   );
+
+  useEffect(() => {
+    if (!accessToken) {
+      return;
+    }
+
+    navigate("/", { replace: true });
+  }, [accessToken, navigate]);
 
   return (
     <div className="flex w-full h-screen items-center justify-center min-h-screen bg-white text-text-primary">

--- a/src/pages/auth/verification-flow/ui/VerificationFlowPage.tsx
+++ b/src/pages/auth/verification-flow/ui/VerificationFlowPage.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useAuthStore } from '@/entities/auth/model/authStore';
 import { Button } from '@/shared/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 import { TermsCheckbox, TermsSubItem } from '@/shared/ui/terms-of-service';
@@ -8,6 +10,8 @@ import type { TermAgreementCode } from '@/entities/terms/model/types';
 
 const VerificationFlowPage = () => {
    const navigate = useNavigate();
+   const accessToken = useAuthStore(state => state.accessToken);
+   const socialVerifyToken = useAuthStore(state => state.socialVerifyToken);
    const termsAgreementListQuery = useTermsAgreementListQuery('verification');
    const agreements = termsAgreementListQuery.data ?? [];
    const [checkedByCode, setCheckedByCode] = useState<Partial<Record<TermAgreementCode, boolean>>>({});
@@ -64,6 +68,17 @@ const VerificationFlowPage = () => {
       }
       closeDetailDialog();
    };
+
+   useEffect(() => {
+      if (accessToken) {
+         navigate('/', { replace: true });
+         return;
+      }
+
+      if (!socialVerifyToken) {
+         navigate('/auth/login', { replace: true });
+      }
+   }, [accessToken, navigate, socialVerifyToken]);
 
    return (
       <div className="bg-white text-(--color-foreground) flex flex-col justify-center items-center min-h-screen">

--- a/src/pages/signup/ui/SignUpPage.tsx
+++ b/src/pages/signup/ui/SignUpPage.tsx
@@ -30,6 +30,7 @@ const SignUpPage = () => {
    const navigate = useNavigate();
    const socialSignupMutation = useSocialSignup();
    const sendSignupSmsCodeMutation = useSendSignupSmsCode();
+   const accessToken = useAuthStore(state => state.accessToken);
    const socialVerifyToken = useAuthStore(state => state.socialVerifyToken);
    const setAuthTokens = useAuthStore(state => state.setAuthTokens);
    const termsSignuptListQuery = useTermsAgreementListQuery('signup');
@@ -169,6 +170,17 @@ const SignUpPage = () => {
          requiredTermsAgreed: areRequiredTermsChecked,
       }).success;
    }, [areRequiredTermsChecked, values.birthDate, values.name, values.nationality, values.phone, values.telecom]);
+
+   useEffect(() => {
+      if (accessToken) {
+         navigate('/', { replace: true });
+         return;
+      }
+
+      if (!socialVerifyToken) {
+         navigate('/auth/login', { replace: true });
+      }
+   }, [accessToken, navigate, socialVerifyToken]);
 
    useEffect(() => {
       if (!showAlert) return;

--- a/src/pages/signup/ui/SignUpPage.tsx
+++ b/src/pages/signup/ui/SignUpPage.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useSocialSignup } from '@/features/auth/model/useSubmitAuthCode';
+import { useSendSignupSmsCode, useSocialSignup } from '@/features/auth/model/useSubmitAuthCode';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import type { TermSignUpCode } from '@/entities/terms/model/types';
 import { useTermDetailQuery, useTermsAgreementListQuery } from '@/entities/terms/model/useTermsQueries';
@@ -29,6 +29,7 @@ import { useNavigate } from 'react-router-dom';
 const SignUpPage = () => {
    const navigate = useNavigate();
    const socialSignupMutation = useSocialSignup();
+   const sendSignupSmsCodeMutation = useSendSignupSmsCode();
    const socialVerifyToken = useAuthStore(state => state.socialVerifyToken);
    const setAuthTokens = useAuthStore(state => state.setAuthTokens);
    const termsSignuptListQuery = useTermsAgreementListQuery('signup');
@@ -93,7 +94,7 @@ const SignUpPage = () => {
       clearErrors('requiredTermsAgreed');
    };
 
-   const handleSendCode = () => {
+   const handleSendCode = async () => {
       const result = sendCodeSchema.safeParse({
          name: getValues('name').trim(),
          nationality: getValues('nationality') ?? '',
@@ -115,10 +116,33 @@ const SignUpPage = () => {
          return;
       }
 
+      if (!socialVerifyToken) {
+         setShowLoginRetryDialog(true);
+         return;
+      }
+
       clearErrors(['phone', 'requiredTermsAgreed']);
-      setIsCodeSent(true);
-      setShowAlert(true);
-      setCountdown(180);
+
+      try {
+         await sendSignupSmsCodeMutation.mutateAsync({
+            socialVerifyToken,
+            mobile: getValues('phone').trim(),
+         });
+
+         setIsCodeSent(true);
+         setShowAlert(true);
+         setCountdown(180);
+      } catch (error) {
+         if (error instanceof ApiError) {
+            setSubmitError(error.message);
+            return;
+         }
+         if (error instanceof Error) {
+            setSubmitError(error.message);
+            return;
+         }
+         setSubmitError('인증번호 발송 중 오류가 발생했습니다. 다시 시도해 주세요.');
+      }
    };
 
    useEffect(() => {
@@ -182,6 +206,7 @@ const SignUpPage = () => {
             gender: mapGender(data.gender),
             mobile: data.phone,
             birthDate: formatBirthDate(data.birthDate),
+            authCode: data.verificationCode,
          });
 
          setAuthTokens({
@@ -408,8 +433,8 @@ const SignUpPage = () => {
                      type="button"
                      variant="primary"
                      className="w-full"
-                     disabled={!canSendCode}
-                     onClick={handleSendCode}
+                     disabled={!canSendCode || sendSignupSmsCodeMutation.isPending}
+                     onClick={() => void handleSendCode()}
                   >
                      인증 번호 전송
                   </Button>

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -14,10 +14,12 @@ export class ApiError extends Error {
 }
 
 const configuredApiBaseUrl = (import.meta.env.PUBLIC_API_BASE_URL ?? "").trim();
+const shouldUseRelativeApiBase = isMswEnabled || import.meta.env.DEV;
 
 const apiClient = axios.create({
-  // MSW가 켜진 환경에서는 상대 경로(/api) 요청을 사용해 worker가 가로채도록 한다.
-  baseURL: isMswEnabled ? "" : configuredApiBaseUrl,
+  // 개발 환경에서는 dev server proxy를 통해 CORS 없이 백엔드에 붙는다.
+  // MSW 사용 시에도 상대 경로(/api) 요청을 유지해 worker가 가로챌 수 있게 한다.
+  baseURL: shouldUseRelativeApiBase ? "" : configuredApiBaseUrl,
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/shared/api/mocks/handlers/auth.ts
+++ b/src/shared/api/mocks/handlers/auth.ts
@@ -13,11 +13,11 @@ export const authHandlers = [
   }),
   http.post("/api/v1/auth/:provider/social/verify", async ({ request }) => {
     const body = (await request.json()) as {
-      code?: string;
-      redirectUri?: string;
+      authCode?: string;
+      state?: string;
     };
 
-    if (!body?.code || !body?.redirectUri) {
+    if (!body?.authCode) {
       return HttpResponse.json(
         { message: "Missing social verify fields." },
         { status: 400 },
@@ -29,7 +29,7 @@ export const authHandlers = [
       message: "ok",
       data: {
         isRegistered: false,
-        socialVerifyToken: `svt-${body.code}`,
+        socialVerifyToken: `svt-${body.authCode}`,
       },
     });
   }),
@@ -58,6 +58,7 @@ export const authHandlers = [
       gender?: string;
       mobile?: string;
       birthDate?: string;
+      authCode?: string;
     };
 
     if (
@@ -65,7 +66,8 @@ export const authHandlers = [
       !body?.name ||
       !body?.gender ||
       !body?.mobile ||
-      !body?.birthDate
+      !body?.birthDate ||
+      !body?.authCode
     ) {
       return HttpResponse.json(
         { message: "Missing signup fields." },
@@ -79,6 +81,25 @@ export const authHandlers = [
       data: {
         accessToken: "access-token-from-signup",
       },
+    });
+  }),
+  http.post("/api/v1/auth/signup/sms/send", async ({ request }) => {
+    const body = (await request.json()) as {
+      socialVerifyToken?: string;
+      mobile?: string;
+    };
+
+    if (!body?.socialVerifyToken || !body?.mobile) {
+      return HttpResponse.json(
+        { message: "Missing sms send fields." },
+        { status: 400 },
+      );
+    }
+
+    return HttpResponse.json({
+      code: "SUCCESS",
+      message: "ok",
+      data: "SMS sent",
     });
   }),
 ];

--- a/src/shared/api/mocks/handlers/auth.ts
+++ b/src/shared/api/mocks/handlers/auth.ts
@@ -11,13 +11,16 @@ export const authHandlers = [
       data: { state },
     });
   }),
-  http.post("/api/v1/auth/:provider/social/verify", async ({ request }) => {
+  http.post("/api/v1/auth/:provider/social/verify", async ({ params, request }) => {
+    const provider = params.provider;
     const body = (await request.json()) as {
       authCode?: string;
       state?: string;
     };
 
-    if (!body?.authCode) {
+    const requiresState = provider === "NAVER" || provider === "GOOGLE";
+
+    if (!body?.authCode || (requiresState && !body?.state)) {
       return HttpResponse.json(
         { message: "Missing social verify fields." },
         { status: 400 },

--- a/src/shared/config/runtime.ts
+++ b/src/shared/config/runtime.ts
@@ -1,2 +1,4 @@
-// 발표/데모 환경을 위해 배포 포함 모든 환경에서 MSW를 항상 사용한다.
-export const isMswEnabled = true;
+const mswFlag = (import.meta.env.PUBLIC_ENABLE_MSW ?? "").trim().toLowerCase();
+
+// 기본값은 실제 API 호출이다. 데모/목업이 필요할 때만 명시적으로 켠다.
+export const isMswEnabled = mswFlag === "true";


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #7

<br/>

## 🔎 개요
- 소셜 로그인 및 회원가입 인증 플로우를 백엔드 Auth API 스펙에 맞게 정리
- provider별 state 처리 규칙을 반영하고, 인증 단계 페이지의 진입 조건을 보완

<br/>

## 📋 작업 내용
- NAVER, GOOGLE은 state를 필수로 검증하고, KAKAO는 state 없이 인증 요청하도록 수정
- OAuth 콜백 처리에서 provider별 state 유효성 검사 추가
- 로그인 완료 상태에서 /auth/login 재진입 시 홈으로 리다이렉트되도록 처리
- socialVerifyToken 없이 /auth/terms, /auth/signup에 접근하면 로그인 페이지로 이동하도록 가드 추가
- OAuth 콜백 내 테스트용 콘솔 및 sessionStorage 디버그 코드 제거
- MSW mock handler도 동일한 Auth 스펙 기준으로 정리

<br/>
