### PR TITLE
[feat] 결제 mock 및 테스트 결제 흐름 보강

### DIFF
--- a/src/pages/tickets/api/paymentApi.ts
+++ b/src/pages/tickets/api/paymentApi.ts
@@ -321,9 +321,10 @@ export const submitTicketOrder = async (payload: TicketCheckoutRequest): Promise
       ordererEmail: payload.ordererEmail,
    });
 
-   if (!payload.userId) {
-      throw new Error('결제 사용자 ID가 없어 주문 확정을 진행할 수 없습니다. 로그인 정보를 다시 확인해 주세요.');
-   }
+   // 테스트를 위해 일반 예매 결제의 사용자 ID 검증을 잠시 비활성화합니다.
+   // if (!payload.userId) {
+   //    throw new Error('결제 사용자 ID가 없어 주문 확정을 진행할 수 없습니다. 로그인 정보를 다시 확인해 주세요.');
+   // }
 
    const payment = await createOrderPayment(order.orderId, {
       paymentMethod: toPaymentMethodCode(payload.paymentMethod),
@@ -331,7 +332,7 @@ export const submitTicketOrder = async (payload: TicketCheckoutRequest): Promise
    });
 
    const confirmation = await confirmOrderPayment(order.orderId, {
-      userId: payload.userId,
+      userId: payload.userId ?? '8df84c70-833e-4374-85ad-fa52f92f939e',
       paymentId: payment.paymentId,
       pgTid: payment.pgTid,
    });

