### PR TITLE
[feat] 소셜 회원가입 mock 응답 검증 강화

### DIFF
--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -35,10 +35,16 @@ export const loginWithSocialVerifyToken = async (payload: {
 export const signupWithSocialVerifyToken = async (
   payload: SocialSignupParams,
 ): Promise<AuthTokenResponse> => {
+  // 회원가입 상세 스펙은 doc/auth-api.md에 아직 비어 있으므로,
+  // 현재 서버와 맞춰진 프론트 payload를 유지하되 응답 형식은 엄격히 검증한다.
   const response = await apiClient.post<ApiEnvelope<AuthTokenResponse>>(
     "/api/v1/auth/signup",
     payload,
   );
+
+  if (!response.data.data?.accessToken) {
+    throw new Error("회원가입 응답에 accessToken이 없습니다. auth signup 스펙 확인이 필요합니다.");
+  }
 
   return response.data.data;
 };

--- a/src/shared/api/mocks/handlers/auth.ts
+++ b/src/shared/api/mocks/handlers/auth.ts
@@ -1,108 +1,198 @@
-import { http, HttpResponse } from "msw";
+import { http, HttpResponse } from 'msw';
+
+type MockAuthSession = {
+   provider: string;
+   isRegistered: boolean;
+   userId: string;
+   mobile?: string;
+   smsCode?: string;
+};
+
+const mockAuthSessions = new Map<string, MockAuthSession>();
+
+const createId = (prefix: string) => {
+   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `${prefix}-${crypto.randomUUID()}`;
+   }
+
+   return `${prefix}-${Date.now()}`;
+};
+
+const encodeBase64Url = (value: string) => {
+   if (typeof btoa === 'function') {
+      return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+   }
+
+   throw new Error('Base64 encoding is not available in the current environment.');
+};
+
+const buildMockAccessToken = (payload: Record<string, unknown>) => {
+   const header = encodeBase64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+   const body = encodeBase64Url(JSON.stringify(payload));
+   const signature = encodeBase64Url('mock-signature');
+
+   return `${header}.${body}.${signature}`;
+};
+
+const resolveRegisteredState = (authCode: string) => {
+   return !/(signup|register|join|new)/i.test(authCode);
+};
 
 export const authHandlers = [
-  http.get("/api/v1/auth/:provider/state", async ({ params }) => {
-    const { provider } = params;
-    const state = `${provider}-state-token`;
+   http.get('/api/v1/auth/:provider/state', async ({ params }) => {
+      const provider = String(params.provider ?? '').toUpperCase();
 
-    return HttpResponse.json({
-      code: "SUCCESS",
-      message: "ok",
-      data: { state },
-    });
-  }),
-  http.post("/api/v1/auth/:provider/social/verify", async ({ params, request }) => {
-    const provider = params.provider;
-    const body = (await request.json()) as {
-      authCode?: string;
-      state?: string;
-    };
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            state: `${provider}-state-token`,
+         },
+      });
+   }),
 
-    const requiresState = provider === "NAVER" || provider === "GOOGLE";
+   http.post('/api/v1/auth/:provider/social/verify', async ({ params, request }) => {
+      const provider = String(params.provider ?? '').toUpperCase();
+      const body = (await request.json()) as {
+         authCode?: string;
+         state?: string;
+      };
 
-    if (!body?.authCode || (requiresState && !body?.state)) {
-      return HttpResponse.json(
-        { message: "Missing social verify fields." },
-        { status: 400 },
-      );
-    }
+      const requiresState = provider === 'NAVER' || provider === 'GOOGLE';
 
-    return HttpResponse.json({
-      code: "SUCCESS",
-      message: "ok",
-      data: {
-        isRegistered: false,
-        socialVerifyToken: `svt-${body.authCode}`,
-      },
-    });
-  }),
-  http.post("/api/v1/auth/login", async ({ request }) => {
-    const body = (await request.json()) as { socialVerifyToken?: string };
+      if (!body?.authCode || (requiresState && !body?.state)) {
+         return HttpResponse.json({ message: 'Missing social verify fields.' }, { status: 400 });
+      }
 
-    if (!body?.socialVerifyToken) {
-      return HttpResponse.json(
-        { message: "Missing social verify token." },
-        { status: 400 },
-      );
-    }
+      const socialVerifyToken = createId('svt');
+      const isRegistered = resolveRegisteredState(body.authCode);
+      const userId = createId('user');
 
-    return HttpResponse.json({
-      code: "SUCCESS",
-      message: "ok",
-      data: {
-        accessToken: "access-token-from-login",
-      },
-    });
-  }),
-  http.post("/api/v1/auth/signup", async ({ request }) => {
-    const body = (await request.json()) as {
-      socialVerifyToken?: string;
-      name?: string;
-      gender?: string;
-      mobile?: string;
-      birthDate?: string;
-      authCode?: string;
-    };
+      mockAuthSessions.set(socialVerifyToken, {
+         provider,
+         isRegistered,
+         userId,
+      });
 
-    if (
-      !body?.socialVerifyToken ||
-      !body?.name ||
-      !body?.gender ||
-      !body?.mobile ||
-      !body?.birthDate ||
-      !body?.authCode
-    ) {
-      return HttpResponse.json(
-        { message: "Missing signup fields." },
-        { status: 400 },
-      );
-    }
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            isRegistered,
+            socialVerifyToken,
+         },
+      });
+   }),
 
