### PR TITLE
[bug] 로그인 만료 안내 팝업창 볼드 미처리 버그

### DIFF
--- a/src/shared/widgets/layout/auth/SessionTimeoutDialog.tsx
+++ b/src/shared/widgets/layout/auth/SessionTimeoutDialog.tsx
@@ -15,7 +15,7 @@ const SessionTimeoutDialog = ({ open, onConfirm }: SessionTimeoutDialogProps) =>
             className="w-[335px] max-w-[calc(100%-40px)] gap-0 rounded-2xl border-0 p-0 shadow-xl"
          >
             <DialogHeader className="px-5 py-5 pb-0 text-left">
-               <DialogTitle align="left" className="text-[18px] leading-[1.55] text-(--text-primary)">
+               <DialogTitle align="left" className="text-heading-4-bold font-bold text-(--text-primary)">
                   로그인 유지 시간이 만료되었어요
                </DialogTitle>
                <DialogDescription align="left" className="text-body-2-regular leading-6 text-(--text-secondary)">


### PR DESCRIPTION
## #️⃣ 관련 이슈
- 로그인 만료 안내 팝업창의 제목의 글귀에 볼드처리가 안 되어 있던 버그
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->

<br/>

## 🔎 개요
- 직접 명시하여 글씨 볼드 처리 완료

<br/>

## 📋 작업 내용
- 팝업창 제목 볼드처리

<br/>