--- a/src/pages/tickets/ui/payment/ResellPaymentPage.tsx
+++ b/src/pages/tickets/ui/payment/ResellPaymentPage.tsx
@@ -117,10 +117,11 @@ export default function ResellPaymentPage() {
    const ticketPrice = Math.max(totalPayment - fee, 0);
 
    const handlePay = () => {
-      if (!resolvedBuyerId) {
-         window.alert('구매자 정보를 확인할 수 없습니다. 다시 로그인한 뒤 시도해 주세요.');
-         return;
-      }
+      // 테스트를 위해 리셀 결제 단계의 로그인 사용자 확인을 잠시 비활성화합니다.
+      // if (!resolvedBuyerId) {
+      //    window.alert('구매자 정보를 확인할 수 없습니다. 다시 로그인한 뒤 시도해 주세요.');
+      //    return;
+      // }
 
       const paymentRequest: ResaleCheckoutRequest = {
          buyerId: resolvedBuyerId,

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -1,15 +1,131 @@
 import { http, HttpResponse } from 'msw';
+import { mockGameSchedules } from './game';
 
-const seatGradesByStadium: Record<
-   string,
-   Array<{
-      seatGradeId: string;
-      stadiumId: string;
-      name: string;
-      displayColorHex: string;
-   }>
-> = {
+type SeatGrade = {
+   seatGradeId: string;
+   stadiumId: string;
+   name: string;
+   displayColorHex: string;
+};
+
+type SeatSection = {
+   sectionId: string;
+   gradeId: string;
+   stadiumId: string;
+   sectionCode: string;
+   capacity: number;
+};
+
+type SeatReservationHold = {
+   holdId: string;
+   seatId: string;
+   gameId: string;
+   queueTokenJti: string;
+};
+
+type TicketOrder = {
+   orderId: string;
+   orderNumber: string;
+   gameId: string;
+   stadiumId: string;
+   orderStatus: 'PENDING' | 'CONFIRMED';
+   totalQuantity: number;
+   totalAmount: number;
+   holdIds: string[];
+   orderedAt: string;
+};
+
+type TicketPayment = {
+   paymentId: string;
+   orderId: string;
+   paymentMethod: string;
+   paymentAmount: number;
+   pgTid: string;
+   paymentStatus: 'SUCCESS';
+   paidAt: string;
+};
+
+type ResaleHold = {
+   holdId: string;
+   listingId: string;
+   queueTokenJti: string;
+};
+
+type ResaleOrder = {
+   orderId: string;
+   orderNumber: string;
+   orderStatus: 'PENDING' | 'COMPLETED';
+   totalQuantity: number;
+   totalAmount: number;
+   holdIds: string[];
+   transactionIds: string[];
+};
+
+type ResalePayment = {
+   paymentId: string;
+   orderId: string;
+   paymentMethod: string;
+   paymentAmount: number;
+   pgTid: string;
+   paymentStatus: 'SUCCESS';
+   paidAt: string;
+};
+
+type TicketRecord = {
+   ticketId: string;
+   orderId: string;
+   gameId: string;
+   seatId: string;
+   qrToken: string;
+};
+
+type ResaleLedger = {
+   id: string;
+   orderId: string;
+   paymentId: string;
+   totalAmount: number;
+   buyerFee: number;
+   sellerFee: number;
+   vat: number;
+   netProfit: number;
+   settlementAmount: number;
+   createdAt: string;
+};
+
+const createSections = ({
+   stadiumId,
+   gradeId,
+   codes,
+   capacity = 500,
+}: {
+   stadiumId: string;
+   gradeId: string;
+   codes: string[];
+   capacity?: number;
+}) => {
+   return codes.map((sectionCode) => ({
+      sectionId: `section-${stadiumId}-${sectionCode.toLowerCase().replace(/[^a-z0-9]+/gi, '-')}`,
+      gradeId,
+      stadiumId,
+      sectionCode,
+      capacity,
+   }));
+};
+
+const seatGradesByStadium: Record<string, SeatGrade[]> = {
    'stadium-kia-champions-field': [
+      {
+         seatGradeId: 'grade-kia-champion',
+         stadiumId: 'stadium-kia-champions-field',
+         name: '챔피언석',
+         displayColorHex: '#D05150',
+      },
+      {
+         seatGradeId: 'grade-kia-center-table',
+         stadiumId: 'stadium-kia-champions-field',
+         name: '중앙테이블석',
+         displayColorHex: '#284785',
+      },
       {
          seatGradeId: 'grade-kia-k8',
          stadiumId: 'stadium-kia-champions-field',
@@ -21,6 +137,42 @@ const seatGradesByStadium: Record<
          stadiumId: 'stadium-kia-champions-field',
          name: 'K9석',
          displayColorHex: '#DB58AF',
+      },
+      {
+         seatGradeId: 'grade-kia-cheering-special',
+         stadiumId: 'stadium-kia-champions-field',
+         name: '응원특별석',
+         displayColorHex: '#F26D5B',
+      },
+      {
+         seatGradeId: 'grade-kia-k5',
+         stadiumId: 'stadium-kia-champions-field',
+         name: 'K5석',
+         displayColorHex: '#93CB3A',
+      },
+      {
+         seatGradeId: 'grade-kia-family',
+         stadiumId: 'stadium-kia-champions-field',
+         name: '훼미리석',
+         displayColorHex: '#5F56B3',
+      },
+      {
+         seatGradeId: 'grade-kia-party',
+         stadiumId: 'stadium-kia-champions-field',
+         name: '파티석',
+         displayColorHex: '#782E8D',
+      },
+      {
+         seatGradeId: 'grade-kia-sky-picnic',
+         stadiumId: 'stadium-kia-champions-field',
+         name: '스카이피크닉석',
+         displayColorHex: '#8B6DE9',
+      },
+      {
+         seatGradeId: 'grade-kia-table-table',
+         stadiumId: 'stadium-kia-champions-field',
+         name: '테이블테이블석',
+         displayColorHex: '#4A68D4',
       },
    ],
    'stadium-samsung-lions-park': [
@@ -39,38 +191,64 @@ const seatGradesByStadium: Record<
    ],
 };
 
-const seatSectionsByStadium: Record<
-   string,
-   Array<{
-      sectionId: string;
-      gradeId: string;
-      stadiumId: string;
-      sectionCode: string;
-      capacity: number;
-   }>
-> = {
+const seatSectionsByStadium: Record<string, SeatSection[]> = {
    'stadium-kia-champions-field': [
-      {
-         sectionId: 'section-kia-108',
-         gradeId: 'grade-kia-k8',
+      ...createSections({
          stadiumId: 'stadium-kia-champions-field',
-         sectionCode: '108',
-         capacity: 500,
-      },
-      {
-         sectionId: 'section-kia-109',
-         gradeId: 'grade-kia-k8',
+         gradeId: 'grade-kia-champion',
+         codes: ['A-1', 'A-2', 'A-3'],
+         capacity: 120,
+      }),
+      ...createSections({
          stadiumId: 'stadium-kia-champions-field',
-         sectionCode: '109',
-         capacity: 500,
-      },
-      {
-         sectionId: 'section-kia-112',
+         gradeId: 'grade-kia-center-table',
+         codes: ['B-1', 'B-2', 'B-3'],
+         capacity: 80,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
+         gradeId: 'grade-kia-k5',
+         codes: ['104', '105', '106', '124', '125', '126'],
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
+         gradeId: 'grade-kia-k8',
+         codes: ['108', '109', '110', '111'],
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
          gradeId: 'grade-kia-k9',
+         codes: ['112', '113', '116', '117'],
+      }),
+      ...createSections({
          stadiumId: 'stadium-kia-champions-field',
-         sectionCode: '112',
-         capacity: 900,
-      },
+         gradeId: 'grade-kia-cheering-special',
+         codes: ['118', '119', '120', '121', '122', '123'],
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
+         gradeId: 'grade-kia-family',
+         codes: ['504', '505', '506', '507', '508'],
+         capacity: 60,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
+         gradeId: 'grade-kia-sky-picnic',
+         codes: ['519', '520', '521', '522', '523'],
+         capacity: 48,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
+         gradeId: 'grade-kia-table-table',
+         codes: ['530', '531', '532', '533', '534', '535'],
+         capacity: 64,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
+         gradeId: 'grade-kia-party',
+         codes: ['J-1', 'J-2', 'J-3', 'J-4', 'J-5', 'J-6'],
+         capacity: 32,
+      }),
    ],
    'stadium-samsung-lions-park': [
       {
@@ -97,6 +275,23 @@ const seatSectionsByStadium: Record<
    ],
 };
 
+const seatReservationHolds = new Map<string, SeatReservationHold>();
+const ticketOrders = new Map<string, TicketOrder>();
+const ticketPayments = new Map<string, TicketPayment>();
+const ticketRecords = new Map<string, TicketRecord>();
+const resaleHolds = new Map<string, ResaleHold>();
+const resaleOrders = new Map<string, ResaleOrder>();
+const resalePayments = new Map<string, ResalePayment>();
+const resaleLedgers = new Map<string, ResaleLedger>();
+
+const createId = (prefix: string) => {
+   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `${prefix}-${crypto.randomUUID()}`;
+   }
+
+   return `${prefix}-${Date.now()}`;
+};
+
 const buildSectionSeats = (sectionId: string) => {
    return ['A', 'B', 'C', 'D', 'E', 'F'].flatMap((rowName) =>
       Array.from({ length: 12 }, (_, index) => ({
@@ -107,6 +302,59 @@ const buildSectionSeats = (sectionId: string) => {
          available: (index + rowName.charCodeAt(0)) % 9 !== 0,
       })),
    );
+};
+
+const buildErrorResponse = (message: string, status = 400) => {
+   return HttpResponse.json({ message }, { status });
+};
+
+const parseJsonBody = async <T>(request: Request): Promise<T | null> => {
+   try {
+      return (await request.json()) as T;
+   } catch {
+      return null;
+   }
+};
+
+const isTicketPaymentMethod = (paymentMethod: unknown) => {
+   return paymentMethod === 'CARD' || paymentMethod === 'ACCOUNT_TRANSFER';
+};
+
+const buildPageResponse = <T>(content: T[], page = 0, size = content.length || 10) => {
+   const pageSize = size > 0 ? size : content.length || 10;
+   const offset = page * pageSize;
+   const pagedContent = content.slice(offset, offset + pageSize);
+   const totalElements = content.length;
+   const totalPages = totalElements === 0 ? 1 : Math.ceil(totalElements / pageSize);
+
+   return {
+      totalElements,
+      totalPages,
+      pageable: {
+         pageNumber: page,
+         paged: true,
+         unpaged: false,
+         pageSize,
+         offset,
+         sort: {
+            sorted: true,
+            unsorted: false,
+            empty: false,
+         },
+      },
+      numberOfElements: pagedContent.length,
+      first: page === 0,
+      last: page >= totalPages - 1,
+      size: pageSize,
+      content: pagedContent,
+      number: page,
+      sort: {
+         sorted: true,
+         unsorted: false,
+         empty: false,
+      },
+      empty: pagedContent.length === 0,
+   };
 };
 
 export const paymentHandlers = [
@@ -147,149 +395,496 @@ export const paymentHandlers = [
       });
    }),
 
-   http.post('/api/v1/seat-reservations/seats/:seatId', async ({ params }) => {
+   http.post('/api/v1/seat-reservations/seats/:seatId', async ({ params, request }) => {
+      const body = await parseJsonBody<{
+         gameId?: string;
+         queueTokenJti?: string;
+      }>(request);
+      const seatId = String(params.seatId);
+      const gameId = body?.gameId?.trim() || 'mock-game-id';
+      const queueTokenJti = body?.queueTokenJti?.trim() || `mock-queue-token-${seatId}`;
+
+      const holdId = createId('hold');
+      seatReservationHolds.set(holdId, {
+         holdId,
+         seatId,
+         gameId,
+         queueTokenJti,
+      });
+
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
-         data: {
-            holdId: `hold-${params.seatId}-${Date.now()}`,
-         },
+         data: { holdId },
+      });
+   }),
+
+   http.post('/api/v1/seat-reservations/:holdId', async ({ params }) => {
+      const holdId = String(params.holdId);
+
+      if (!seatReservationHolds.has(holdId)) {
+         return buildErrorResponse('Seat hold not found.', 404);
+      }
+
+      seatReservationHolds.delete(holdId);
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: { holdId },
+      });
+   }),
+
+   http.get('/api/v1/orders', async () => {
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: Array.from(ticketOrders.values()).map((order) => ({
+            orderId: order.orderId,
+            orderNumber: order.orderNumber,
+            orderStatus: order.orderStatus,
+            totalQuantity: order.totalQuantity,
+            totalAmount: order.totalAmount,
+            orderedAt: order.orderedAt,
+            gameId: order.gameId,
+            stadiumId: order.stadiumId,
+         })),
       });
    }),
 
    http.post('/api/v1/orders', async ({ request }) => {
       const body = (await request.json()) as {
-         holdIds: string[];
+         gameId?: string;
+         holdIds?: string[];
+         ordererName?: string;
+         ordererPhone?: string;
+         ordererEmail?: string;
       };
+
+      if (!body?.gameId || !body?.holdIds?.length || !body?.ordererName || !body?.ordererPhone || !body?.ordererEmail) {
+         return buildErrorResponse('Missing order fields.');
+      }
+
+      const missingHold = body.holdIds.find((holdId) => !seatReservationHolds.has(holdId));
+
+      if (missingHold) {
+         return buildErrorResponse(`Seat hold not found: ${missingHold}`, 404);
+      }
+
+      const orderId = createId('order');
+      const orderedAt = new Date().toISOString();
+      const matchedGame = mockGameSchedules.find((game) => game.gameId === body.gameId);
+      const order: TicketOrder = {
+         orderId,
+         orderNumber: `ORD-${Date.now()}`,
+         gameId: body.gameId,
+         stadiumId: matchedGame?.stadiumId ?? 'stadium-kia-champions-field',
+         orderStatus: 'PENDING',
+         totalQuantity: body.holdIds.length,
+         totalAmount: body.holdIds.length * 12000,
+         holdIds: body.holdIds,
+         orderedAt,
+      };
+
+      ticketOrders.set(orderId, order);
 
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
          data: {
-            orderId: `order-${Date.now()}`,
-            orderNumber: `ORD-${Date.now()}`,
-            gameId: 'mock-game-id',
-            orderStatus: 'PENDING',
-            totalQuantity: body.holdIds.length,
-            totalAmount: body.holdIds.length * 10000,
+            orderId: order.orderId,
+            orderNumber: order.orderNumber,
+            gameId: order.gameId,
+            orderStatus: order.orderStatus,
+            totalQuantity: order.totalQuantity,
+            totalAmount: order.totalAmount,
          },
       });
    }),
 
    http.post('/api/v1/orders/:orderId/payments', async ({ params, request }) => {
       const body = (await request.json()) as {
-         paymentMethod: string;
+         paymentMethod?: string;
+         idempotencyKey?: string;
       };
+
+      const order = ticketOrders.get(String(params.orderId));
+
+      if (!order) {
+         return buildErrorResponse('Order not found.', 404);
+      }
+
+      if (!isTicketPaymentMethod(body?.paymentMethod) || !body?.idempotencyKey) {
+         return buildErrorResponse('Missing payment fields.');
+      }
+
+      const paymentId = createId('payment');
+      const payment: TicketPayment = {
+         paymentId,
+         orderId: order.orderId,
+         paymentMethod: body.paymentMethod,
+         paymentAmount: order.totalAmount,
+         pgTid: createId('mock-pg-tid'),
+         paymentStatus: 'SUCCESS',
+         paidAt: new Date().toISOString(),
+      };
+
+      ticketPayments.set(paymentId, payment);
 
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
          data: {
-            paymentId: `payment-${Date.now()}`,
-            orderId: params.orderId,
+            paymentId: payment.paymentId,
+            orderId: payment.orderId,
             paymentType: 'PAYMENT',
-            paymentMethod: body.paymentMethod,
-            paymentAmount: 24000,
+            paymentMethod: payment.paymentMethod,
+            paymentAmount: payment.paymentAmount,
             pgProvider: 'MOCK',
-            pgTid: `mock-pg-tid-${Date.now()}`,
-            paymentStatus: 'SUCCESS',
-            paidAt: new Date().toISOString(),
+            pgTid: payment.pgTid,
+            paymentStatus: payment.paymentStatus,
+            paidAt: payment.paidAt,
             failedReason: null,
          },
       });
    }),
 
