### PR TITLE
[feat] 경기 일정 API 및 MSW 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,10 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,8 +7,8 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '<PACKAGE_VERSION>'
-const INTEGRITY_CHECKSUM = '<INTEGRITY_CHECKSUM>'
+const PACKAGE_VERSION = '2.12.7'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 

--- a/src/entities/game/api/scheduleApi.ts
+++ b/src/entities/game/api/scheduleApi.ts
@@ -1,0 +1,36 @@
+import apiClient from '@/shared/api/client';
+import type { ApiEnvelope } from '@/features/auth/api/types';
+
+export type FetchGameSchedulesParams = {
+  year?: number;
+  month?: number;
+  today?: boolean;
+};
+
+export type GameScheduleResponse = {
+  gameId: string;
+  startAt: string;
+  leagueType: string;
+  homeTeamId: string;
+  awayTeamId: string;
+  stadiumId: string;
+  gameStatus: string;
+  homeTeamScore: number;
+  awayTeamScore: number;
+  gameResult: string;
+  ticketingStatus: string;
+  ticketingOpenedAt?: string;
+  ticketingEndAt?: string;
+};
+
+export const fetchGameSchedules = async (params: FetchGameSchedulesParams = {}) => {
+  const response = await apiClient.get<ApiEnvelope<GameScheduleResponse[]>>('/api/v1/games/schedules', {
+    params: {
+      year: params.year,
+      month: params.month,
+      today: params.today,
+    },
+  });
+
+  return response.data.data;
+};

