### PR TITLE
[feat] 예매 및 결제 페이지 헤더 통일화

### DIFF
--- a/src/app/providers/router/ui/AppRouter.tsx
+++ b/src/app/providers/router/ui/AppRouter.tsx
@@ -26,12 +26,14 @@ import PaymentProcessingPage from '@/pages/tickets/ui/payment/PaymentProcessingP
 import PaymentCompletePage from '@/pages/tickets/ui/payment/PaymentCompletePage';
 import BooksPage from '@/pages/books';
 import SeatsPage from '@/pages/books/ui/SeatsPage';
+import BookingFlowStateGuard from './BookingFlowStateGuard';
 import OAuthMessageListener from './OAuthMessageListener';
 
 const AppRouter = () => {
    return (
       <BrowserRouter>
          <OAuthMessageListener />
+         <BookingFlowStateGuard />
          <Routes>
             <Route path="/auth" element={<AuthLayout />}>
                <Route path="login" element={<LoginPage />} />

--- a/src/app/providers/router/ui/BookingFlowStateGuard.tsx
+++ b/src/app/providers/router/ui/BookingFlowStateGuard.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useSeatSelectionStore } from '@/pages/books/model/useSeatSelectionStore';
+import { useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
+
+const isBookingFlowPath = (pathname: string) => pathname.startsWith('/books') || pathname.startsWith('/tickets');
+
+const BookingFlowStateGuard = () => {
+   const { pathname } = useLocation();
+   const previousPathnameRef = useRef<string | null>(null);
+
+   useEffect(() => {
+      const previousPathname = previousPathnameRef.current;
+      const isCurrentBookingFlow = isBookingFlowPath(pathname);
+      const selectedSeatCount = Object.values(useSeatSelectionStore.getState().zones).reduce(
+         (count, zone) => count + zone.selectedSeatIds.length,
+         0,
+      );
+
+      console.info('[BookingFlowStateGuard]', {
+         previousPathname,
+         pathname,
+         isCurrentBookingFlow,
+         selectedSeatCount,
+      });
+
+      if (!isCurrentBookingFlow) {
+         console.info('[BookingFlowStateGuard] booking flow exited, clearing seat selections and timer');
+         useSeatSelectionStore.getState().clearAllSelections();
+         useBookingFlowTimerStore.getState().clearTimer();
+      } else if (previousPathname && isBookingFlowPath(previousPathname) && !isCurrentBookingFlow) {
+         console.info('[BookingFlowStateGuard] moved out of booking flow, clearing seat selections and timer');
+         useSeatSelectionStore.getState().clearAllSelections();
+         useBookingFlowTimerStore.getState().clearTimer();
+      }
+
+      previousPathnameRef.current = pathname;
+   }, [pathname]);
+
+   return null;
+};
+
+export default BookingFlowStateGuard;

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -484,6 +484,7 @@ function SeatsPage() {
                   <button
                      type="button"
                      disabled={selectedSeats.length === 0}
+                     onClick={() => navigate('/tickets/payment')}
                      className={[
                         'h-[56px] w-full rounded-[8px] text-label-1-bold transition-colors',
                         selectedSeats.length === 0

--- a/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
@@ -71,7 +71,7 @@ export default function PaymentCompletePage() {
 
    return (
       <div className="min-h-screen flex flex-col bg-background">
-         <BooksHeader />
+         <BooksHeader currentStepIndex={3} showBackButton={false} showTimer={false} confirmBeforeExit={false} />
 
          <main className="flex-1 bg-white flex justify-center px-4">
             <div className="w-full max-w-[1200px] py-12 flex flex-col gap-[26px] items-center">

--- a/src/pages/tickets/ui/payment/PaymentHeader.tsx
+++ b/src/pages/tickets/ui/payment/PaymentHeader.tsx
@@ -1,32 +1,8 @@
 // src/pages/tickets/ui/payment/PaymentHeader.tsx
 
-import { useEffect, useRef, useState } from 'react';
-import { AlertCircle, ChevronLeft, ChevronRight } from 'lucide-react';
-import { Link, useNavigate } from 'react-router-dom';
+import BooksHeader from '@/shared/widgets/layout/books/BooksHeader';
 
-function useBookingTimer(initialSeconds = 599) {
-   const [remaining, setRemaining] = useState(initialSeconds);
-   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-   useEffect(() => {
-      timerRef.current = setInterval(() => {
-         setRemaining(prev => {
-            if (prev <= 1) {
-               clearInterval(timerRef.current!);
-               return 0;
-            }
-            return prev - 1;
-         });
-      }, 1000);
-      return () => {
-         if (timerRef.current) clearInterval(timerRef.current);
-      };
-   }, []);
-
-   const mm = String(Math.floor(remaining / 60)).padStart(2, '0');
-   const ss = String(remaining % 60).padStart(2, '0');
-   return `${mm}:${ss}`;
-}
+const PAYMENT_STEPS = ['구역 선택', '좌석 선택', '결제'];
 
 interface PaymentHeaderProps {
    matchTitle: string;
@@ -35,61 +11,15 @@ interface PaymentHeaderProps {
 }
 
 export function PaymentHeader({ matchTitle, venue, dateTime }: PaymentHeaderProps) {
-   const navigate = useNavigate();
-   const timeStr = useBookingTimer();
-
    return (
-      <header className="bg-background flex flex-col w-full">
-         {/* 1행: 로고 / 예매 시간 / 유저 아이콘 */}
-         <div className="flex items-center justify-between px-8 py-4 border-b border-border-light">
-            <Link to="/" className="text-[21px] font-bold tracking-[-0.5px] text-foreground">
-               GoTi
-            </Link>
-            <div className="flex items-center gap-6">
-               <div className="flex items-center gap-2 text-[18px] leading-[1.55]">
-                  <span className="font-medium text-(--text-secondary)">예매 시간</span>
-                  <span className="font-bold text-primary">{timeStr}</span>
-                  <button type="button" className="size-6 flex items-center justify-center" aria-label="예매 시간 안내">
-                     <AlertCircle className="size-5 text-(--text-tertiary)" />
-                  </button>
-               </div>
-               <button type="button" className="size-6 flex items-center justify-center" aria-label="마이페이지">
-                  <img src="/Icon/Line/Mypage.svg" alt="마이페이지" className="size-6" />
-               </button>
-            </div>
-         </div>
-
-         {/* 2행: 뒤로가기 / 경기 정보 / 단계 표시 */}
-         <div className="flex items-center h-[72px] pl-7 pr-8 gap-6 border-b border-border-light">
-            <div className="flex flex-1 items-center gap-3 min-w-0">
-               <button
-                  type="button"
-                  onClick={() => navigate(-1)}
-                  className="p-1 flex items-center justify-center shrink-0"
-                  aria-label="뒤로가기"
-               >
-                  <ChevronLeft className="size-6 text-foreground" />
-               </button>
-               <div className="flex items-center gap-4 min-w-0 overflow-hidden">
-                  <span className="text-[22px] font-bold leading-[1.55] text-foreground whitespace-nowrap shrink-0">
-                     {matchTitle}
-                  </span>
-                  <div className="flex items-center gap-2 text-[18px] font-medium leading-[1.55] text-(--text-secondary) min-w-0">
-                     <span className="whitespace-nowrap">{venue}</span>
-                     <span>∙</span>
-                     <span className="whitespace-nowrap">{dateTime}</span>
-                  </div>
-               </div>
-            </div>
-            {/* 단계 표시 */}
-            <div className="flex items-center gap-4 shrink-0">
-               <span className="text-[14px] font-medium leading-[1.45] text-(--text-disabled)">구역 선택</span>
-               <ChevronRight className="size-4 text-(--text-disabled)" />
-               <span className="text-[14px] font-medium leading-[1.45] text-(--text-disabled)">좌석선택</span>
-               <ChevronRight className="size-4 text-(--text-disabled)" />
-               <span className="text-[14px] font-semibold leading-[1.45] text-(--text-secondary)">결제</span>
-            </div>
-         </div>
-      </header>
+      <BooksHeader
+         matchTitle={matchTitle}
+         venue={venue}
+         dateTime={dateTime}
+         steps={PAYMENT_STEPS}
+         currentStepIndex={2}
+         showBackButton
+         backAriaLabel="이전 화면으로 이동"
+      />
    );
 }

--- a/src/pages/tickets/ui/payment/TicketPaymentPage.tsx
+++ b/src/pages/tickets/ui/payment/TicketPaymentPage.tsx
@@ -1,7 +1,8 @@
 // src/pages/tickets/ui/payment/TicketPaymentPage.tsx
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSeatSelectionStore } from '@/pages/books/model/useSeatSelectionStore';
 import { Button } from '@/shared/ui/button';
 import type { PaymentRequest } from '@/pages/tickets/api/paymentApi';
 import {
@@ -40,6 +41,7 @@ const MOCK_GAME = {
 
 export default function TicketPaymentPage() {
    const navigate = useNavigate();
+   const zonesState = useSeatSelectionStore((state) => state.zones);
 
    // 주문자 정보
    const [deliveryMethod, setDeliveryMethod] = useState<DeliveryMethod>('mobile');
@@ -98,6 +100,20 @@ export default function TicketPaymentPage() {
    // 수수료: 매당 1,000원
    const fee = orderInfo.quantity * 1000;
    const totalPayment = shippingFee + fee; // ticketPrice·할인 0원 (TODO: 실데이터 연결 후 업데이트)
+
+   useEffect(() => {
+      const selectedSeatSummary = Object.entries(zonesState).flatMap(([zoneId, zone]) =>
+         zone.selectedSeatIds.map((seatId) => ({
+            zoneId,
+            seatId,
+         })),
+      );
+
+      console.info('[TicketPaymentPage] mounted with seat selections', {
+         selectedSeatCount: selectedSeatSummary.length,
+         selectedSeatSummary,
+      });
+   }, [zonesState]);
 
    const handlePay = () => {
       const paymentRequest: PaymentRequest = {

--- a/src/shared/lib/useBookingFlowTimerStore.ts
+++ b/src/shared/lib/useBookingFlowTimerStore.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+export const DEFAULT_BOOKING_TIMER_SECONDS = 599;
+
+type BookingFlowTimerStore = {
+   expiresAt: number | null;
+   ensureTimerStarted: (initialSeconds?: number) => void;
+   clearTimer: () => void;
+};
+
+export const useBookingFlowTimerStore = create<BookingFlowTimerStore>()(
+   persist(
+      (set) => ({
+         expiresAt: null,
+
+         ensureTimerStarted: (initialSeconds = DEFAULT_BOOKING_TIMER_SECONDS) =>
+            set((state) => {
+               if (state.expiresAt && state.expiresAt > Date.now()) {
+                  return state;
+               }
+
+               return {
+                  expiresAt: Date.now() + initialSeconds * 1000,
+               };
+            }),
+
+         clearTimer: () => set({ expiresAt: null }),
+      }),
+      {
+         name: 'booking-flow-timer',
+         storage: createJSONStorage(() => sessionStorage),
+         partialize: (state) => ({
+            expiresAt: state.expiresAt,
+         }),
+      },
+   ),
+);

--- a/src/shared/widgets/layout/books/BooksExitDialog.tsx
+++ b/src/shared/widgets/layout/books/BooksExitDialog.tsx
@@ -16,10 +16,10 @@ const BooksExitDialog = ({ open, onOpenChange, onConfirm }: BooksExitDialogProps
             className="w-[calc(100%-40px)] max-w-[335px] gap-0 overflow-hidden rounded-[16px] border-0 bg-(--background-elevated) p-0 shadow-xl"
          >
             <DialogHeader className="gap-3 p-5 text-left">
-               <DialogTitle align="left" className="text-[18px] leading-[1.55] text-(--text-primary)">
+               <DialogTitle align="left" className="text-heading-4-bold font-bold text-(--text-primary)">
                   예매를 종료하시겠습니까?
                </DialogTitle>
-               <DialogDescription align="left" className="text-[14px] leading-[1.5] text-(--text-secondary)">
+               <DialogDescription align="left" className="text-body-2-regular text-(--text-secondary)">
                   진행 중인 예매 정보가 사라집니다.
                </DialogDescription>
             </DialogHeader>
@@ -29,12 +29,12 @@ const BooksExitDialog = ({ open, onOpenChange, onConfirm }: BooksExitDialogProps
                   type="button"
                   variant="tertiary"
                   size="lg"
-                  className="h-12 w-full rounded-[8px] border-(--border-normal) text-[16px] font-bold text-(--text-secondary)"
+                  className="text-label-1-bold h-12 w-full rounded-[8px] border-(--border-normal) font-bold text-(--text-secondary)"
                   onClick={() => onOpenChange(false)}
                >
                   취소
                </Button>
-               <Button type="button" size="lg" className="h-12 w-full rounded-[8px] text-[16px] font-bold" onClick={onConfirm}>
+               <Button type="button" size="lg" className="text-label-1-bold h-12 w-full rounded-[8px] font-bold" onClick={onConfirm}>
                   나가기
                </Button>
             </DialogFooter>

--- a/src/shared/widgets/layout/books/BooksHeader.tsx
+++ b/src/shared/widgets/layout/books/BooksHeader.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import { ChevronLeft, HelpCircle, User } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useSeatSelectionStore } from '@/pages/books/model/useSeatSelectionStore';
 import { DEFAULT_BOOKING_TIMER_SECONDS, useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
 
 import BooksExitDialog from './BooksExitDialog';
+import BooksTimeoutDialog from './BooksTimeoutDialog';
 
 const DEFAULT_STEPS = ['구역 선택', '좌석 선택', '배송/주문자 확인', '결제'];
 const EXIT_DESTINATIONS = {
@@ -54,11 +56,13 @@ const BooksHeader = ({
    const resolvedCurrentStepIndex = currentStepIndex ?? (pathname.includes('/books/seats/') ? 1 : 0);
    const shouldShowBackButton = showBackButton ?? resolvedCurrentStepIndex > 0;
    const [isExitDialogOpen, setIsExitDialogOpen] = useState(false);
+   const [isTimeoutDialogOpen, setIsTimeoutDialogOpen] = useState(false);
    const [exitDestination, setExitDestination] = useState<ExitDestinationKey>('home');
    const [now, setNow] = useState(Date.now());
    const expiresAt = useBookingFlowTimerStore((state) => state.expiresAt);
    const ensureTimerStarted = useBookingFlowTimerStore((state) => state.ensureTimerStarted);
    const clearTimer = useBookingFlowTimerStore((state) => state.clearTimer);
+   const clearAllSelections = useSeatSelectionStore((state) => state.clearAllSelections);
 
    useEffect(() => {
       if (!showTimer) {
@@ -88,7 +92,20 @@ const BooksHeader = ({
    const ss = String(remainingSeconds % 60).padStart(2, '0');
    const timeStr = `${mm}:${ss}`;
 
+   useEffect(() => {
+      if (!showTimer || expiresAt === null || remainingSeconds > 0) {
+         return;
+      }
+
+      clearAllSelections();
+      setIsTimeoutDialogOpen(true);
+   }, [clearAllSelections, expiresAt, remainingSeconds, showTimer]);
+
    const openExitDialog = (destination: ExitDestinationKey) => {
+      if (isTimeoutDialogOpen) {
+         return;
+      }
+
       if (!confirmBeforeExit) {
          clearTimer();
          navigate(EXIT_DESTINATIONS[destination]);
@@ -108,6 +125,14 @@ const BooksHeader = ({
                setIsExitDialogOpen(false);
                clearTimer();
                navigate(EXIT_DESTINATIONS[exitDestination]);
+            }}
+         />
+         <BooksTimeoutDialog
+            open={isTimeoutDialogOpen}
+            onConfirm={() => {
+               setIsTimeoutDialogOpen(false);
+               clearTimer();
+               navigate('/');
             }}
          />
 

--- a/src/shared/widgets/layout/books/BooksHeader.tsx
+++ b/src/shared/widgets/layout/books/BooksHeader.tsx
@@ -1,26 +1,100 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ChevronLeft, HelpCircle, User } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { DEFAULT_BOOKING_TIMER_SECONDS, useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
 
 import BooksExitDialog from './BooksExitDialog';
 
-const steps = ['구역 선택', '좌석 선택', '배송/주문자 확인', '결제'];
+const DEFAULT_STEPS = ['구역 선택', '좌석 선택', '배송/주문자 확인', '결제'];
 const EXIT_DESTINATIONS = {
    home: '/',
    mypage: '/mypage',
 } as const;
+const DEFAULT_MATCH_INFO = {
+   matchTitle: '기아 vs LG',
+   venue: '기아 챔피언스필드',
+   dateTime: '3.21 (토) 오후 18:30',
+} as const;
 
 type ExitDestinationKey = keyof typeof EXIT_DESTINATIONS;
 
-const BooksHeader = () => {
+export interface BooksHeaderProps {
+   matchTitle?: string;
+   venue?: string;
+   dateTime?: string;
+   steps?: string[];
+   currentStepIndex?: number;
+   showBackButton?: boolean;
+   backAriaLabel?: string;
+   onBack?: () => void;
+   showTimer?: boolean;
+   timerInitialSeconds?: number;
+   confirmBeforeExit?: boolean;
+}
+
+/**
+ * 예매 플로우 전반에서 사용하는 공용 헤더입니다.
+ * 단계 표시, 경기 정보, 카운트다운, 이탈 확인 동작을 화면별로 조정할 수 있습니다.
+ */
+const BooksHeader = ({
+   matchTitle = DEFAULT_MATCH_INFO.matchTitle,
+   venue = DEFAULT_MATCH_INFO.venue,
+   dateTime = DEFAULT_MATCH_INFO.dateTime,
+   steps = DEFAULT_STEPS,
+   currentStepIndex,
+   showBackButton,
+   backAriaLabel = '이전 화면으로 이동',
+   onBack,
+   showTimer = true,
+   timerInitialSeconds = DEFAULT_BOOKING_TIMER_SECONDS,
+   confirmBeforeExit = true,
+}: BooksHeaderProps = {}) => {
    const navigate = useNavigate();
    const { pathname } = useLocation();
-   const currentStepIndex = pathname.includes('/books/seats/') ? 1 : 0;
-   const isSeatPage = currentStepIndex === 1;
+   const resolvedCurrentStepIndex = currentStepIndex ?? (pathname.includes('/books/seats/') ? 1 : 0);
+   const shouldShowBackButton = showBackButton ?? resolvedCurrentStepIndex > 0;
    const [isExitDialogOpen, setIsExitDialogOpen] = useState(false);
    const [exitDestination, setExitDestination] = useState<ExitDestinationKey>('home');
+   const [now, setNow] = useState(Date.now());
+   const expiresAt = useBookingFlowTimerStore((state) => state.expiresAt);
+   const ensureTimerStarted = useBookingFlowTimerStore((state) => state.ensureTimerStarted);
+   const clearTimer = useBookingFlowTimerStore((state) => state.clearTimer);
+
+   useEffect(() => {
+      if (!showTimer) {
+         return;
+      }
+
+      ensureTimerStarted(timerInitialSeconds);
+   }, [ensureTimerStarted, showTimer, timerInitialSeconds]);
+
+   useEffect(() => {
+      if (!showTimer || expiresAt === null) {
+         return;
+      }
+
+      const intervalId = window.setInterval(() => {
+         setNow(Date.now());
+      }, 1000);
+
+      return () => {
+         window.clearInterval(intervalId);
+      };
+   }, [expiresAt, showTimer]);
+
+   const remainingSeconds =
+      showTimer && expiresAt !== null ? Math.max(0, Math.ceil((expiresAt - now) / 1000)) : timerInitialSeconds;
+   const mm = String(Math.floor(remainingSeconds / 60)).padStart(2, '0');
+   const ss = String(remainingSeconds % 60).padStart(2, '0');
+   const timeStr = `${mm}:${ss}`;
 
    const openExitDialog = (destination: ExitDestinationKey) => {
+      if (!confirmBeforeExit) {
+         clearTimer();
+         navigate(EXIT_DESTINATIONS[destination]);
+         return;
+      }
+
       setExitDestination(destination);
       setIsExitDialogOpen(true);
    };
@@ -32,81 +106,97 @@ const BooksHeader = () => {
             onOpenChange={setIsExitDialogOpen}
             onConfirm={() => {
                setIsExitDialogOpen(false);
+               clearTimer();
                navigate(EXIT_DESTINATIONS[exitDestination]);
             }}
          />
 
          <header className="border-b border-border-light bg-background">
-         <div className="flex h-16 items-center justify-between px-4 lg:h-[68px] lg:px-8">
-            <button
-               type="button"
-               className="text-heading-4-bold tracking-tight text-foreground"
-               onClick={() => openExitDialog('home')}
-            >
-               goTi
-            </button>
-            <div className="flex items-center gap-5">
-               <div className="relative flex items-center gap-1 text-heading-4-medium text-muted-foreground">
-                  <span>예매 시간</span>
-                  <span className="text-heading-4-bold text-primary">9:59</span>
-                  <HelpCircle className="h-4 w-4" aria-hidden="true" />
-                  <div className="absolute right-0 top-7 z-10 hidden w-[230px] rounded-lg bg-fill-inverse p-3 text-caption-1-medium text-white shadow-lg lg:block">
-                     시간이 종료되면 해당 화면에서 나가게 되며, 처음부터 다시 진행해야 합니다.
-                  </div>
-               </div>
+            <div className="flex h-16 items-center justify-between px-4 lg:h-[68px] lg:px-8">
                <button
                   type="button"
-                  aria-label="마이페이지"
-                  onClick={() => openExitDialog('mypage')}
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-md text-icon-secondary"
+                  className="text-heading-4-bold tracking-tight text-foreground"
+                  onClick={() => openExitDialog('home')}
                >
-                  <User className="h-5 w-5" aria-hidden="true" />
+                  goTi
                </button>
-            </div>
-         </div>
-
-         <div className="flex flex-col gap-4 border-t border-border-light px-4 py-4 lg:h-[72px] lg:flex-row lg:items-center lg:justify-between lg:gap-6 lg:px-8 lg:py-0">
-            <div className="flex flex-wrap items-center gap-2 text-body-1-medium text-muted-foreground">
-               {isSeatPage ? (
+               <div className="flex items-center gap-5">
+                  {showTimer ? (
+                     <div className="group relative flex items-center gap-1 text-heading-4-medium text-muted-foreground">
+                        <span>예매 시간</span>
+                        <span className="text-heading-4-bold text-primary">{timeStr}</span>
+                        <button
+                           type="button"
+                           className="inline-flex h-4 w-4 items-center justify-center text-icon-secondary"
+                           aria-label="예매 시간 안내"
+                        >
+                           <HelpCircle className="h-4 w-4" aria-hidden="true" />
+                        </button>
+                        <div className="absolute right-0 top-7 z-10 hidden w-[230px] rounded-lg bg-fill-inverse p-3 text-caption-1-medium text-white shadow-lg group-hover:block group-focus-within:block">
+                           시간이 종료되면 해당 화면에서 나가게 되며, 처음부터 다시 진행해야 합니다.
+                        </div>
+                     </div>
+                  ) : null}
                   <button
                      type="button"
-                     aria-label="구역 선택 화면으로 이동"
-                     onClick={() => navigate('/books')}
-                     className="inline-flex h-8 w-8 items-center justify-center rounded-md text-icon-secondary transition-colors hover:bg-fill-hover"
+                     aria-label="마이페이지"
+                     onClick={() => openExitDialog('mypage')}
+                     className="inline-flex h-8 w-8 items-center justify-center rounded-md text-icon-secondary"
                   >
-                     <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+                     <User className="h-5 w-5" aria-hidden="true" />
                   </button>
-               ) : null}
-               <h1 className="mr-2 text-heading-2-bold text-foreground">기아 vs LG</h1>
-               <span>기아 챔피언스필드</span>
-               <span aria-hidden="true">·</span>
-               <span>3.21 (토) 오후 18:30</span>
+               </div>
             </div>
-            <ol className="flex flex-wrap items-center gap-1 lg:gap-2" aria-label="예매 진행 단계">
-               {steps.map((step, index) => {
-                  const isCurrent = index === currentStepIndex;
 
-                  return (
-                     <li key={step} className="flex items-center gap-1 lg:gap-2">
-                        <span
-                           className={[
-                              'rounded-full px-3 py-1 text-label-2-medium',
-                              isCurrent ? 'text-label-2-semibold text-muted-foreground' : 'text-disabled-foreground',
-                           ].join(' ')}
-                           aria-current={isCurrent ? 'step' : undefined}
-                        >
-                           {step}
-                        </span>
-                        {index < steps.length - 1 ? (
-                           <span className="text-body-1-bold text-border" aria-hidden="true">
-                              ›
+            <div className="flex flex-col gap-4 border-t border-border-light px-4 py-4 lg:h-[72px] lg:flex-row lg:items-center lg:justify-between lg:gap-6 lg:px-8 lg:py-0">
+               <div className="flex flex-wrap items-center gap-2 text-body-1-medium text-muted-foreground">
+                  {shouldShowBackButton ? (
+                     <button
+                        type="button"
+                        aria-label={backAriaLabel}
+                        onClick={() => {
+                           if (onBack) {
+                              onBack();
+                              return;
+                           }
+
+                           navigate(-1);
+                        }}
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-icon-secondary transition-colors hover:bg-fill-hover"
+                     >
+                        <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+                     </button>
+                  ) : null}
+                  <h1 className="mr-2 text-heading-2-bold text-foreground">{matchTitle}</h1>
+                  <span>{venue}</span>
+                  <span aria-hidden="true">·</span>
+                  <span>{dateTime}</span>
+               </div>
+               <ol className="flex flex-wrap items-center gap-1 lg:gap-2" aria-label="예매 진행 단계">
+                  {steps.map((step, index) => {
+                     const isCurrent = index === resolvedCurrentStepIndex;
+
+                     return (
+                        <li key={step} className="flex items-center gap-1 lg:gap-2">
+                           <span
+                              className={[
+                                 'rounded-full px-3 py-1 text-label-2-medium',
+                                 isCurrent ? 'text-label-2-semibold text-muted-foreground' : 'text-disabled-foreground',
+                              ].join(' ')}
+                              aria-current={isCurrent ? 'step' : undefined}
+                           >
+                              {step}
                            </span>
-                        ) : null}
-                     </li>
-                  );
-               })}
-            </ol>
-         </div>
+                           {index < steps.length - 1 ? (
+                              <span className="text-body-1-bold text-border" aria-hidden="true">
+                                 ›
+                              </span>
+                           ) : null}
+                        </li>
+                     );
+                  })}
+               </ol>
+            </div>
          </header>
       </>
    );

--- a/src/shared/widgets/layout/books/BooksHeader.tsx
+++ b/src/shared/widgets/layout/books/BooksHeader.tsx
@@ -1,9 +1,16 @@
 import { useState } from 'react';
 import { ChevronLeft, HelpCircle, User } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
+
 import BooksExitDialog from './BooksExitDialog';
 
 const steps = ['구역 선택', '좌석 선택', '배송/주문자 확인', '결제'];
+const EXIT_DESTINATIONS = {
+   home: '/',
+   mypage: '/mypage',
+} as const;
+
+type ExitDestinationKey = keyof typeof EXIT_DESTINATIONS;
 
 const BooksHeader = () => {
    const navigate = useNavigate();
@@ -11,6 +18,12 @@ const BooksHeader = () => {
    const currentStepIndex = pathname.includes('/books/seats/') ? 1 : 0;
    const isSeatPage = currentStepIndex === 1;
    const [isExitDialogOpen, setIsExitDialogOpen] = useState(false);
+   const [exitDestination, setExitDestination] = useState<ExitDestinationKey>('home');
+
+   const openExitDialog = (destination: ExitDestinationKey) => {
+      setExitDestination(destination);
+      setIsExitDialogOpen(true);
+   };
 
    return (
       <>
@@ -19,7 +32,7 @@ const BooksHeader = () => {
             onOpenChange={setIsExitDialogOpen}
             onConfirm={() => {
                setIsExitDialogOpen(false);
-               navigate('/');
+               navigate(EXIT_DESTINATIONS[exitDestination]);
             }}
          />
 
@@ -28,7 +41,7 @@ const BooksHeader = () => {
             <button
                type="button"
                className="text-heading-4-bold tracking-tight text-foreground"
-               onClick={() => setIsExitDialogOpen(true)}
+               onClick={() => openExitDialog('home')}
             >
                goTi
             </button>
@@ -44,6 +57,7 @@ const BooksHeader = () => {
                <button
                   type="button"
                   aria-label="마이페이지"
+                  onClick={() => openExitDialog('mypage')}
                   className="inline-flex h-8 w-8 items-center justify-center rounded-md text-icon-secondary"
                >
                   <User className="h-5 w-5" aria-hidden="true" />

--- a/src/shared/widgets/layout/books/BooksLayout.tsx
+++ b/src/shared/widgets/layout/books/BooksLayout.tsx
@@ -1,5 +1,8 @@
 import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
+
+import { useSeatSelectionStore } from '@/pages/books/model/useSeatSelectionStore';
+
 import BooksHeader from './BooksHeader';
 
 const BooksLayout = () => {
@@ -35,6 +38,9 @@ const BooksLayout = () => {
          window.removeEventListener('keydown', handleKeyDown);
          window.removeEventListener('gesturestart', handleGesture as EventListener);
          window.removeEventListener('gesturechange', handleGesture as EventListener);
+
+         // 예매 플로우를 벗어나면 이전 좌석 선택 상태를 남기지 않습니다.
+         useSeatSelectionStore.getState().clearAllSelections();
       };
    }, []);
 

--- a/src/shared/widgets/layout/books/BooksLayout.tsx
+++ b/src/shared/widgets/layout/books/BooksLayout.tsx
@@ -1,8 +1,6 @@
 import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
-import { useSeatSelectionStore } from '@/pages/books/model/useSeatSelectionStore';
-
 import BooksHeader from './BooksHeader';
 
 const BooksLayout = () => {
@@ -38,9 +36,6 @@ const BooksLayout = () => {
          window.removeEventListener('keydown', handleKeyDown);
          window.removeEventListener('gesturestart', handleGesture as EventListener);
          window.removeEventListener('gesturechange', handleGesture as EventListener);
-
-         // 예매 플로우를 벗어나면 이전 좌석 선택 상태를 남기지 않습니다.
-         useSeatSelectionStore.getState().clearAllSelections();
       };
    }, []);
 

--- a/src/shared/widgets/layout/books/BooksTimeoutDialog.tsx
+++ b/src/shared/widgets/layout/books/BooksTimeoutDialog.tsx
@@ -18,7 +18,7 @@ const BooksTimeoutDialog = ({ open, onConfirm }: BooksTimeoutDialogProps) => {
             className="w-[calc(100%-40px)] max-w-[335px] gap-0 overflow-hidden rounded-[16px] border-0 bg-(--background-elevated) p-0 shadow-xl"
          >
             <DialogHeader className="gap-3 p-5 text-left">
-               <DialogTitle align="left" className="text-heading-4-bold text-(--text-primary)">
+               <DialogTitle align="left" className="text-heading-4-bold font-bold text-(--text-primary)">
                   예매 가능 시간이 만료되었습니다.
                </DialogTitle>
                <DialogDescription align="left" className="text-body-2-regular text-(--text-secondary)">

--- a/src/shared/widgets/layout/books/BooksTimeoutDialog.tsx
+++ b/src/shared/widgets/layout/books/BooksTimeoutDialog.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@/shared/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+
+type BooksTimeoutDialogProps = {
+   open: boolean;
+   onConfirm: () => void;
+};
+
+/**
+ * 예매 가능 시간이 만료되었을 때 표시하는 전용 팝업입니다.
+ */
+const BooksTimeoutDialog = ({ open, onConfirm }: BooksTimeoutDialogProps) => {
+   return (
+      <Dialog open={open}>
+         <DialogContent
+            showCloseButton={false}
+            closeOnlyWithButton
+            className="w-[calc(100%-40px)] max-w-[335px] gap-0 overflow-hidden rounded-[16px] border-0 bg-(--background-elevated) p-0 shadow-xl"
+         >
+            <DialogHeader className="gap-3 p-5 text-left">
+               <DialogTitle align="left" className="text-heading-4-bold text-(--text-primary)">
+                  예매 가능 시간이 만료되었습니다.
+               </DialogTitle>
+               <DialogDescription align="left" className="text-body-2-regular text-(--text-secondary)">
+                  예매가 종료되며 홈으로 이동합니다.
+               </DialogDescription>
+            </DialogHeader>
+
+            <DialogFooter className="px-5 pb-5 pt-0">
+               <Button type="button" size="lg" className="text-label-1-bold h-12 w-full rounded-[8px] font-bold" onClick={onConfirm}>
+                  확인
+               </Button>
+            </DialogFooter>
+         </DialogContent>
+      </Dialog>
+   );
+};
+
+export default BooksTimeoutDialog;


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #98

<br/>

## 🔎 개요
예매 및 결제 페이지 헤더 통일화 후 예매시간 카운드다운 전역관리 변경

<br/>

## 📋 작업 내용
- 예매 및 결제 페이지 헤더 통일화 후 메인화면 이동 로직 예매 및 결제 페이지 헤더 마이페이지 아이콘 버튼 적용
- 예매 카운트 다운 0초 도달 시 좌석 선택 내용 삭제 후 메인화면 이동 팝업 구현
- 예매 카운트다운 전역관리 변경
<br/>