-   http.post('/api/v1/orders/:orderId/payment-confirmations', async ({ params }) => {
+   http.post('/api/v1/orders/:orderId/payment-confirmations', async ({ params, request }) => {
+      const body = (await request.json()) as {
+         userId?: string;
+         paymentId?: string;
+         pgTid?: string;
+      };
+
+      const order = ticketOrders.get(String(params.orderId));
+
+      if (!order) {
+         return buildErrorResponse('Order not found.', 404);
+      }
+
+      if (!body?.userId || !body?.paymentId || !body?.pgTid) {
+         return buildErrorResponse('Missing payment confirmation fields.');
+      }
+
+      const payment = ticketPayments.get(body.paymentId);
+
+      if (!payment || payment.orderId !== order.orderId || payment.pgTid !== body.pgTid) {
+         return buildErrorResponse('Payment confirmation does not match the order.', 409);
+      }
+
+      const confirmedOrder: TicketOrder = {
+         ...order,
+         orderStatus: 'CONFIRMED',
+      };
+      ticketOrders.set(order.orderId, confirmedOrder);
+
+      confirmedOrder.holdIds.forEach((holdId) => {
+         const hold = seatReservationHolds.get(holdId);
+
+         if (!hold) {
+            return;
+         }
+
+         const ticketId = createId('ticket');
+         ticketRecords.set(ticketId, {
+            ticketId,
+            orderId: confirmedOrder.orderId,
+            gameId: confirmedOrder.gameId,
+            seatId: hold.seatId,
+            qrToken: `qr-${ticketId}`,
+         });
+      });
+
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
          data: {
-            orderId: params.orderId,
-            orderStatus: 'CONFIRMED',
-            issuedTicketCount: 2,
+            orderId: confirmedOrder.orderId,
+            orderStatus: confirmedOrder.orderStatus,
+            issuedTicketCount: confirmedOrder.totalQuantity,
          },
       });
    }),
 