--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -1,0 +1,290 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { buildMockQueueTokenJti } from '@/shared/config/booking';
+import { fetchGameSchedules, type FetchGameSchedulesParams, type GameScheduleResponse } from '@/entities/game/api/scheduleApi';
+import type { DaySchedule, GameRow, GameStatus, ReselStatus, TicketStatus } from '@/pages/home/ui/game-schedule/types';
+
+export type NormalizedScheduleGame = {
+  id: string;
+  serverHomeTeamId: string;
+  serverAwayTeamId: string;
+  homeTeamId?: string;
+  awayTeamId?: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  homeTeamFullName: string;
+  awayTeamFullName: string;
+  date: string;
+  dateLabel: string;
+  time: string;
+  venue: string;
+  stadiumId?: string;
+  queueTokenJti?: string;
+  score: string | null;
+  status: GameStatus;
+  ticket: TicketStatus;
+  resell: ReselStatus;
+  ticketInfo?: string;
+  reselInfo?: string;
+  isToday: boolean;
+  ticketingOpenedAt?: string;
+};
+
+type TeamReference = {
+  frontendId: string;
+  shortName: string;
+  fullName: string;
+  aliases: string[];
+};
+
+const TEAM_REFERENCES: TeamReference[] = [
+  { frontendId: 'kia', shortName: 'KIA', fullName: 'KIA 타이거즈', aliases: ['kia', 'teamkia', 'kiatigers', '기아', '기아타이거즈'] },
+  { frontendId: 'samsung', shortName: '삼성', fullName: '삼성 라이온즈', aliases: ['samsung', 'teamsamsung', '삼성', '삼성라이온즈'] },
+  { frontendId: 'lg', shortName: 'LG', fullName: 'LG 트윈스', aliases: ['lg', 'teamlg', 'lgtwins', '엘지', '엘지트윈스', 'lg트윈스'] },
+  { frontendId: 'hanwha', shortName: '한화', fullName: '한화 이글스', aliases: ['hanwha', 'teamhanwha', '한화', '한화이글스'] },
+  { frontendId: 'ssg', shortName: 'SSG', fullName: 'SSG 랜더스', aliases: ['ssg', 'teamssg', 'ssglanders', '랜더스', 'ssg랜더스'] },
+  { frontendId: 'nc', shortName: 'NC', fullName: 'NC 다이노스', aliases: ['nc', 'teamnc', 'ncdinos', 'nc다이노스'] },
+  { frontendId: 'kt', shortName: 'KT', fullName: 'KT wiz', aliases: ['kt', 'teamkt', 'ktwiz', '케이티', '케이티위즈'] },
+  { frontendId: 'lotte', shortName: '롯데', fullName: '롯데 자이언츠', aliases: ['lotte', 'teamlotte', '롯데', '롯데자이언츠'] },
+  { frontendId: 'doosan', shortName: '두산', fullName: '두산 베어스', aliases: ['doosan', 'teamdoosan', '두산', '두산베어스'] },
+  { frontendId: 'kiwoom', shortName: '키움', fullName: '키움 히어로즈', aliases: ['kiwoom', 'teamkiwoom', '키움', '키움히어로즈'] },
+];
+
+const STADIUM_NAME_BY_ID: Record<string, string> = {
+  'stadium-jamsil-baseball': '잠실',
+  'stadium-samsung-lions-park': '대구',
+  'stadium-sajik-baseball': '사직',
+  'stadium-changwon-nc-park': '창원',
+  'stadium-gocheok-skydome': '고척',
+  'stadium-kia-champions-field': '광주',
+  'stadium-kt-wiz-park': '수원',
+  'stadium-daejeon-baseball': '대전',
+  'stadium-incheon-landers-field': '인천',
+};
+
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
+
+const normalizeLookupValue = (value: string) => value.toLowerCase().replace(/[\s\-_./()]/g, '');
+
+const findTeamReference = (teamId: string) => {
+  const normalized = normalizeLookupValue(teamId);
+  return TEAM_REFERENCES.find((reference) => reference.aliases.some((alias) => normalizeLookupValue(alias) === normalized));
+};
+
+const parseApiDateTime = (value: string) => {
+  const [date = '', time = ''] = value.trim().split(' ');
+  return { date, time: time.slice(0, 5) };
+};
+
+const toDateLabel = (date: string) => {
+  const [year, month, day] = date.split('-').map(Number);
+
+  if (!year || !month || !day) {
+    return date;
+  }
+
+  const parsed = new Date(year, month - 1, day);
+  return `${month}월 ${day}일 (${DAY_LABELS[parsed.getDay()]})`;
+};
+
+const formatOpenedAtInfo = (value?: string) => {
+  if (!value) {
+    return undefined;
+  }
+
+  const [date = '', time = ''] = value.split(' ');
+  const [, month = '', day = ''] = date.split('-');
+  const [hour = '', minute = ''] = time.split(':');
+  const meridiem = Number(hour) < 12 ? '오전' : '오후';
+  const displayHour = (() => {
+    const numericHour = Number(hour);
+    if (!Number.isFinite(numericHour)) {
+      return hour;
+    }
+
+    const converted = numericHour % 12;
+    return String(converted === 0 ? 12 : converted);
+  })();
+
+  return `${Number(month)}월 ${Number(day)}일\n${meridiem} ${displayHour}시${minute ? ` ${minute}분` : ''} 오픈`;
+};
+
+const mapGameStatus = (value: string): GameStatus => {
+  switch (value.toUpperCase()) {
+    case 'FINISHED':
+      return '종료';
+    case 'CANCELED':
+    case 'CANCELLED':
+      return '취소';
+    case 'IN_PROGRESS':
+    case 'LIVE':
+      return '경기중';
+    default:
+      return '예정';
+  }
+};
+
+const mapTicketStatus = (value: string): TicketStatus => {
+  switch (value.toUpperCase()) {
+    case 'AVAILABLE':
+    case 'OPEN':
+      return '예매하기';
+    case 'SOLD_OUT':
+    case 'CLOSED':
+    case 'ENDED':
+      return '매진';
+    default:
+      return '판매예정';
+  }
+};
+
+const mapResellStatus = (ticketStatus: TicketStatus): ReselStatus => {
+  switch (ticketStatus) {
+    case '예매하기':
+      return '리셀예매';
+    case '매진':
+      return '리셀매진';
+    default:
+      return '리셀예정';
+  }
+};
+
+const resolveVenueName = (stadiumId: string, homeTeamName: string) => {
+  return STADIUM_NAME_BY_ID[stadiumId] ?? homeTeamName;
+};
+
+const isSameCalendarDate = (date: string, target: Date) => {
+  const [year, month, day] = date.split('-').map(Number);
+
+  return (
+    target.getFullYear() === year &&
+    target.getMonth() + 1 === month &&
+    target.getDate() === day
+  );
+};
+
+const normalizeScheduleGame = (game: GameScheduleResponse): NormalizedScheduleGame => {
+  const { date, time } = parseApiDateTime(game.startAt);
+  const homeTeam = findTeamReference(game.homeTeamId);
+  const awayTeam = findTeamReference(game.awayTeamId);
+  const status = mapGameStatus(game.gameStatus);
+  const ticket = mapTicketStatus(game.ticketingStatus);
+
+  return {
+    id: game.gameId,
+    serverHomeTeamId: game.homeTeamId,
+    serverAwayTeamId: game.awayTeamId,
+    homeTeamId: homeTeam?.frontendId,
+    awayTeamId: awayTeam?.frontendId,
+    homeTeamName: homeTeam?.shortName ?? game.homeTeamId,
+    awayTeamName: awayTeam?.shortName ?? game.awayTeamId,
+    homeTeamFullName: homeTeam?.fullName ?? game.homeTeamId,
+    awayTeamFullName: awayTeam?.fullName ?? game.awayTeamId,
+    date,
+    dateLabel: toDateLabel(date),
+    time,
+    venue: resolveVenueName(game.stadiumId, homeTeam?.shortName ?? game.homeTeamId),
+    stadiumId: game.stadiumId,
+    queueTokenJti: buildMockQueueTokenJti(game.gameId),
+    score: status === '종료' ? `${game.awayTeamScore}:${game.homeTeamScore}` : null,
+    status,
+    ticket,
+    resell: mapResellStatus(ticket),
+    ticketInfo: ticket === '판매예정' ? formatOpenedAtInfo(game.ticketingOpenedAt) : undefined,
+    reselInfo: ticket === '판매예정' ? '정식 예매 오픈 후\n리셀 오픈 예정' : undefined,
+    isToday: isSameCalendarDate(date, new Date()),
+    ticketingOpenedAt: game.ticketingOpenedAt,
+  };
+};
+
+const sortByStartAt = (left: NormalizedScheduleGame, right: NormalizedScheduleGame) => {
+  const leftKey = `${left.date} ${left.time}`;
+  const rightKey = `${right.date} ${right.time}`;
+  return leftKey.localeCompare(rightKey);
+};
+
+export const mapGamesToDaySchedules = (games: NormalizedScheduleGame[]): DaySchedule[] => {
+  const grouped = new Map<string, DaySchedule>();
+
+  [...games].sort(sortByStartAt).forEach((game) => {
+    const row: GameRow = {
+      gameId: game.id,
+      homeTeamId: game.homeTeamId,
+      awayTeamId: game.awayTeamId,
+      stadiumId: game.stadiumId,
+      queueTokenJti: game.queueTokenJti,
+      time: game.time,
+      venue: game.venue,
+      away: game.awayTeamName,
+      home: game.homeTeamName,
+      score: game.score,
+      status: game.status,
+      ticket: game.ticket,
+      resell: game.resell,
+      ticketInfo: game.ticketInfo,
+      reselInfo: game.reselInfo,
+    };
+
+    const current = grouped.get(game.date);
+
+    if (current) {
+      current.games.push(row);
+      return;
+    }
+
+    grouped.set(game.date, {
+      year: Number(game.date.slice(0, 4)),
+      date: game.dateLabel,
+      isToday: game.isToday,
+      games: [row],
+    });
+  });
+
+  return Array.from(grouped.values());
+};
+
+export const getClosestMatch = (games: NormalizedScheduleGame[], teamId: string) => {
+  const now = new Date();
+  const currentDayKey = now.toISOString().slice(0, 10);
+
+  return [...games]
+    .filter((game) => game.homeTeamId === teamId || game.awayTeamId === teamId)
+    .filter((game) => game.date >= currentDayKey)
+    .sort(sortByStartAt)[0] ?? null;
+};
+
+export const getDDay = (date: string) => {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const [year, month, day] = date.split('-').map(Number);
+  const target = new Date(year, month - 1, day);
+  const diffDays = Math.round((target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'D-DAY';
+  if (diffDays > 0) return `D-${diffDays}`;
+  return `D+${Math.abs(diffDays)}`;
+};
+
+export const getPopularMatches = (games: NormalizedScheduleGame[], limit = 5) => {
+  return [...games]
+    .filter((game) => game.status === '예정')
+    .sort((left, right) => {
+      if (left.ticket !== right.ticket) {
+        if (left.ticket === '예매하기') return -1;
+        if (right.ticket === '예매하기') return 1;
+      }
+
+      return sortByStartAt(left, right);
+    })
+    .slice(0, limit);
+};
+
+export const useGameSchedules = (params: FetchGameSchedulesParams = {}) => {
+  return useQuery({
+    queryKey: ['game-schedules', params.year ?? null, params.month ?? null, params.today ?? null],
+    queryFn: async () => {
+      const schedules = await fetchGameSchedules(params);
+      return schedules.map(normalizeScheduleGame).sort(sortByStartAt);
+    },
+  });
+};

--- a/src/pages/home/ui/FavoriteTeamMatchCard.tsx
+++ b/src/pages/home/ui/FavoriteTeamMatchCard.tsx
@@ -5,13 +5,14 @@ import { Link } from 'react-router-dom';
 
 import { teams } from '@/entities/team/model/teams';
 import type { Team } from '@/entities/team/model/types';
-import { getClosestMatch, getDDay } from '@/entities/team/model/schedule';
+import { getClosestMatch, getDDay, useGameSchedules } from '@/entities/game/model/schedule';
 import { Button } from '@/shared/ui/button';
 import { useBookingEntryFlow } from '@/shared/lib/use-booking-entry-flow';
 
 const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
    const { openBookingEntry, bookingGuideDialog } = useBookingEntryFlow();
-   const match = getClosestMatch(team.id);
+   const { data } = useGameSchedules();
+   const match = getClosestMatch(data ?? [], team.id);
 
    /** 헤더 — 경기 없을 때도 공통 사용 */
    const Header = (
@@ -51,14 +52,20 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
 
    const isHome = match.homeTeamId === team.id;
    const opponentId = isHome ? match.awayTeamId : match.homeTeamId;
-   const opponent = teams.find(t => t.id === opponentId) ?? teams[0];
+   const opponent = teams.find(t => t.id === opponentId) ?? {
+      id: opponentId ?? 'unknown',
+      name: isHome ? match.awayTeamFullName : match.homeTeamFullName,
+      logoSrc: '/Icon/Line/Baseball.svg',
+      logoAspectClassName: 'aspect-square',
+      isEnabled: false,
+   };
    // 응원팀은 항상 좌측(HOME) 위치에 표시
    const homeTeam = team;
    const awayTeam = opponent;
    const dDay = getDDay(match.date);
    const formattedDate = `${match.date.replace(/-/g, '.')} ${match.time}`;
-   const awayTeamName = teams.find(t => t.id === match.awayTeamId)?.name ?? match.awayTeamId;
-   const homeTeamName = teams.find(t => t.id === match.homeTeamId)?.name ?? match.homeTeamId;
+   const awayTeamName = match.awayTeamFullName;
+   const homeTeamName = match.homeTeamFullName;
 
    const handleBookingClick = () => {
       openBookingEntry({

--- a/src/pages/home/ui/GameSchedule.tsx
+++ b/src/pages/home/ui/GameSchedule.tsx
@@ -1,6 +1,7 @@
 // src/pages/home/ui/GameSchedule.tsx
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useGameSchedules, mapGamesToDaySchedules } from '@/entities/game/model/schedule';
 
 import {
    AVAILABLE_YEARS,
@@ -10,7 +11,6 @@ import {
    TAB_ALL,
    TAB_TODAY,
    TAB_WEEK,
-   scheduleData,
    tabs,
 } from './game-schedule/constants';
 import AllNavigator from './game-schedule/AllNavigator';
@@ -29,6 +29,20 @@ const GameSchedule = () => {
 
    const [allYear, setAllYear] = useState(CURRENT_YEAR);
    const [allMonth, setAllMonth] = useState(CURRENT_MONTH);
+
+   const scheduleQuery = useGameSchedules(
+      activeTab === TAB_TODAY
+         ? { today: true }
+         : {
+              year: activeTab === TAB_WEEK ? weekYear : allYear,
+              month: activeTab === TAB_WEEK ? weekMonth : allMonth,
+           },
+   );
+
+   const scheduleData = useMemo(
+      () => mapGamesToDaySchedules(scheduleQuery.data ?? []),
+      [scheduleQuery.data],
+   );
 
    const filteredData = useMemo(
       () =>
@@ -129,7 +143,13 @@ const GameSchedule = () => {
                />
             )}
 
-            <ScheduleList activeTab={activeTab} filteredData={filteredData} />
+            {scheduleQuery.isError ? (
+               <div className="rounded-[10px] border border-border bg-surface px-5 py-10 text-center text-body-1-medium text-muted-foreground">
+                  경기 일정을 불러오지 못했습니다.
+               </div>
+            ) : (
+               <ScheduleList activeTab={activeTab} filteredData={filteredData} />
+            )}
          </div>
       </section>
    );

--- a/src/pages/home/ui/PopularGames.tsx
+++ b/src/pages/home/ui/PopularGames.tsx
@@ -1,34 +1,13 @@
 import { Calendar, MapPin } from 'lucide-react';
-import { getPopularMatches } from '@/entities/team/model/schedule';
-
-const teamDisplayName: Record<string, string> = {
-   kia: 'KIA',
-   samsung: '삼성',
-   lg: 'LG',
-   lotte: '롯데',
-   doosan: '두산',
-   hanwha: '한화',
-   nc: 'NC',
-   kt: 'KT',
-   kiwoom: '키움',
-   ssg: 'SSG',
-};
-
-const teamLogoPath: Record<string, string> = {
-   kia: '/baseball/logos/kia.png',
-   samsung: '/baseball/logos/samsung.png',
-   lg: '/baseball/logos/lg.png',
-   lotte: '/baseball/logos/lotte.png',
-   doosan: '/baseball/logos/doosan.png',
-   hanwha: '/baseball/logos/hanwha.png',
-   nc: '/baseball/logos/nc.png',
-   kt: '/baseball/logos/kt.png',
-   kiwoom: '/baseball/logos/kiwoom.png',
-   ssg: '/baseball/logos/ssg.png',
-};
+import { getPopularMatches, useGameSchedules } from '@/entities/game/model/schedule';
 
 const PopularGames = () => {
-   const matches = getPopularMatches(5);
+   const { data } = useGameSchedules();
+   const matches = getPopularMatches(data ?? [], 5);
+
+   if (!data) {
+      return null;
+   }
 
    return (
       <section className="flex flex-col gap-5 w-full">
@@ -66,11 +45,11 @@ const PopularGames = () => {
                      {/* 팀 매치업 */}
                      <div className="flex items-center justify-between h-7">
                         <span className="w-17.5 text-[18px] font-bold leading-[1.55] text-foreground">
-                           {teamDisplayName[match.awayTeamId]}
+                           {match.awayTeamName}
                         </span>
                         <span className="text-[14px] font-bold text-(--text-tertiary)">vs</span>
                         <span className="w-17.5 text-[18px] font-bold leading-[1.55] text-foreground text-right">
-                           {teamDisplayName[match.homeTeamId]}
+                           {match.homeTeamName}
                         </span>
                      </div>
 

--- a/src/pages/home/ui/game-schedule/ScheduleList.tsx
+++ b/src/pages/home/ui/game-schedule/ScheduleList.tsx
@@ -3,7 +3,7 @@ import { TicketX } from 'lucide-react';
 import { useBookingEntryFlow } from '@/shared/lib/use-booking-entry-flow';
 import { cn } from '@/shared/lib/utils';
 import { Badge } from '@/shared/ui/badge';
-import { TAB_TODAY, TODAY, TEAM_IDS, statusColor, teamLogos } from './constants';
+import { TAB_TODAY, TEAM_IDS, statusColor, teamLogos } from './constants';
 import type { DaySchedule, GameRow } from './types';
 import { getGameResultTexts } from './utils';
 
@@ -404,7 +404,7 @@ function ScheduleList({ activeTab, filteredData }: ScheduleListProps) {
   return (
     <div className={cn('flex flex-col w-full', activeTab !== TAB_TODAY && 'gap-[25px]')}>
       {filteredData.map(day => {
-        const isToday = day.isToday ?? day.date === TODAY;
+        const isToday = day.isToday === true;
 
         return (
           <div key={day.date}>

--- a/src/pages/home/ui/game-schedule/constants.ts
+++ b/src/pages/home/ui/game-schedule/constants.ts
@@ -28,82 +28,6 @@ export const teamLogos: Record<string, string> = {
    KIA: '/baseball/logos/kia.png',
 };
 
-export const scheduleData: DaySchedule[] = [
-   {
-      year: 2025,
-      date: '7월 1일 (수)',
-      games: [
-        {
-            gameId: 'j02',
-            homeTeamId: 'lg',
-            stadiumId: 'stadium-jamsil-baseball',
-            queueTokenJti: 'queue-token-j02',
-            time: '18:30',
-            venue: '잠실',
-            away: 'KIA',
-            home: 'LG',
-            score: '5:3',
-            status: '종료',
-            ticket: '매진',
-            resell: '리셀매진',
-         },
-      ],
-   },
-   {
-      year: 2025,
-      date: '7월 3일 (금)',
-      isToday: true,
-      games: [
-         {
-            time: '18:30',
-            venue: '잠실',
-            away: 'KIA',
-            home: 'LG',
-            score: '2:1',
-            status: '경기중',
-            ticket: '예매하기',
-            resell: '리셀매진',
-         },
-        {
-            gameId: 'j03',
-            homeTeamId: 'samsung',
-            stadiumId: 'stadium-samsung-lions-park',
-            queueTokenJti: 'queue-token-j03',
-            time: '18:30',
-            venue: '대구',
-            away: '두산',
-            home: '삼성',
-            score: null,
-            status: '예정',
-            ticket: '예매하기',
-            resell: '리셀예매',
-         },
-      ],
-   },
-   {
-      year: 2025,
-      date: '7월 5일 (일)',
-      games: [
-        {
-            gameId: 'j09',
-            homeTeamId: 'lg',
-            stadiumId: 'stadium-jamsil-baseball',
-            queueTokenJti: 'queue-token-j09',
-            time: '17:00',
-            venue: '잠실',
-            away: 'KIA',
-            home: 'LG',
-            score: null,
-            status: '예정',
-            ticket: '판매예정',
-            resell: '리셀예정',
-            ticketInfo: '6월 25일\n오전 11시 오픈',
-            reselInfo: '정식 예매 오픈\n2시간 후',
-         },
-      ],
-   },
-];
-
 export const statusColor: Record<GameStatus, string> = {
    경기중: 'text-[#38c976]',
    예정: 'text-primary',
@@ -111,15 +35,16 @@ export const statusColor: Record<GameStatus, string> = {
    취소: 'text-[#acb4bb]',
 };
 
-export const TODAY = '7월 3일 (금)';
-export const CURRENT_YEAR = 2025;
-export const CURRENT_MONTH = 7;
-export const CURRENT_WEEK = 1;
+const now = new Date();
+
+export const CURRENT_YEAR = now.getFullYear();
+export const CURRENT_MONTH = now.getMonth() + 1;
+export const CURRENT_WEEK = Math.ceil(now.getDate() / 7);
 
 // 시즌 월 순서: 3월~12월, 1월, 2월
 export const SEASON_MONTHS = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2];
 export const DISABLED_MONTHS = [10, 11, 12, 1, 2];
-export const AVAILABLE_YEARS = [2021, 2022, 2023, 2024, 2025, 2026];
+export const AVAILABLE_YEARS = Array.from({ length: 6 }, (_, index) => CURRENT_YEAR - 2 + index);
 
 export const tabs = ['오늘 일정', '주간 일정', '전체 일정'];
 export const TAB_TODAY = 0;

--- a/src/pages/home/ui/game-schedule/types.ts
+++ b/src/pages/home/ui/game-schedule/types.ts
@@ -5,6 +5,7 @@ export type ReselStatus = '리셀예매' | '리셀매진' | '리셀예정';
 export type GameRow = {
    gameId?: string;
    homeTeamId?: string;
+   awayTeamId?: string;
    stadiumId?: string;
    queueTokenJti?: string;
    time: string;

--- a/src/pages/home/ui/game-schedule/utils.ts
+++ b/src/pages/home/ui/game-schedule/utils.ts
@@ -2,7 +2,6 @@ import {
    TAB_ALL,
    TAB_TODAY,
    TAB_WEEK,
-   TODAY,
 } from './constants';
 import type { DaySchedule } from './types';
 
@@ -36,7 +35,7 @@ function isDayInActiveTab(
 ): boolean {
    switch (activeTab) {
       case TAB_TODAY:
-         return day.date === TODAY;
+         return day.isToday === true;
       case TAB_WEEK: {
          const { month, day: dayNum } = parseDate(day.date);
          const week = getWeekOfMonth(dayNum);

--- a/src/pages/teams/ui/TeamDetailPage.tsx
+++ b/src/pages/teams/ui/TeamDetailPage.tsx
@@ -20,8 +20,6 @@ const TeamDetailPage = () => {
 
    const [activeBookingTab, setActiveBookingTab] = useState(0);
 
-   const teamName = teamId ? TEAM_NAME_BY_ID[teamId] : undefined;
-
    if (!team) {
       return <Navigate to="/teams" replace />;
    }
@@ -71,7 +69,7 @@ const TeamDetailPage = () => {
 
                {/* 탭 컨텐츠 */}
                <div className="flex flex-col gap-6.25 items-start w-full">
-                  {activeBookingTab === 0 && <TeamScheduleTab teamName={teamName} />}
+                  {activeBookingTab === 0 && <TeamScheduleTab teamId={teamId} teamName={teamId ? TEAM_NAME_BY_ID[teamId] : undefined} />}
 
                   {activeBookingTab === 1 && <SeatMapTab />}
 

--- a/src/pages/teams/ui/TeamScheduleTab.tsx
+++ b/src/pages/teams/ui/TeamScheduleTab.tsx
@@ -2,6 +2,7 @@
 import { useMemo, useRef, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
+import { mapGamesToDaySchedules, useGameSchedules } from '@/entities/game/model/schedule';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
 import ScheduleList from '@/pages/home/ui/game-schedule/ScheduleList';
@@ -12,21 +13,26 @@ import {
    CURRENT_YEAR,
    WEEK_OPTIONS,
    TAB_WEEK,
-   scheduleData,
 } from '@/pages/home/ui/game-schedule/constants';
 import { filterScheduleData } from '@/pages/home/ui/game-schedule/utils';
 import { BookingGuide } from './BookingGuide';
 
 interface Props {
+   teamId: string | undefined;
    teamName: string | undefined;
 }
 
-export function TeamScheduleTab({ teamName }: Props) {
+export function TeamScheduleTab({ teamId, teamName }: Props) {
    const [weekYear, setWeekYear] = useState(CURRENT_YEAR);
    const [weekMonth, setWeekMonth] = useState(CURRENT_MONTH);
    const [selectedWeek, setSelectedWeek] = useState(CURRENT_WEEK);
    const [showPicker, setShowPicker] = useState(false);
    const pickerContainerRef = useRef<HTMLDivElement>(null);
+   const scheduleQuery = useGameSchedules({
+      year: weekYear,
+      month: weekMonth,
+   });
+   const scheduleData = useMemo(() => mapGamesToDaySchedules(scheduleQuery.data ?? []), [scheduleQuery.data]);
 
    const filteredData = useMemo(() => {
       const byWeek = filterScheduleData(scheduleData, {
@@ -38,15 +44,15 @@ export function TeamScheduleTab({ teamName }: Props) {
          allMonth: weekMonth,
       });
 
-      if (!teamName) return byWeek;
+      if (!teamId) return byWeek;
 
       return byWeek
          .map(day => ({
             ...day,
-            games: day.games.filter(g => g.away === teamName || g.home === teamName),
+            games: day.games.filter(g => g.awayTeamId === teamId || g.homeTeamId === teamId),
          }))
          .filter(day => day.games.length > 0);
-   }, [weekMonth, selectedWeek, teamName]);
+   }, [scheduleData, selectedWeek, teamId, weekMonth, weekYear]);
 
    const prevMonth = () => {
       if (weekMonth === 1) {
@@ -137,7 +143,13 @@ export function TeamScheduleTab({ teamName }: Props) {
          <div className="flex flex-col gap-30 items-start w-full">
             {/* 경기 일정 리스트 */}
             <div className="flex flex-col gap-6.25 items-start w-full">
-               <ScheduleList activeTab={TAB_WEEK} filteredData={filteredData} />
+               {scheduleQuery.isError ? (
+                  <div className="rounded-[10px] border border-border bg-surface px-5 py-10 text-center text-body-1-medium text-muted-foreground w-full">
+                     {teamName ? `${teamName} 경기 일정을 불러오지 못했습니다.` : '경기 일정을 불러오지 못했습니다.'}
+                  </div>
+               ) : (
+                  <ScheduleList activeTab={TAB_WEEK} filteredData={filteredData} />
+               )}
             </div>
 
             {/* 예매 안내 */}

--- a/src/pages/tickets/ui/TicketsPage.tsx
+++ b/src/pages/tickets/ui/TicketsPage.tsx
@@ -1,13 +1,14 @@
 // src/pages/tickets/ui/TicketsPage.tsx
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { RefreshCw, SlidersHorizontal } from 'lucide-react';
 
+import { useGameSchedules } from '@/entities/game/model/schedule';
 import { useBookingEntryFlow } from '@/shared/lib/use-booking-entry-flow';
 import { Button } from '@/shared/ui/button';
 import { FilterSidebar } from './FilterSidebar';
 import { GameCard } from './GameCard';
-import { MOCK_GAMES, MAX_PRICE } from './constants';
+import { MAX_PRICE } from './constants';
 import type { FilterState, GameItem, TabType } from './types';
 
 function applyFilters(games: GameItem[], filters: FilterState, activeTab: TabType): GameItem[] {
@@ -35,24 +36,45 @@ function applyFilters(games: GameItem[], filters: FilterState, activeTab: TabTyp
 
 const TicketsPage = () => {
    const { openBookingEntry, bookingGuideDialog } = useBookingEntryFlow();
+   const scheduleQuery = useGameSchedules();
    const [activeTab, setActiveTab] = useState<TabType>('예매');
-   const [displayedGames, setDisplayedGames] = useState<GameItem[]>(MOCK_GAMES);
    const [isFilterOpen, setIsFilterOpen] = useState(false);
    /** 마지막 조회 시 적용된 검색어 (결과 없음 문구 분기용) */
    const [appliedSearchQuery, setAppliedSearchQuery] = useState('');
+
+   const allGames = useMemo<GameItem[]>(() => {
+      return (scheduleQuery.data ?? []).map((game) => ({
+         id: game.id,
+         homeTeamId: game.homeTeamId ?? '',
+         stadiumId: game.stadiumId,
+         queueTokenJti: game.queueTokenJti,
+         awayTeam: game.awayTeamFullName,
+         homeTeam: game.homeTeamFullName,
+         date: game.date,
+         dateTime: `${game.date.replace(/-/g, '.')} ${game.time}`,
+         venue: game.venue,
+         remainingSeats: game.ticket === '매진' ? 0 : 999,
+         minPrice: 0,
+         maxPrice: 0,
+         bookingStatus: game.ticket === '예매하기' ? '예매 가능' : game.ticket === '판매예정' ? '판매 예정' : '매진',
+         resellStatus: game.resell === '리셀예매' ? '리셀 가능' : game.resell === '리셀예정' ? '리셀 예정' : '매진',
+      }));
+   }, [scheduleQuery.data]);
+
+   const [displayedGames, setDisplayedGames] = useState<GameItem[]>([]);
 
    /** 필터 사이드바에서 조회하기 클릭 시 */
    const handleApply = (filters: FilterState) => {
       setActiveTab(filters.tab);
       setAppliedSearchQuery(filters.searchQuery.trim());
-      setDisplayedGames(applyFilters(MOCK_GAMES, filters, filters.tab));
+      setDisplayedGames(applyFilters(allGames, filters, filters.tab));
       setIsFilterOpen(false);
    };
 
    const handleRefresh = () => {
       setActiveTab('예매');
       setAppliedSearchQuery('');
-      setDisplayedGames(MOCK_GAMES);
+      setDisplayedGames(allGames);
    };
 
    const handleBookingClick = (game: GameItem) => {
@@ -66,6 +88,8 @@ const TicketsPage = () => {
          dateTime: game.dateTime,
       });
    };
+
+   const gamesToRender = displayedGames.length > 0 || appliedSearchQuery || activeTab !== '예매' ? displayedGames : allGames;
 
    return (
       <div className="w-full px-4 py-12.5 pb-30 flex justify-center bg-white h-full">
@@ -94,7 +118,7 @@ const TicketsPage = () => {
                <div className="flex items-center justify-between h-8 ">
                   <h2 className="text-heading-1-bold text-foreground">경기일정</h2>
                   <div className="flex items-center gap-4">
-                     <span className="text-body-2-regular text-muted-foreground">총 {displayedGames.length}개</span>
+                     <span className="text-body-2-regular text-muted-foreground">총 {gamesToRender.length}개</span>
                      <button
                         onClick={handleRefresh}
                         className="flex items-center gap-2 bg-background border border-border rounded-lg px-3 py-1 text-body-2-medium text-foreground h-8 hover:bg-surface transition-colors"
@@ -107,8 +131,12 @@ const TicketsPage = () => {
 
                {/* 게임 카드 목록 */}
                <div className="flex flex-col gap-4 h-full">
-                  {displayedGames.length > 0 ? (
-                     displayedGames.map(game => (
+                  {scheduleQuery.isError ? (
+                     <div className="flex items-center justify-center h-full bg-surface rounded-[14px] text-body-1-medium text-muted-foreground">
+                        경기 일정을 불러오지 못했습니다.
+                     </div>
+                  ) : gamesToRender.length > 0 ? (
+                     gamesToRender.map(game => (
                         <GameCard key={game.id} game={game} activeTab={activeTab} onBookingClick={handleBookingClick} />
                      ))
                   ) : (

--- a/src/shared/api/mocks/handlers/game.ts
+++ b/src/shared/api/mocks/handlers/game.ts
@@ -1,0 +1,177 @@
+import { http, HttpResponse } from 'msw';
+
+type MockGameSchedule = {
+  gameId: string;
+  startAt: string;
+  leagueType: 'REGULAR';
+  homeTeamId: string;
+  awayTeamId: string;
+  stadiumId: string;
+  gameStatus: 'SCHEDULED' | 'FINISHED' | 'IN_PROGRESS';
+  homeTeamScore: number;
+  awayTeamScore: number;
+  gameResult: 'HOME_WIN' | 'AWAY_WIN' | 'DRAW';
+  ticketingStatus: 'AVAILABLE' | 'SCHEDULED' | 'CLOSED';
+  ticketingOpenedAt: string;
+};
+
+const formatLocalDate = (value: Date) => {
+  const year = value.getFullYear();
+  const month = String(value.getMonth() + 1).padStart(2, '0');
+  const day = String(value.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+};
+
+const formatLocalDateTime = (offsetDays: number, hour: number, minute: number) => {
+  const value = new Date();
+  value.setDate(value.getDate() + offsetDays);
+  value.setHours(hour, minute, 0, 0);
+
+  return `${formatLocalDate(value)} ${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+};
+
+const MOCK_TODAY = formatLocalDate(new Date());
+
+export const mockGameSchedules: MockGameSchedule[] = [
+  {
+    gameId: 'game-kia-home-yesterday',
+    startAt: formatLocalDateTime(-1, 18, 30),
+    leagueType: 'REGULAR',
+    homeTeamId: 'team-kia',
+    awayTeamId: 'team-lg',
+    stadiumId: 'stadium-kia-champions-field',
+    gameStatus: 'FINISHED',
+    homeTeamScore: 6,
+    awayTeamScore: 2,
+    gameResult: 'HOME_WIN',
+    ticketingStatus: 'CLOSED',
+    ticketingOpenedAt: '2026-03-11 11:00',
+  },
+  {
+    gameId: 'game-samsung-home-today',
+    startAt: formatLocalDateTime(0, 18, 30),
+    leagueType: 'REGULAR',
+    homeTeamId: 'team-samsung',
+    awayTeamId: 'team-doosan',
+    stadiumId: 'stadium-samsung-lions-park',
+    gameStatus: 'SCHEDULED',
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    gameResult: 'DRAW',
+    ticketingStatus: 'AVAILABLE',
+    ticketingOpenedAt: formatLocalDateTime(-7, 11, 0),
+  },
+  {
+    gameId: 'game-kia-home-tomorrow',
+    startAt: formatLocalDateTime(1, 18, 30),
+    leagueType: 'REGULAR',
+    homeTeamId: 'team-kia',
+    awayTeamId: 'team-kiwoom',
+    stadiumId: 'stadium-kia-champions-field',
+    gameStatus: 'SCHEDULED',
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    gameResult: 'DRAW',
+    ticketingStatus: 'AVAILABLE',
+    ticketingOpenedAt: formatLocalDateTime(-6, 11, 0),
+  },
+  {
+    gameId: 'game-samsung-home-this-weekend',
+    startAt: formatLocalDateTime(3, 14, 0),
+    leagueType: 'REGULAR',
+    homeTeamId: 'team-samsung',
+    awayTeamId: 'team-kt',
+    stadiumId: 'stadium-samsung-lions-park',
+    gameStatus: 'SCHEDULED',
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    gameResult: 'DRAW',
+    ticketingStatus: 'AVAILABLE',
+    ticketingOpenedAt: formatLocalDateTime(-4, 11, 0),
+  },
+  {
+    gameId: 'game-kia-home-next-week',
+    startAt: formatLocalDateTime(8, 18, 30),
+    leagueType: 'REGULAR',
+    homeTeamId: 'team-kia',
+    awayTeamId: 'team-doosan',
+    stadiumId: 'stadium-kia-champions-field',
+    gameStatus: 'SCHEDULED',
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    gameResult: 'DRAW',
+    ticketingStatus: 'AVAILABLE',
+    ticketingOpenedAt: formatLocalDateTime(1, 11, 0),
+  },
+  {
+    gameId: 'game-samsung-home-next-weekend',
+    startAt: formatLocalDateTime(9, 17, 0),
+    leagueType: 'REGULAR',
+    homeTeamId: 'team-samsung',
+    awayTeamId: 'team-lg',
+    stadiumId: 'stadium-samsung-lions-park',
+    gameStatus: 'SCHEDULED',
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    gameResult: 'DRAW',
+    ticketingStatus: 'SCHEDULED',
+    ticketingOpenedAt: formatLocalDateTime(5, 11, 0),
+  },
+  {
+    gameId: 'game-kia-home-two-weeks',
+    startAt: formatLocalDateTime(14, 18, 30),
+    leagueType: 'REGULAR',
+    homeTeamId: 'team-kia',
+    awayTeamId: 'team-hanwha',
+    stadiumId: 'stadium-kia-champions-field',
+    gameStatus: 'SCHEDULED',
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    gameResult: 'DRAW',
+    ticketingStatus: 'AVAILABLE',
+    ticketingOpenedAt: formatLocalDateTime(8, 11, 0),
+  },
+];
+
+const matchesCalendarDate = (startAt: string, date: string) => startAt.slice(0, 10) === date;
+
+export const gameHandlers = [
+  http.get('/api/v1/games/schedules', async ({ request }) => {
+    const searchParams = new URL(request.url).searchParams;
+    const teamId = searchParams.get('teamId');
+    const year = searchParams.get('year');
+    const month = searchParams.get('month');
+    const today = searchParams.get('today');
+
+    const filteredGames = mockGameSchedules.filter((game) => {
+      if (teamId && game.homeTeamId !== teamId && game.awayTeamId !== teamId) {
+        return false;
+      }
+
+      if (year || month) {
+        const [gameYear, gameMonth] = game.startAt.split(' ')[0]?.split('-') ?? [];
+
+        if (year && gameYear !== year) {
+          return false;
+        }
+
+        if (month && gameMonth !== month.padStart(2, '0')) {
+          return false;
+        }
+      }
+
+      if (today === 'true' && !matchesCalendarDate(game.startAt, MOCK_TODAY)) {
+        return false;
+      }
+
+      return true;
+    });
+
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: filteredGames,
+    });
+  }),
+];

--- a/src/shared/api/mocks/handlers/index.ts
+++ b/src/shared/api/mocks/handlers/index.ts
@@ -1,7 +1,9 @@
 import { authHandlers } from "./auth";
+import { gameHandlers } from "./game";
 import { paymentHandlers } from "./payment";
 
 export const handlers = [
   ...authHandlers,
+  ...gameHandlers,
   ...paymentHandlers,
 ];


### PR DESCRIPTION
## #️⃣ 관련 이슈

- #118
- #116

<br/>

## 🔎 개요

홈, 팀 상세, 티켓 목록에서 공통으로 사용할 경기 일정 조회 레이어를 추가하고, API 응답을 화면 데이터로 변환해 일정 기능을 연동했습니다.

<br/>

## 📋 작업 내용

- `entities/game`에 경기 일정 API와 공통 schedule 변환 로직을 추가했습니다.
- API 응답을 홈 화면 일정 UI에서 사용하는 형태로 정규화하는 매핑 로직을 구현했습니다.
- `GameSchedule`, `PopularGames`, `FavoriteTeamMatchCard`, `TeamScheduleTab`, `TicketsPage`가 정적 데이터 대신 일정 API를 사용하도록 변경했습니다.
- 일정 조회 실패 시 각 화면에서 에러 상태를 표시하도록 보완했습니다.
- MSW에 `/api/v1/games/schedules` 핸들러를 추가하고 mock 데이터를 연결했습니다.
- `mockServiceWorker`와 `package.json`의 MSW 설정을 갱신해 로컬 mock 환경에서 일정 API를 재현할 수 있도록 했습니다.

<br/>