-    return HttpResponse.json({
-      code: "SUCCESS",
-      message: "ok",
-      data: {
-        accessToken: "access-token-from-signup",
-      },
-    });
-  }),
-  http.post("/api/v1/auth/signup/sms/send", async ({ request }) => {
-    const body = (await request.json()) as {
-      socialVerifyToken?: string;
-      mobile?: string;
-    };
+   http.post('/api/v1/auth/login', async ({ request }) => {
+      const body = (await request.json()) as { socialVerifyToken?: string };
 
-    if (!body?.socialVerifyToken || !body?.mobile) {
-      return HttpResponse.json(
-        { message: "Missing sms send fields." },
-        { status: 400 },
-      );
-    }
+      if (!body?.socialVerifyToken) {
+         return HttpResponse.json({ message: 'Missing social verify token.' }, { status: 400 });
+      }
 
-    return HttpResponse.json({
-      code: "SUCCESS",
-      message: "ok",
-      data: "SMS sent",
-    });
-  }),
+      const session = mockAuthSessions.get(body.socialVerifyToken);
+
+      if (!session) {
+         return HttpResponse.json({ message: 'Invalid social verify token.' }, { status: 401 });
+      }
+
+      if (!session.isRegistered) {
+         return HttpResponse.json({ message: 'Signup is required for this account.' }, { status: 409 });
+      }
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            accessToken: buildMockAccessToken({
+               sub: session.userId,
+               userId: session.userId,
+               provider: session.provider,
+            }),
+         },
+      });
+   }),
+
+   http.post('/api/v1/auth/signup/sms/send', async ({ request }) => {
+      const body = (await request.json()) as {
+         socialVerifyToken?: string;
+         mobile?: string;
+      };
+
+      if (!body?.socialVerifyToken || !body?.mobile) {
+         return HttpResponse.json({ message: 'Missing sms send fields.' }, { status: 400 });
+      }
+
+      const session = mockAuthSessions.get(body.socialVerifyToken);
+
+      if (!session) {
+         return HttpResponse.json({ message: 'Invalid social verify token.' }, { status: 401 });
+      }
+
+      if (session.isRegistered) {
+         return HttpResponse.json({ message: 'Existing member does not require signup SMS.' }, { status: 409 });
+      }
+
+      const smsCode = '123456';
+      mockAuthSessions.set(body.socialVerifyToken, {
+         ...session,
+         mobile: body.mobile,
+         smsCode,
+      });
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: smsCode,
+      });
+   }),
+
+   http.post('/api/v1/auth/signup', async ({ request }) => {
+      const body = (await request.json()) as {
+         socialVerifyToken?: string;
+         name?: string;
+         gender?: string;
+         mobile?: string;
+         birthDate?: string;
+         authCode?: string;
+      };
+
+      if (!body?.socialVerifyToken || !body?.name || !body?.gender || !body?.mobile || !body?.birthDate || !body?.authCode) {
+         return HttpResponse.json({ message: 'Missing signup fields.' }, { status: 400 });
+      }
+
+      const session = mockAuthSessions.get(body.socialVerifyToken);
+
+      if (!session) {
+         return HttpResponse.json({ message: 'Invalid social verify token.' }, { status: 401 });
+      }
+
+      if (session.isRegistered) {
+         return HttpResponse.json({ message: 'This account is already registered.' }, { status: 409 });
+      }
+
+      if (!session.smsCode || session.smsCode !== body.authCode) {
+         return HttpResponse.json({ message: 'Invalid SMS verification code.' }, { status: 400 });
+      }
+
+      mockAuthSessions.set(body.socialVerifyToken, {
+         ...session,
+         isRegistered: true,
+         mobile: body.mobile,
+      });
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            accessToken: buildMockAccessToken({
+               sub: session.userId,
+               userId: session.userId,
+               mobile: body.mobile,
+               name: body.name,
+            }),
+         },
+      });
+   }),
 ];


### PR DESCRIPTION
## #️⃣ 관련 이슈

- #116

<br/>

## 🔎 개요

소셜 회원가입 플로우에서 mock 응답의 정합성을 높이고, 회원가입 응답이 기대값과 다를 때 프론트에서 바로 감지할 수 있도록 응답 검증을 강화했습니다.

<br/>

## 📋 작업 내용

- 소셜 로그인 검증 이후 mock 세션을 유지하도록 auth MSW 핸들러를 보강했습니다.
- 회원 여부에 따라 로그인/회원가입 분기를 더 정확하게 처리하도록 mock 응답을 정리했습니다.
- SMS 인증 발송 및 회원가입 완료 시나리오를 연속된 세션 기준으로 검증할 수 있게 수정했습니다.
- `signupWithSocialVerifyToken`에서 `accessToken` 누락 시 명시적으로 에러를 던지도록 응답 검증을 추가했습니다.
- `doc/auth-api.md` 기준으로 상세 스펙이 비어 있는 부분은 코드 주석으로 불확실성을 남겼습니다.

<br/>