-   http.post('/api/v1/resales/holds', async () => {
+   http.post('/api/v1/resales/holds', async ({ request }) => {
+      const body = (await request.json()) as {
+         listingId?: string;
+         queueTokenJti?: string;
+      };
+
+      if (!body?.listingId || !body?.queueTokenJti) {
+         return buildErrorResponse('Missing resale hold fields.');
+      }
+
+      const holdId = createId('resale-hold');
+      resaleHolds.set(holdId, {
+         holdId,
+         listingId: body.listingId,
+         queueTokenJti: body.queueTokenJti,
+      });
+
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
-         data: {
-            holdId: crypto.randomUUID(),
-         },
+         data: { holdId },
       });
    }),
 
    http.post('/api/v1/resales/orders', async ({ request }) => {
       const body = (await request.json()) as {
-         holdIds: string[];
+         holdIds?: string[];
       };
+
+      if (!body?.holdIds?.length) {
+         return buildErrorResponse('Missing resale order fields.');
+      }
+
+      const missingHold = body.holdIds.find((holdId) => !resaleHolds.has(holdId));
+
+      if (missingHold) {
+         return buildErrorResponse(`Resale hold not found: ${missingHold}`, 404);
+      }
+
+      const orderId = createId('resale-order');
+      const order: ResaleOrder = {
+         orderId,
+         orderNumber: `RESALE-ORD-${Date.now()}`,
+         orderStatus: 'PENDING',
+         totalQuantity: body.holdIds.length,
+         totalAmount: 54000 * body.holdIds.length,
+         holdIds: body.holdIds,
+         transactionIds: body.holdIds.map(() => createId('transaction')),
+      };
+
+      resaleOrders.set(orderId, order);
 
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
          data: {
-            orderId: crypto.randomUUID(),
-            orderNumber: `RESALE-ORD-${Date.now()}`,
-            orderStatus: 'PENDING',
-            totalQuantity: body.holdIds.length,
-            totalAmount: 54000,
+            orderId: order.orderId,
+            orderNumber: order.orderNumber,
+            orderStatus: order.orderStatus,
+            totalQuantity: order.totalQuantity,
+            totalAmount: order.totalAmount,
          },
       });
    }),
 
