### PR TITLE
[design] 예매 화면 모바일 UI 적용

### DIFF
--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { BOOKING_ZONES } from '@/pages/books/model/zoneData';
+import { Drawer, DrawerContent, DrawerTrigger } from '@/shared/ui/drawer';
 
 import BookingCaptchaGate from './components/BookingCaptchaGate';
 import BookingZoneList from './components/BookingZoneList';
@@ -39,6 +40,7 @@ const BooksPage = () => {
    const [captchaInput, setCaptchaInput] = useState('');
    const [captchaError, setCaptchaError] = useState('');
    const [captchaSeed, setCaptchaSeed] = useState(0);
+   const [isZoneDrawerOpen, setIsZoneDrawerOpen] = useState(true);
 
    const captchaCode = useMemo(() => createMockCaptcha(), [captchaSeed]);
 
@@ -52,6 +54,28 @@ const BooksPage = () => {
       setCaptchaSeed((prev) => prev + 1);
       setIsCaptchaOpen(true);
    }, [requiresCaptcha]);
+
+   useEffect(() => {
+      const mediaQuery = window.matchMedia('(min-width: 1024px)');
+      const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+         if (event.matches) {
+            setIsZoneDrawerOpen(false);
+         }
+      };
+
+      handleChange(mediaQuery);
+      mediaQuery.addEventListener('change', handleChange);
+
+      return () => {
+         mediaQuery.removeEventListener('change', handleChange);
+      };
+   }, []);
+
+   useEffect(() => {
+      if (isCaptchaOpen) {
+         setIsZoneDrawerOpen(false);
+      }
+   }, [isCaptchaOpen]);
 
    const handleSelectZone = (zoneId: string) => {
       setSelectedZoneId(zoneId);
@@ -104,7 +128,54 @@ const BooksPage = () => {
             onRefresh={refreshCaptcha}
             onSubmit={submitCaptcha}
          />
-         <main className="flex min-h-[calc(100vh-140px)] flex-col lg:grid lg:h-[calc(100vh-140px)] lg:grid-cols-[minmax(0,1fr)_420px]">
+         <section className="relative min-h-[calc(100vh-140px)] bg-[#f1f2f4] lg:hidden">
+            <BookingZoneMap
+               zones={zones}
+               selectedZoneId={selectedZoneId}
+               onSelectZone={handleSelectZone}
+               mobileExpanded={!isCaptchaOpen && !isZoneDrawerOpen}
+            />
+            {!isCaptchaOpen ? (
+               <Drawer open={isZoneDrawerOpen} onOpenChange={setIsZoneDrawerOpen} modal={false}>
+                  {!isZoneDrawerOpen ? (
+                     <div className="absolute inset-x-0 bottom-0 z-10">
+                        <DrawerTrigger asChild>
+                           <button
+                              type="button"
+                              className="w-full rounded-t-[16px] bg-elevated px-5 py-4 text-left shadow-[0_-6px_24px_rgba(0,0,0,0.16)]"
+                           >
+                              <div className="mb-3 flex justify-center" aria-hidden="true">
+                                 <div className="h-1 w-9 rounded-full bg-border-light" />
+                              </div>
+                              <div className="flex items-center justify-between gap-3">
+                                 <span className="text-heading-3-bold text-foreground">좌석 등급/잔여석</span>
+                                 <span className="text-body-1-medium text-tertiary">{zones.length}개 구역</span>
+                              </div>
+                           </button>
+                        </DrawerTrigger>
+                     </div>
+                  ) : null}
+                  <DrawerContent
+                     showOverlay={false}
+                     resizable
+                     defaultHeight={360}
+                     minHeight={232}
+                     maxHeight={488}
+                     className="overflow-hidden border-none p-0"
+                  >
+                     <div className="h-full overflow-y-auto">
+                        <BookingZoneList
+                           variant="drawer"
+                           zones={zones}
+                           selectedZoneId={selectedZoneId}
+                           onSelectZone={handleSelectZone}
+                        />
+                     </div>
+                  </DrawerContent>
+               </Drawer>
+            ) : null}
+         </section>
+         <main className="hidden min-h-[calc(100vh-140px)] lg:grid lg:h-[calc(100vh-140px)] lg:grid-cols-[minmax(0,1fr)_420px]">
             <BookingZoneMap zones={zones} selectedZoneId={selectedZoneId} onSelectZone={handleSelectZone} />
             <BookingZoneList zones={zones} selectedZoneId={selectedZoneId} onSelectZone={handleSelectZone} />
          </main>

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -234,13 +234,7 @@ function SeatsPage() {
       setSeatMapOffset({ x: 0, y: 0 });
    };
 
-   const canDragSeatMap = () => {
-      if (seatMapScale > 1) {
-         return true;
-      }
-
-      return typeof window !== 'undefined' && window.matchMedia('(max-width: 1279px)').matches;
-   };
+   const canDragSeatMap = () => true;
 
    const toggleSeat = (seat: SeatItem) => {
       if (seat.status === 'disabled' || seat.status === 'held') {

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -7,7 +7,9 @@ import { createSeatsForZone, getSeatBlocks } from '@/pages/books/model/seatData'
 import { useSeatSelectionStore } from '@/pages/books/model/useSeatSelectionStore';
 import { BOOKING_ZONES, formatPrice, getZoneOverviewImage } from '@/pages/books/model/zoneData';
 import type { SeatItem } from '@/pages/books/model/types';
+import { Drawer, DrawerContent, DrawerTrigger } from '@/shared/ui/drawer';
 import SeatBlockGrid from './components/SeatBlockGrid';
+import SelectedSeatSummaryList, { type SelectedSeatSummaryItem } from './components/SelectedSeatSummaryList';
 
 const MIN_SCALE = 0.8;
 const MAX_SCALE = 2.4;
@@ -22,13 +24,6 @@ const MINIMAP_PADDING_X = 24;
 const MINIMAP_PADDING_Y = 18;
 
 const stepLabels = ['구역 선택', '좌석 선택', '배송/주문자 확인', '결제'];
-
-type SelectedSeatSummaryItem = {
-   seat: SeatItem;
-   zoneId: string;
-   zoneName: string;
-   price: number;
-};
 
 function SeatsPage() {
    const navigate = useNavigate();
@@ -51,6 +46,7 @@ function SeatsPage() {
    const [seatMapScale, setSeatMapScale] = useState(1);
    const [seatMapOffset, setSeatMapOffset] = useState({ x: 0, y: 0 });
    const [isSeatMapDragging, setIsSeatMapDragging] = useState(false);
+   const [isSeatDrawerOpen, setIsSeatDrawerOpen] = useState(true);
    const dragStartRef = useRef<{ x: number; y: number } | null>(null);
    const mapViewportRef = useRef<HTMLDivElement | null>(null);
    const [mapViewportSize, setMapViewportSize] = useState({ width: 0, height: 0 });
@@ -78,6 +74,22 @@ function SeatsPage() {
 
       return () => {
          window.removeEventListener('resize', updateViewportSize);
+      };
+   }, []);
+
+   useEffect(() => {
+      const mediaQuery = window.matchMedia('(min-width: 1280px)');
+      const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+         if (event.matches) {
+            setIsSeatDrawerOpen(false);
+         }
+      };
+
+      handleChange(mediaQuery);
+      mediaQuery.addEventListener('change', handleChange);
+
+      return () => {
+         mediaQuery.removeEventListener('change', handleChange);
       };
    }, []);
 
@@ -114,6 +126,7 @@ function SeatsPage() {
    }, [zonesState]);
 
    const selectedPrice = selectedSeats.reduce((total, item) => total + item.price, 0);
+   const bookingButtonLabel = `${selectedSeats.length}매 예매하기`;
 
    const sectionBounds = useMemo(() => {
       if (seatBlocks.length === 0) {
@@ -221,6 +234,14 @@ function SeatsPage() {
       setSeatMapOffset({ x: 0, y: 0 });
    };
 
+   const canDragSeatMap = () => {
+      if (seatMapScale > 1) {
+         return true;
+      }
+
+      return typeof window !== 'undefined' && window.matchMedia('(max-width: 1279px)').matches;
+   };
+
    const toggleSeat = (seat: SeatItem) => {
       if (seat.status === 'disabled' || seat.status === 'held') {
          return;
@@ -230,7 +251,7 @@ function SeatsPage() {
    };
 
    const handleMapPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
-      if (seatMapScale <= 1) {
+      if (!canDragSeatMap()) {
          return;
       }
 
@@ -270,13 +291,13 @@ function SeatsPage() {
    return (
       <div className="w-full bg-background text-foreground">
          <main className="flex min-h-[calc(100vh-140px)] flex-col xl:h-[calc(100vh-140px)] xl:flex-row">
-            <section className="flex min-h-[680px] flex-1 flex-col overflow-hidden bg-[#f1f2f4]">
-               <div className="flex items-center justify-between gap-4 px-5 py-3 lg:px-8">
-                  <div className="inline-flex min-w-0 items-center gap-2 rounded-[12px] bg-background px-3 py-2">
+            <section className="relative flex min-h-[660px] flex-1 flex-col overflow-hidden bg-[#eef0f3] xl:min-h-[680px]">
+               <div className="flex items-center justify-between gap-4 px-5 py-5 lg:px-8 lg:py-3">
+                  <div className="inline-flex min-w-0 items-center gap-2 rounded-[12px] bg-background px-4 py-2 shadow-[0_1px_2px_rgba(15,23,42,0.04)] lg:px-3">
                      <span className="inline-flex items-center justify-center rounded-[8px] bg-primary-light px-2 py-1 text-caption-1-bold text-primary">
                         선택 구역
                      </span>
-                     <span className="truncate text-body-2-bold text-foreground">{zone.name}</span>
+                     <span className="truncate text-body-1-bold text-foreground">{zone.name}</span>
                   </div>
 
                   <div className="hidden items-center lg:flex" aria-label="예매 단계">
@@ -304,14 +325,15 @@ function SeatsPage() {
                   </div>
                </div>
 
-               <div className="relative flex-1 overflow-hidden px-4 pb-6 lg:px-8">
-                  <div className="relative h-full min-h-[560px] overflow-hidden rounded-[24px] bg-[#eef0f3]">
+               <div className="relative flex-1 overflow-hidden px-0 pb-[144px] lg:px-8 lg:pb-6 xl:pb-6">
+                  <div className="relative h-full min-h-[516px] overflow-hidden bg-[#eef0f3] lg:min-h-[560px] lg:rounded-[24px]">
                      <div ref={mapViewportRef} className="absolute inset-0 overflow-hidden">
                         <div
                            className={[
                               'absolute left-1/2 top-14 origin-top',
-                              isSeatMapDragging ? 'cursor-grabbing' : seatMapScale > 1 ? 'cursor-grab' : 'cursor-default',
+                              isSeatMapDragging ? 'cursor-grabbing' : canDragSeatMap() ? 'cursor-grab' : 'cursor-default',
                               isSeatMapDragging ? '' : 'transition-transform duration-150',
+                              'touch-none',
                            ].join(' ')}
                            style={{
                               width: `${STAGE_WIDTH}px`,
@@ -324,7 +346,7 @@ function SeatsPage() {
                            onPointerCancel={handleMapPointerUp}
                         >
                            <div
-                              className="absolute rounded-xl bg-white/70 px-8 py-3 text-body-2-semibold text-muted-foreground shadow-[0_8px_24px_rgba(15,23,42,0.06)] backdrop-blur"
+                              className="absolute rounded-[10px] bg-[rgba(233,235,238,0.72)] px-8 py-3 text-body-1-bold text-muted-foreground shadow-[0_8px_24px_rgba(15,23,42,0.06)] backdrop-blur lg:rounded-xl lg:bg-white/70 lg:text-body-2-semibold"
                               style={{
                                  left: '50%',
                                  top: '24px',
@@ -347,7 +369,7 @@ function SeatsPage() {
                         </div>
                      </div>
 
-                     <div className="absolute bottom-5 left-5 overflow-hidden rounded-[16px] bg-[#b0b0b0] shadow-[0_16px_40px_rgba(15,23,42,0.18)]">
+                     <div className="absolute bottom-5 left-5 hidden overflow-hidden rounded-[16px] bg-[#b0b0b0] shadow-[0_16px_40px_rgba(15,23,42,0.18)] lg:block">
                         <div className="relative h-[140px] w-[215px]">
                            <svg
                               viewBox={`0 0 ${MINIMAP_WIDTH} ${MINIMAP_HEIGHT}`}
@@ -384,7 +406,7 @@ function SeatsPage() {
                         </div>
                      </div>
 
-                     <div className="absolute bottom-6 right-6 flex flex-col gap-2">
+                     <div className="absolute bottom-6 right-6 hidden flex-col gap-2 lg:flex">
                         <MapControlButton ariaLabel="확대" onClick={() => updateSeatMapScale(seatMapScale + SCALE_STEP)}>
                            <Plus className="h-5 w-5" aria-hidden="true" />
                         </MapControlButton>
@@ -397,9 +419,89 @@ function SeatsPage() {
                      </div>
                   </div>
                </div>
+
+               <Drawer open={isSeatDrawerOpen} onOpenChange={setIsSeatDrawerOpen} modal={false}>
+                  {!isSeatDrawerOpen ? (
+                     <div className="absolute inset-x-0 bottom-0 z-10 xl:hidden">
+                        <DrawerTrigger asChild>
+                           <button
+                              type="button"
+                              className="w-full rounded-t-[16px] bg-elevated px-5 py-4 text-left shadow-[0_-6px_24px_rgba(0,0,0,0.16)]"
+                           >
+                              <div className="mb-3 flex justify-center" aria-hidden="true">
+                                 <div className="h-1 w-9 rounded-full bg-border-light" />
+                              </div>
+                              <div className="flex items-center justify-between gap-3">
+                                 <div className="flex items-center gap-1 text-heading-3-bold text-foreground">
+                                    <span>선택 좌석</span>
+                                    <span className="text-primary">{selectedSeats.length}</span>
+                                 </div>
+                                 <span className="text-body-1-medium text-tertiary">
+                                    {selectedSeats.length > 0 ? bookingButtonLabel : '열기'}
+                                 </span>
+                              </div>
+                           </button>
+                        </DrawerTrigger>
+                     </div>
+                  ) : null}
+                  <DrawerContent
+                     showOverlay={false}
+                     resizable
+                     defaultHeight={280}
+                     minHeight={152}
+                     maxHeight={560}
+                     className="overflow-hidden border-none p-0 xl:hidden"
+                  >
+                     <div className="h-full overflow-y-auto">
+                        <div className="flex items-center justify-between gap-3 px-5 py-4">
+                           <div className="flex items-center gap-1 text-heading-3-bold text-foreground">
+                              <h2>선택 좌석</h2>
+                              <span className="text-primary">{selectedSeats.length}</span>
+                           </div>
+                           {selectedSeats.length > 0 ? (
+                              <button
+                                 type="button"
+                                 onClick={clearAllSelections}
+                                 className="text-body-1-medium text-tertiary transition-colors hover:text-foreground"
+                              >
+                                 전체 삭제
+                              </button>
+                           ) : null}
+                        </div>
+
+                        <div className="px-5 pb-4">
+                           <SelectedSeatSummaryList
+                              items={selectedSeats}
+                              onRemove={toggleSelectedSeat}
+                              emptyClassName="h-full min-h-[220px] bg-transparent"
+                           />
+                        </div>
+
+                        <div className="px-5 pb-5">
+                           <div className="flex items-center justify-between gap-3 px-1 pb-5 text-heading-4-medium text-secondary">
+                              <span>총 결제 금액</span>
+                              <span className="text-heading-4-bold text-primary">{formatPrice(selectedPrice)}</span>
+                           </div>
+                           <button
+                              type="button"
+                              disabled={selectedSeats.length === 0}
+                              onClick={() => navigate('/tickets/payment')}
+                              className={[
+                                 'h-12 w-full rounded-[8px] text-label-1-bold transition-colors',
+                                 selectedSeats.length === 0
+                                    ? 'bg-fill-disabled text-disabled-foreground'
+                                    : 'bg-primary text-white hover:bg-primary-strong',
+                              ].join(' ')}
+                           >
+                              {bookingButtonLabel}
+                           </button>
+                        </div>
+                     </div>
+                  </DrawerContent>
+               </Drawer>
             </section>
 
-            <aside className="flex w-full shrink-0 flex-col border-l border-border-light bg-background xl:w-[420px]">
+            <aside className="hidden w-full shrink-0 flex-col border-l border-border-light bg-background xl:flex xl:w-[420px]">
                <div className="relative h-[220px] overflow-hidden border-b border-border-light bg-[#e9ebee] px-5 py-4">
                   <div className="relative mx-auto h-[188px] w-[260px] shrink-0">
                      <img
@@ -429,56 +531,18 @@ function SeatsPage() {
                   ) : null}
                </div>
 
-               <div className="flex flex-1 flex-col justify-between gap-4 px-5 pb-5">
+               <div className="flex flex-1 flex-col px-5 pb-5">
                   <div className="flex-1 overflow-y-auto rounded-2xl bg-background">
-                     {selectedSeats.length > 0 ? (
-                        <ul className="space-y-3">
-                           {selectedSeats.map((item) => (
-                              <li
-                                 key={item.seat.id}
-                                 className="flex items-center justify-between rounded-xl border border-border-light px-4 py-3"
-                              >
-                                 <div>
-                                    <p className="text-body-2-semibold text-foreground">{item.zoneName}</p>
-                                    <p className="text-body-2-regular text-muted-foreground">
-                                       {item.seat.block}구역 {item.seat.rowLabel} {item.seat.seatNumber}번
-                                    </p>
-                                 </div>
-                                 <div className="flex items-center gap-3">
-                                    <span className="text-body-2-semibold text-primary">{formatPrice(item.price)}</span>
-                                    <button
-                                       type="button"
-                                       onClick={() => toggleSelectedSeat(item.zoneId, item.seat.id)}
-                                       className="text-caption-1-medium text-muted-foreground transition-colors hover:text-foreground"
-                                    >
-                                       삭제
-                                    </button>
-                                 </div>
-                              </li>
-                           ))}
-                        </ul>
-                     ) : (
-                        <div className="flex h-full min-h-[320px] items-center justify-center text-body-1-regular text-muted-foreground">
-                           선택한 좌석이 없습니다.
-                        </div>
-                     )}
+                     <SelectedSeatSummaryList
+                        items={selectedSeats}
+                        onRemove={toggleSelectedSeat}
+                        emptyClassName="h-full min-h-[220px] bg-transparent"
+                     />
                   </div>
 
-                  <div className="space-y-3 rounded-2xl bg-surface p-4">
-                     <div className="flex items-center justify-between text-body-2-regular text-muted-foreground">
-                        <span>선택 구역</span>
-                        <span className="text-body-2-semibold text-foreground">
-                           {selectedSeats.length > 0 ? `${selectedSeats.length}개 좌석 선택` : '-'}
-                        </span>
-                     </div>
-                     <div className="flex items-center justify-between text-body-2-regular text-muted-foreground">
-                        <span>총 좌석 수</span>
-                        <span className="text-body-2-semibold text-foreground">{selectedSeats.length}석</span>
-                     </div>
-                     <div className="flex items-center justify-between text-body-1-semibold text-foreground">
-                        <span>예상 결제 금액</span>
-                        <span>{formatPrice(selectedPrice)}</span>
-                     </div>
+                  <div className="flex items-center justify-between gap-3 px-1 pb-5 pt-6 text-heading-4-medium text-secondary">
+                     <span>총 결제 금액</span>
+                     <span className="text-heading-4-bold text-primary">{formatPrice(selectedPrice)}</span>
                   </div>
 
                   <button
@@ -492,7 +556,7 @@ function SeatsPage() {
                            : 'bg-primary text-white hover:bg-primary-strong',
                      ].join(' ')}
                   >
-                     예매하기
+                     {bookingButtonLabel}
                   </button>
                </div>
             </aside>

--- a/src/pages/books/ui/components/BookingZoneList.tsx
+++ b/src/pages/books/ui/components/BookingZoneList.tsx
@@ -5,35 +5,45 @@ type BookingZoneListProps = {
    zones: ZoneItem[];
    selectedZoneId: string;
    onSelectZone: (zoneId: string) => void;
+   variant?: 'panel' | 'drawer';
 };
 
-function BookingZoneList({ zones, selectedZoneId, onSelectZone }: BookingZoneListProps) {
+function BookingZoneList({ zones, selectedZoneId, onSelectZone, variant = 'panel' }: BookingZoneListProps) {
+   const isDrawer = variant === 'drawer';
+
    return (
       <aside
-         className="w-full border-t border-border-light bg-background lg:w-[420px] lg:border-t-0 lg:border-l"
+         className={[
+            'w-full bg-background',
+            isDrawer ? 'rounded-t-[16px]' : 'border-t border-border-light lg:w-[420px] lg:border-l lg:border-t-0',
+         ].join(' ')}
          aria-label="좌석 등급 및 잔여석"
       >
-         <div className="border-b border-border-light px-5 py-5">
+         <div className={isDrawer ? 'px-5 py-4' : 'border-b border-border-light px-5 py-5'}>
             <h2 className="text-heading-3-bold text-foreground">좌석 등급/잔여석</h2>
          </div>
-         <ul className="px-5 py-0">
+         <ul className={isDrawer ? 'px-5 pb-6' : 'px-5 py-0'}>
             {zones.map((zone) => {
                const hasRemaining = zone.remaining > 0;
                const isSelected = zone.id === selectedZoneId;
 
                return (
-                  <li key={zone.id} className="border-b border-[#f1f2f4] last:border-b-0">
+                  <li key={zone.id} className={isDrawer ? '' : 'border-b border-[#f1f2f4] last:border-b-0'}>
                      <button
                         type="button"
                         onClick={() => onSelectZone(zone.id)}
                         className={[
-                           'flex h-12 w-full items-center gap-3 px-0 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset',
+                           'flex min-h-12 w-full items-center gap-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset',
+                           isDrawer ? 'rounded-[12px] px-2 py-3' : 'px-0',
                            isSelected ? 'bg-fill-hoveraccent' : 'hover:bg-fill-hover',
                         ].join(' ')}
                         aria-pressed={isSelected}
                      >
-                        <div className="ml-1 h-12 w-3 shrink-0" aria-hidden="true">
-                           <div className="mt-[18px] h-3 w-3 rounded-[3px]" style={{ backgroundColor: zone.color }} />
+                        <div className={isDrawer ? 'ml-1 flex h-full w-4 shrink-0 items-center' : 'ml-1 h-12 w-3 shrink-0'} aria-hidden="true">
+                           <div
+                              className={isDrawer ? 'h-4 w-4 rounded-[4px]' : 'mt-[18px] h-3 w-3 rounded-[3px]'}
+                              style={{ backgroundColor: zone.color }}
+                           />
                         </div>
                         <div className="flex min-w-0 flex-1 items-center gap-2 text-body-2-regular text-muted-foreground">
                            <span className="truncate text-body-1-medium text-foreground">{zone.name}</span>
@@ -41,7 +51,8 @@ function BookingZoneList({ zones, selectedZoneId, onSelectZone }: BookingZoneLis
                         </div>
                         <span
                            className={[
-                              'min-w-[34px] pr-1 text-right text-body-1-bold',
+                              'min-w-[34px] text-right text-body-1-bold',
+                              isDrawer ? '' : 'pr-1',
                               hasRemaining ? 'text-primary' : 'text-disabled-foreground',
                            ].join(' ')}
                         >

--- a/src/pages/books/ui/components/BookingZoneMap.tsx
+++ b/src/pages/books/ui/components/BookingZoneMap.tsx
@@ -1,32 +1,43 @@
-import type { ZoneItem } from '@/pages/books/model/types';
+import type { ZoneItem } from "@/pages/books/model/types";
 
 type BookingZoneMapProps = {
-   zones: ZoneItem[];
-   selectedZoneId: string;
-   onSelectZone: (zoneId: string) => void;
+  zones: ZoneItem[];
+  selectedZoneId: string;
+  onSelectZone: (zoneId: string) => void;
+  mobileExpanded?: boolean;
 };
 
-const KIA_STADIUM_IMAGE = '/baseball/seat/kia.png';
+const KIA_STADIUM_IMAGE = "/baseball/seat/kia.png";
 
-function BookingZoneMap({ selectedZoneId }: BookingZoneMapProps) {
-   return (
-      <section
-         className="flex min-h-[360px] items-center justify-center overflow-hidden bg-[#f1f2f4] px-5 py-8 sm:px-8 lg:min-h-0 lg:px-[70px] lg:py-[74px]"
-         aria-label="구장 맵"
-      >
-         <div className="flex aspect-square w-full max-w-[740px] items-center justify-center">
-            <img
-               src={KIA_STADIUM_IMAGE}
-               alt="기아 챔피언스필드 구역도"
-               className="h-full w-full object-contain"
-               draggable={false}
-            />
-            <span className="sr-only">
-               현재 선택된 구역은 {selectedZoneId}이며, 구역 선택은 우측 좌석 등급 목록에서 진행할 수 있습니다.
-            </span>
-         </div>
-      </section>
-   );
+function BookingZoneMap({
+  selectedZoneId,
+  mobileExpanded = false,
+}: BookingZoneMapProps) {
+  return (
+    <section
+      className={[
+        "flex items-center justify-center overflow-hidden bg-[#f1f2f4] px-3 sm:px-8 lg:h-auto lg:min-h-0 lg:px-[70px] lg:py-[74px]",
+        mobileExpanded ? "min-h-[268px] py-4" : "min-h-[172px] py-2",
+      ].join(" ")}
+      aria-label="구장 맵"
+    >
+      <div className="flex w-full items-center justify-center lg:max-w-[740px]">
+        <img
+          src={KIA_STADIUM_IMAGE}
+          alt="기아 챔피언스필드 구역도"
+          className={[
+            "h-auto object-contain object-center lg:w-full lg:max-h-none",
+            mobileExpanded ? "w-[122%] max-w-none" : "w-[112%] max-w-none",
+          ].join(" ")}
+          draggable={false}
+        />
+        <span className="sr-only">
+          현재 선택된 구역은 {selectedZoneId}이며, 구역 선택은 우측 좌석 등급
+          목록에서 진행할 수 있습니다.
+        </span>
+      </div>
+    </section>
+  );
 }
 
 export default BookingZoneMap;

--- a/src/pages/books/ui/components/SelectedSeatSummaryList.tsx
+++ b/src/pages/books/ui/components/SelectedSeatSummaryList.tsx
@@ -1,0 +1,55 @@
+import { cn } from '@/shared/lib/utils';
+
+import type { SeatItem } from '@/pages/books/model/types';
+import SelectedSeatSummaryListItem from './SelectedSeatSummaryListItem';
+
+export type SelectedSeatSummaryItem = {
+   seat: SeatItem;
+   zoneId: string;
+   zoneName: string;
+   price: number;
+};
+
+type SelectedSeatSummaryListProps = {
+   items: SelectedSeatSummaryItem[];
+   onRemove: (zoneId: string, seatId: string) => void;
+   priceLabel?: string;
+   className?: string;
+   emptyClassName?: string;
+};
+
+function SelectedSeatSummaryList({
+   items,
+   onRemove,
+   priceLabel = '주말',
+   className,
+   emptyClassName,
+}: SelectedSeatSummaryListProps) {
+   if (items.length === 0) {
+      return (
+         <div
+            className={cn(
+               'flex min-h-24 items-center justify-center rounded-2xl bg-surface text-body-1-regular text-muted-foreground',
+               emptyClassName,
+            )}
+         >
+            선택한 좌석이 없습니다.
+         </div>
+      );
+   }
+
+   return (
+      <ul className={cn('space-y-4', className)}>
+         {items.map((item) => (
+            <SelectedSeatSummaryListItem
+               key={`${item.zoneId}-${item.seat.id}`}
+               item={item}
+               priceLabel={priceLabel}
+               onRemove={onRemove}
+            />
+         ))}
+      </ul>
+   );
+}
+
+export default SelectedSeatSummaryList;

--- a/src/pages/books/ui/components/SelectedSeatSummaryListItem.tsx
+++ b/src/pages/books/ui/components/SelectedSeatSummaryListItem.tsx
@@ -1,0 +1,50 @@
+import { X } from 'lucide-react';
+
+import { formatPrice } from '@/pages/books/model/zoneData';
+import type { SeatItem } from '@/pages/books/model/types';
+
+type SelectedSeatSummaryListItemProps = {
+   item: {
+      seat: SeatItem;
+      zoneId: string;
+      zoneName: string;
+      price: number;
+   };
+   priceLabel?: string;
+   onRemove: (zoneId: string, seatId: string) => void;
+};
+
+function SelectedSeatSummaryListItem({
+   item,
+   priceLabel = '주말',
+   onRemove,
+}: SelectedSeatSummaryListItemProps) {
+   return (
+      <li className="flex items-center gap-2 rounded-[12px] bg-surface py-4 pl-5 pr-3">
+         <div className="flex min-w-0 flex-1 items-center justify-between gap-5">
+            <div className="min-w-0 flex-1">
+               <p className="overflow-hidden text-body-1-bold text-secondary [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]">
+                  {item.zoneName}
+               </p>
+               <p className="mt-1 text-body-2-regular text-muted-foreground">
+                  {item.seat.block}구역 {item.seat.rowLabel} {item.seat.seatNumber}번
+               </p>
+            </div>
+            <div className="flex shrink-0 items-center justify-end gap-1 whitespace-nowrap">
+               <span className="text-label-2-regular text-muted-foreground">{priceLabel}</span>
+               <span className="text-body-1-bold text-secondary">{formatPrice(item.price)}</span>
+            </div>
+         </div>
+         <button
+            type="button"
+            onClick={() => onRemove(item.zoneId, item.seat.id)}
+            className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-icon-secondary transition-colors hover:bg-fill-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            aria-label={`${item.zoneName} ${item.seat.block}구역 ${item.seat.rowLabel} ${item.seat.seatNumber}번 삭제`}
+         >
+            <X className="h-4 w-4" aria-hidden="true" />
+         </button>
+      </li>
+   );
+}
+
+export default SelectedSeatSummaryListItem;

--- a/src/shared/ui/drawer.tsx
+++ b/src/shared/ui/drawer.tsx
@@ -1,0 +1,278 @@
+import * as React from 'react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
+
+import { cn } from '@/shared/lib/utils';
+
+type DrawerContextValue = {
+   open: boolean;
+   setOpen: (nextOpen: boolean) => void;
+};
+
+const DrawerContext = React.createContext<DrawerContextValue | null>(null);
+
+function useDrawerContext() {
+   const context = React.useContext(DrawerContext);
+
+   if (!context) {
+      throw new Error('Drawer components must be used within Drawer.');
+   }
+
+   return context;
+}
+
+function Drawer({
+   open: openProp,
+   defaultOpen = false,
+   onOpenChange,
+   children,
+   ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+   const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+   const isControlled = openProp !== undefined;
+   const open = isControlled ? openProp : uncontrolledOpen;
+
+   const setOpen = React.useCallback(
+      (nextOpen: boolean) => {
+         if (!isControlled) {
+            setUncontrolledOpen(nextOpen);
+         }
+
+         onOpenChange?.(nextOpen);
+      },
+      [isControlled, onOpenChange],
+   );
+
+   return (
+      <DrawerContext.Provider value={{ open, setOpen }}>
+         <DialogPrimitive.Root open={open} onOpenChange={setOpen} {...props}>
+            {children}
+         </DialogPrimitive.Root>
+      </DrawerContext.Provider>
+   );
+}
+
+function DrawerTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+   return <DialogPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+   return <DialogPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+   return <DialogPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+   return (
+      <DialogPrimitive.Overlay
+         data-slot="drawer-overlay"
+         className={cn(
+            'fixed inset-0 z-50 bg-black/28 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+            className,
+         )}
+         {...props}
+      />
+   );
+}
+
+function DrawerContent({
+   className,
+   children,
+   showOverlay = true,
+   showHandle = true,
+   overlayClassName,
+   resizable = false,
+   defaultHeight = 320,
+   minHeight = 180,
+   maxHeight = 560,
+   ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+   showOverlay?: boolean;
+   showHandle?: boolean;
+   overlayClassName?: string;
+   resizable?: boolean;
+   defaultHeight?: number;
+   minHeight?: number;
+   maxHeight?: number;
+}) {
+   const { open, setOpen } = useDrawerContext();
+   const touchStartYRef = React.useRef<number | null>(null);
+   const [swipeOffset, setSwipeOffset] = React.useState(0);
+   const resizeStartRef = React.useRef<{ pointerId: number; clientY: number; height: number } | null>(null);
+   const [viewportHeight, setViewportHeight] = React.useState(() => (typeof window === 'undefined' ? 0 : window.innerHeight));
+   const resolvedMaxHeight = viewportHeight > 0 ? Math.min(maxHeight, viewportHeight - 32) : maxHeight;
+   const clampedMinHeight = Math.min(minHeight, resolvedMaxHeight);
+   const clampHeight = React.useCallback(
+      (nextHeight: number) => Math.min(resolvedMaxHeight, Math.max(clampedMinHeight, nextHeight)),
+      [clampedMinHeight, resolvedMaxHeight],
+   );
+   const [currentHeight, setCurrentHeight] = React.useState(() => clampHeight(defaultHeight));
+
+   React.useEffect(() => {
+      const handleResize = () => {
+         setViewportHeight(window.innerHeight);
+      };
+
+      handleResize();
+      window.addEventListener('resize', handleResize);
+
+      return () => {
+         window.removeEventListener('resize', handleResize);
+      };
+   }, []);
+
+   React.useEffect(() => {
+      setCurrentHeight((prevHeight) => clampHeight(open ? defaultHeight : prevHeight));
+   }, [clampHeight, defaultHeight, open]);
+
+   return (
+      <DrawerPortal>
+         {showOverlay ? <DrawerOverlay className={overlayClassName} /> : null}
+         <DialogPrimitive.Content
+            data-slot="drawer-content"
+            className={cn(
+               'fixed inset-x-0 bottom-0 z-50 mt-24 rounded-t-[16px] border border-border-light bg-elevated shadow-[0_-6px_24px_rgba(0,0,0,0.16)] outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full',
+               className,
+            )}
+            style={{
+               height: resizable ? `${currentHeight}px` : undefined,
+               maxHeight: resizable ? `${resolvedMaxHeight}px` : undefined,
+               transform: swipeOffset > 0 ? `translateY(${swipeOffset}px)` : undefined,
+               transition: swipeOffset > 0 ? 'none' : undefined,
+            }}
+            onTouchStart={(event) => {
+               if (resizable) {
+                  props.onTouchStart?.(event);
+                  return;
+               }
+
+               touchStartYRef.current = event.touches[0]?.clientY ?? null;
+               props.onTouchStart?.(event);
+            }}
+            onTouchMove={(event) => {
+               if (resizable) {
+                  props.onTouchMove?.(event);
+                  return;
+               }
+
+               if (touchStartYRef.current === null) {
+                  props.onTouchMove?.(event);
+                  return;
+               }
+
+               const currentY = event.touches[0]?.clientY ?? touchStartYRef.current;
+               setSwipeOffset(Math.max(0, currentY - touchStartYRef.current));
+               props.onTouchMove?.(event);
+            }}
+            onTouchEnd={(event) => {
+               if (resizable) {
+                  props.onTouchEnd?.(event);
+                  return;
+               }
+
+               if (swipeOffset > 84) {
+                  setOpen(false);
+               }
+
+               touchStartYRef.current = null;
+               setSwipeOffset(0);
+               props.onTouchEnd?.(event);
+            }}
+            {...props}
+         >
+            {showHandle ? (
+               <div
+                  className={cn('flex justify-center pt-[10px]', resizable ? 'touch-none cursor-row-resize' : '')}
+                  aria-hidden="true"
+                  onPointerDown={(event) => {
+                     if (!resizable) {
+                        return;
+                     }
+
+                     resizeStartRef.current = {
+                        pointerId: event.pointerId,
+                        clientY: event.clientY,
+                        height: currentHeight,
+                     };
+                     event.currentTarget.setPointerCapture(event.pointerId);
+                  }}
+                  onPointerMove={(event) => {
+                     if (!resizable || !resizeStartRef.current || resizeStartRef.current.pointerId !== event.pointerId) {
+                        return;
+                     }
+
+                     const deltaY = resizeStartRef.current.clientY - event.clientY;
+                     setCurrentHeight(clampHeight(resizeStartRef.current.height + deltaY));
+                  }}
+                  onPointerUp={(event) => {
+                     if (!resizable || !resizeStartRef.current || resizeStartRef.current.pointerId !== event.pointerId) {
+                        return;
+                     }
+
+                     const dragDistance = event.clientY - resizeStartRef.current.clientY;
+                     const isNearMinimum = currentHeight <= clampedMinHeight + 24;
+
+                     if (dragDistance > 80 && isNearMinimum) {
+                        setOpen(false);
+                     }
+
+                     resizeStartRef.current = null;
+                     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+                        event.currentTarget.releasePointerCapture(event.pointerId);
+                     }
+                  }}
+                  onPointerCancel={(event) => {
+                     if (!resizable) {
+                        return;
+                     }
+
+                     resizeStartRef.current = null;
+                     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+                        event.currentTarget.releasePointerCapture(event.pointerId);
+                     }
+                  }}
+               >
+                  <div className="h-1 w-9 rounded-full bg-border-light" />
+               </div>
+            ) : null}
+            {children}
+         </DialogPrimitive.Content>
+      </DrawerPortal>
+   );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
+   return <div data-slot="drawer-header" className={cn('flex flex-col p-5', className)} {...props} />;
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
+   return <div data-slot="drawer-footer" className={cn('p-5 pt-0', className)} {...props} />;
+}
+
+function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+   return <DialogPrimitive.Title data-slot="drawer-title" className={cn('text-heading-3-bold text-foreground', className)} {...props} />;
+}
+
+function DrawerDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
+   return (
+      <DialogPrimitive.Description
+         data-slot="drawer-description"
+         className={cn('text-body-2-regular text-muted-foreground', className)}
+         {...props}
+      />
+   );
+}
+
+export {
+   Drawer,
+   DrawerClose,
+   DrawerContent,
+   DrawerDescription,
+   DrawerFooter,
+   DrawerHeader,
+   DrawerOverlay,
+   DrawerPortal,
+   DrawerTitle,
+   DrawerTrigger,
+};

--- a/src/shared/widgets/layout/books/BooksHeader.tsx
+++ b/src/shared/widgets/layout/books/BooksHeader.tsx
@@ -91,6 +91,7 @@ const BooksHeader = ({
    const mm = String(Math.floor(remainingSeconds / 60)).padStart(2, '0');
    const ss = String(remainingSeconds % 60).padStart(2, '0');
    const timeStr = `${mm}:${ss}`;
+   const currentStepLabel = steps[resolvedCurrentStepIndex] ?? '';
 
    useEffect(() => {
       if (!showTimer || expiresAt === null || remainingSeconds > 0) {
@@ -137,7 +138,46 @@ const BooksHeader = ({
          />
 
          <header className="border-b border-border-light bg-background">
-            <div className="flex h-16 items-center justify-between px-4 lg:h-[68px] lg:px-8">
+            <div className="lg:hidden">
+               <div className="relative flex items-center justify-between px-3 py-2">
+                  <div className="flex w-10 justify-start">
+                     {shouldShowBackButton ? (
+                        <button
+                           type="button"
+                           aria-label={backAriaLabel}
+                           onClick={() => {
+                              if (onBack) {
+                                 onBack();
+                                 return;
+                              }
+
+                              navigate(-1);
+                           }}
+                           className="inline-flex h-8 w-8 items-center justify-center rounded-md text-icon-secondary"
+                        >
+                           <ChevronLeft className="h-6 w-6" aria-hidden="true" />
+                        </button>
+                     ) : null}
+                  </div>
+                  <h1 className="absolute left-1/2 -translate-x-1/2 text-heading-4-bold text-foreground">
+                     {currentStepLabel}
+                  </h1>
+                  <div className="flex w-10 justify-end">
+                     {showTimer ? <span className="text-body-1-bold text-primary">{timeStr}</span> : null}
+                  </div>
+               </div>
+
+               <div className="border-b border-border-light px-5 py-[9px]">
+                  <p className="text-body-1-bold text-foreground">{matchTitle}</p>
+                  <div className="flex flex-wrap items-center gap-1 text-caption-1-medium text-secondary">
+                     <span>{venue}</span>
+                     <span aria-hidden="true">·</span>
+                     <span>{dateTime}</span>
+                  </div>
+               </div>
+            </div>
+
+            <div className="hidden h-16 items-center justify-between px-4 lg:flex lg:h-[68px] lg:px-8">
                <button
                   type="button"
                   className="text-heading-4-bold tracking-tight text-foreground"
@@ -173,7 +213,7 @@ const BooksHeader = ({
                </div>
             </div>
 
-            <div className="flex flex-col gap-4 border-t border-border-light px-4 py-4 lg:h-[72px] lg:flex-row lg:items-center lg:justify-between lg:gap-6 lg:px-8 lg:py-0">
+            <div className="hidden flex-col gap-4 border-t border-border-light px-4 py-4 lg:flex lg:h-[72px] lg:flex-row lg:items-center lg:justify-between lg:gap-6 lg:px-8 lg:py-0">
                <div className="flex flex-wrap items-center gap-2 text-body-1-medium text-muted-foreground">
                   {shouldShowBackButton ? (
                      <button


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #102

<br/>

## 🔎 개요
예매 플로우의 모바일/데스크톱 UI를 Figma 기준으로 정리했습니다. 

<br/>

## 📋 작업 내용
- 모바일 예매 페이지에 Drawer 기반 구역 선택 UI를 추가
- BookingZoneList에 panel / drawer 변형을 도입해 모바일과 PC에서 재사용할 수 있도록 정리
- BookingZoneMap에 모바일 확장 상태 대응 UI를 추가해드로어 열림 여부에 따라 맵 노출 높이와 크기를 조정
- SeatsPage의 선택 좌석 리스트를 SelectedSeatSummaryList SelectedSeatSummaryListItem 컴포넌트
- 선택 좌석 리스트 아이템 UI를 Figma 기준으로 갱신
- BooksHeader의 모바일 레이아웃을 별도 분리해 뒤로가기 / 단계명 / 타이머 + 경기 정보 구조로 통일화
- 좌석 선택 맵이 모바일과 PC 모두 초기 100% 배율에서도 드래그로 이동 가능하도록 수정


<br/>