-   http.get('/api/v1/resales/orders/:orderId/transactions', async () => {
+   http.get('/api/v1/resales/orders/:orderId/transactions', async ({ params }) => {
+      const order = resaleOrders.get(String(params.orderId));
+
+      if (!order) {
+         return buildErrorResponse('Resale order not found.', 404);
+      }
+
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
-         data: [crypto.randomUUID()],
+         data: order.transactionIds,
       });
    }),
 
    http.post('/api/v1/resales/payments', async ({ request }) => {
       const body = (await request.json()) as {
-         orderId: string;
-         paymentMethod: string;
-         totalAmount: number;
+         orderId?: string;
+         buyerId?: string;
+         totalAmount?: number;
+         totalBuyerFee?: number;
+         totalSellerFee?: number;
+         items?: Array<{
+            transactionId?: string;
+            sellerId?: string;
+            settlementAmount?: number;
+         }>;
+         paymentMethod?: string;
+         idempotencyKey?: string;
       };
+
+      const order = body?.orderId ? resaleOrders.get(body.orderId) : undefined;
+
+      if (
+         !order ||
+         !body?.buyerId ||
+         typeof body.totalAmount !== 'number' ||
+         typeof body.totalBuyerFee !== 'number' ||
+         typeof body.totalSellerFee !== 'number' ||
+         !body.items?.length ||
+         !body.paymentMethod ||
+         !body.idempotencyKey
+      ) {
+         return buildErrorResponse('Missing resale payment fields.');
+      }
+
+      const invalidItem = body.items.find(
+         (item) => !item.transactionId || !item.sellerId || typeof item.settlementAmount !== 'number',
+      );
+
+      if (invalidItem) {
+         return buildErrorResponse('Invalid resale payment item.');
+      }
+
+      const paymentId = createId('resale-payment');
+      const payment: ResalePayment = {
+         paymentId,
+         orderId: order.orderId,
+         paymentMethod: body.paymentMethod,
+         paymentAmount: body.totalAmount,
+         pgTid: createId('mock-resale-pg-tid'),
+         paymentStatus: 'SUCCESS',
+         paidAt: new Date().toISOString(),
+      };
+
+      resalePayments.set(paymentId, payment);
+      resaleLedgers.set(order.orderId, {
+         id: createId('ledger'),
+         orderId: order.orderId,
+         paymentId,
+         totalAmount: body.totalAmount,
+         buyerFee: body.totalBuyerFee,
+         sellerFee: body.totalSellerFee,
+         vat: Math.round(body.totalSellerFee / 11),
+         netProfit: body.totalBuyerFee + body.totalSellerFee,
+         settlementAmount: body.items.reduce((sum, item) => sum + (item.settlementAmount ?? 0), 0),
+         createdAt: payment.paidAt,
+      });
 
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
          data: {
-            paymentId: crypto.randomUUID(),
-            orderId: body.orderId,
+            paymentId: payment.paymentId,
+            orderId: payment.orderId,
             paymentType: 'PAYMENT',
-            paymentMethod: body.paymentMethod,
-            paymentAmount: body.totalAmount,
+            paymentMethod: payment.paymentMethod,
+            paymentAmount: payment.paymentAmount,
             pgProvider: 'MOCK',
-            pgTid: `mock-resale-pg-tid-${Date.now()}`,
-            paymentStatus: 'SUCCESS',
-            paidAt: new Date().toISOString(),
+            pgTid: payment.pgTid,
+            paymentStatus: payment.paymentStatus,
+            paidAt: payment.paidAt,
             failedReason: null,
          },
       });
    }),
 
-   http.patch('/api/v1/resales/orders/:orderId/complete', async ({ params }) => {
+   http.patch('/api/v1/resales/payments/orders/:orderId/release', async ({ params }) => {
+      const orderId = String(params.orderId);
+      const order = resaleOrders.get(orderId);
+
+      if (!order) {
+         return buildErrorResponse('Resale order not found.', 404);
+      }
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: `Escrow released for order ${orderId}`,
+      });
+   }),
+
+   http.get('/api/v1/resales/payments/ledgers', async ({ request }) => {
+      const searchParams = new URL(request.url).searchParams;
+      const page = Number(searchParams.get('page') ?? 0);
+      const size = Number(searchParams.get('size') ?? 10);
+      const ledgers = Array.from(resaleLedgers.values()).sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: buildPageResponse(ledgers, page, size),
+      });
+   }),
+
+   http.get('/api/v1/resales/payments/ledgers/orders/:orderId', async ({ params }) => {
+      const ledger = resaleLedgers.get(String(params.orderId));
+
+      if (!ledger) {
+         return buildErrorResponse('Ledger not found.', 404);
+      }
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: ledger,
+      });
+   }),
+
+   http.patch('/api/v1/resales/orders/:orderId/complete', async ({ params, request }) => {
+      const paymentId = new URL(request.url).searchParams.get('paymentId');
+      const order = resaleOrders.get(String(params.orderId));
+
+      if (!order) {
+         return buildErrorResponse('Resale order not found.', 404);
+      }
+
+      if (!paymentId) {
+         return buildErrorResponse('Missing paymentId query parameter.');
+      }
+
+      const payment = resalePayments.get(paymentId);
+
+      if (!payment || payment.orderId !== order.orderId) {
+         return buildErrorResponse('Resale payment does not match the order.', 409);
+      }
+
+      const completedOrder: ResaleOrder = {
+         ...order,
+         orderStatus: 'COMPLETED',
+      };
+      resaleOrders.set(order.orderId, completedOrder);
+
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
          data: {
-            orderId: params.orderId,
-            orderNumber: `RESALE-ORD-${Date.now()}`,
-            buyerId: crypto.randomUUID(),
-            totalAmount: 54000,
-            orderStatus: 'COMPLETED',
-            items: [
-               {
-                  transactionId: crypto.randomUUID(),
-                  listingId: crypto.randomUUID(),
-                  seatInfo: '1루 지정석 1열 12번',
-                  price: 54000,
-               },
-            ],
+            orderId: completedOrder.orderId,
+            orderNumber: completedOrder.orderNumber,
+            buyerId: createId('buyer'),
+            totalAmount: completedOrder.totalAmount,
+            orderStatus: completedOrder.orderStatus,
+            items: completedOrder.transactionIds.map((transactionId, index) => ({
+               transactionId,
+               listingId: createId(`listing-${index + 1}`),
+               seatInfo: `1루 지정석 ${index + 1}열 ${index + 12}번`,
+               price: 54000,
+            })),
+         },
+      });
+   }),
+
+   http.get('/api/v1/tickets/:ticketId', async ({ params }) => {
+      const ticket = ticketRecords.get(String(params.ticketId));
+
+      if (!ticket) {
+         return buildErrorResponse('Ticket not found.', 404);
+      }
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            ticketId: ticket.ticketId,
+            orderId: ticket.orderId,
+            gameId: ticket.gameId,
+            seatId: ticket.seatId,
+            ticketStatus: 'ISSUED',
+         },
+      });
+   }),
+
+   http.get('/api/v1/tickets/:ticketId/qr', async ({ params }) => {
+      const ticket = ticketRecords.get(String(params.ticketId));
+
+      if (!ticket) {
+         return buildErrorResponse('Ticket not found.', 404);
+      }
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            ticketId: ticket.ticketId,
+            qrToken: ticket.qrToken,
          },
       });
    }),


### PR DESCRIPTION
## #️⃣ 관련 이슈

- #115

<br/>

## 🔎 개요

일반 예매와 리셀 결제 시나리오를 로컬 mock 환경에서 끝까지 검증할 수 있도록 결제 관련 MSW와 테스트용 결제 흐름을 보강했습니다.

<br/>

## 📋 작업 내용

- 결제 관련 MSW 핸들러를 확장해 주문 생성, 결제 생성, 결제 확정, 장부/티켓 데이터까지 mock으로 처리할 수 있게 했습니다.
- 좌석, 구역, 경기 정보와 연결되는 결제 mock 데이터를 정리해 테스트 흐름의 일관성을 높였습니다.
- 일반 예매 결제에서 테스트를 위해 사용자 ID 검증을 임시 완화하고 기본 userId fallback을 추가했습니다.
- 리셀 결제 단계에서도 테스트를 위해 로그인 사용자 확인을 임시 비활성화했습니다.
- 결제 화면에서 상태 확인을 위한 로그와 일부 보조 데이터를 추가해 mock 기반 검증을 쉽게 했습니다.

<br/>
