### PR TITLE
[feat] 경기 일정 API 연결 및 위치/경기장명 맵핑 수정

### DIFF
--- a/src/entities/game/api/scheduleApi.ts
+++ b/src/entities/game/api/scheduleApi.ts
@@ -2,8 +2,10 @@ import apiClient from '@/shared/api/client';
 import type { ApiEnvelope } from '@/features/auth/api/types';
 
 export type FetchGameSchedulesParams = {
+  teamId?: string;
   year?: number;
   month?: number;
+  week?: number;
   today?: boolean;
 };
 
@@ -21,13 +23,20 @@ export type GameScheduleResponse = {
   ticketingStatus: string;
   ticketingOpenedAt?: string;
   ticketingEndAt?: string;
+  homeTeamCode?: string;
+  awayTeamCode?: string;
+  homeTeamName?: string;
+  awayTeamName?: string;
+  stadiumName?: string;
 };
 
 export const fetchGameSchedules = async (params: FetchGameSchedulesParams = {}) => {
   const response = await apiClient.get<ApiEnvelope<GameScheduleResponse[]>>('/api/v1/games/schedules', {
     params: {
+      teamId: params.teamId,
       year: params.year,
       month: params.month,
+      week: params.week,
       today: params.today,
     },
   });

--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -51,15 +51,15 @@ const TEAM_REFERENCES: TeamReference[] = [
 ];
 
 const STADIUM_NAME_BY_ID: Record<string, string> = {
-  'stadium-jamsil-baseball': '잠실',
-  'stadium-samsung-lions-park': '대구',
-  'stadium-sajik-baseball': '사직',
-  'stadium-changwon-nc-park': '창원',
-  'stadium-gocheok-skydome': '고척',
-  'stadium-kia-champions-field': '광주',
-  'stadium-kt-wiz-park': '수원',
-  'stadium-daejeon-baseball': '대전',
-  'stadium-incheon-landers-field': '인천',
+  'stadium-jamsil-baseball': '잠실 야구장',
+  'stadium-samsung-lions-park': '대구 삼성 라이온즈 파크',
+  'stadium-sajik-baseball': '사직 야구장',
+  'stadium-changwon-nc-park': '창원 NC파크',
+  'stadium-gocheok-skydome': '고척 스카이돔',
+  'stadium-kia-champions-field': '기아 챔피언스필드',
+  'stadium-kt-wiz-park': '수원 KT위즈파크',
+  'stadium-daejeon-baseball': '대전 한화생명 볼파크',
+  'stadium-incheon-landers-field': '인천 SSG 랜더스필드',
 };
 
 const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];

--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -32,47 +32,114 @@ export type NormalizedScheduleGame = {
 
 type TeamReference = {
   frontendId: string;
+  teamCode: string;
   shortName: string;
   fullName: string;
   aliases: string[];
 };
 
 const TEAM_REFERENCES: TeamReference[] = [
-  { frontendId: 'kia', shortName: 'KIA', fullName: 'KIA 타이거즈', aliases: ['kia', 'teamkia', 'kiatigers', '기아', '기아타이거즈'] },
-  { frontendId: 'samsung', shortName: '삼성', fullName: '삼성 라이온즈', aliases: ['samsung', 'teamsamsung', '삼성', '삼성라이온즈'] },
-  { frontendId: 'lg', shortName: 'LG', fullName: 'LG 트윈스', aliases: ['lg', 'teamlg', 'lgtwins', '엘지', '엘지트윈스', 'lg트윈스'] },
-  { frontendId: 'hanwha', shortName: '한화', fullName: '한화 이글스', aliases: ['hanwha', 'teamhanwha', '한화', '한화이글스'] },
-  { frontendId: 'ssg', shortName: 'SSG', fullName: 'SSG 랜더스', aliases: ['ssg', 'teamssg', 'ssglanders', '랜더스', 'ssg랜더스'] },
-  { frontendId: 'nc', shortName: 'NC', fullName: 'NC 다이노스', aliases: ['nc', 'teamnc', 'ncdinos', 'nc다이노스'] },
-  { frontendId: 'kt', shortName: 'KT', fullName: 'KT wiz', aliases: ['kt', 'teamkt', 'ktwiz', '케이티', '케이티위즈'] },
-  { frontendId: 'lotte', shortName: '롯데', fullName: '롯데 자이언츠', aliases: ['lotte', 'teamlotte', '롯데', '롯데자이언츠'] },
-  { frontendId: 'doosan', shortName: '두산', fullName: '두산 베어스', aliases: ['doosan', 'teamdoosan', '두산', '두산베어스'] },
-  { frontendId: 'kiwoom', shortName: '키움', fullName: '키움 히어로즈', aliases: ['kiwoom', 'teamkiwoom', '키움', '키움히어로즈'] },
+  { frontendId: 'kia', teamCode: 'KIA', shortName: 'KIA', fullName: 'KIA 타이거즈', aliases: ['kia', 'teamkia', 'kiatigers', '기아', '기아타이거즈'] },
+  { frontendId: 'samsung', teamCode: 'SS', shortName: '삼성', fullName: '삼성 라이온즈', aliases: ['samsung', 'teamsamsung', '삼성', '삼성라이온즈', 'ss', 'samsunglions'] },
+  { frontendId: 'lg', teamCode: 'LG', shortName: 'LG', fullName: 'LG 트윈스', aliases: ['lg', 'teamlg', 'lgtwins', '엘지', '엘지트윈스', 'lg트윈스'] },
+  { frontendId: 'hanwha', teamCode: 'HH', shortName: '한화', fullName: '한화 이글스', aliases: ['hanwha', 'teamhanwha', '한화', '한화이글스', 'hh', 'hanwhaeagles'] },
+  { frontendId: 'ssg', teamCode: 'SSG', shortName: 'SSG', fullName: 'SSG 랜더스', aliases: ['ssg', 'teamssg', 'ssglanders', '랜더스', 'ssg랜더스'] },
+  { frontendId: 'nc', teamCode: 'NC', shortName: 'NC', fullName: 'NC 다이노스', aliases: ['nc', 'teamnc', 'ncdinos', 'nc다이노스'] },
+  { frontendId: 'kt', teamCode: 'KT', shortName: 'KT', fullName: 'KT wiz', aliases: ['kt', 'teamkt', 'ktwiz', '케이티', '케이티위즈'] },
+  { frontendId: 'lotte', teamCode: 'LOT', shortName: '롯데', fullName: '롯데 자이언츠', aliases: ['lotte', 'teamlotte', '롯데', '롯데자이언츠', 'lot', 'lottegiants'] },
+  { frontendId: 'doosan', teamCode: 'DO', shortName: '두산', fullName: '두산 베어스', aliases: ['doosan', 'teamdoosan', '두산', '두산베어스', 'do', 'doosanbears'] },
+  { frontendId: 'kiwoom', teamCode: 'KIW', shortName: '키움', fullName: '키움 히어로즈', aliases: ['kiwoom', 'teamkiwoom', '키움', '키움히어로즈', 'kiw', 'kiwoomheroes'] },
 ];
 
-const STADIUM_NAME_BY_ID: Record<string, string> = {
-  'stadium-jamsil-baseball': '잠실 야구장',
-  'stadium-samsung-lions-park': '대구 삼성 라이온즈 파크',
-  'stadium-sajik-baseball': '사직 야구장',
-  'stadium-changwon-nc-park': '창원 NC파크',
-  'stadium-gocheok-skydome': '고척 스카이돔',
-  'stadium-kia-champions-field': '기아 챔피언스필드',
-  'stadium-kt-wiz-park': '수원 KT위즈파크',
-  'stadium-daejeon-baseball': '대전 한화생명 볼파크',
-  'stadium-incheon-landers-field': '인천 SSG 랜더스필드',
+type StadiumReference = {
+  displayName: string;
+  aliases: string[];
+};
+
+const STADIUM_REFERENCES: Record<string, StadiumReference> = {
+  'stadium-jamsil-baseball': {
+    displayName: '잠실 야구장',
+    aliases: ['잠실야구장'],
+  },
+  'stadium-samsung-lions-park': {
+    displayName: '대구 삼성 라이온즈 파크',
+    aliases: ['대구삼성라이온즈파크', '삼성라이온즈파크'],
+  },
+  'stadium-sajik-baseball': {
+    displayName: '사직 야구장',
+    aliases: ['사직야구장'],
+  },
+  'stadium-changwon-nc-park': {
+    displayName: '창원 NC파크',
+    aliases: ['창원nc파크', 'nc파크'],
+  },
+  'stadium-gocheok-skydome': {
+    displayName: '고척 스카이돔',
+    aliases: ['고척스카이돔'],
+  },
+  'stadium-kia-champions-field': {
+    displayName: '기아 챔피언스필드',
+    aliases: ['광주기아챔피언스필드', '기아챔피언스필드'],
+  },
+  'stadium-kt-wiz-park': {
+    displayName: '수원 KT위즈파크',
+    aliases: ['수원kt위즈파크', 'kt위즈파크'],
+  },
+  'stadium-daejeon-baseball': {
+    displayName: '대전 한화생명 볼파크',
+    aliases: ['대전한화생명볼파크'],
+  },
+  'stadium-incheon-landers-field': {
+    displayName: '인천 SSG 랜더스필드',
+    aliases: ['인천ssg랜더스필드', 'ssg랜더스필드'],
+  },
 };
 
 const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
 
 const normalizeLookupValue = (value: string) => value.toLowerCase().replace(/[\s\-_./()]/g, '');
 
-const findTeamReference = (teamId: string) => {
-  const normalized = normalizeLookupValue(teamId);
-  return TEAM_REFERENCES.find((reference) => reference.aliases.some((alias) => normalizeLookupValue(alias) === normalized));
+const findTeamReference = (...candidates: Array<string | undefined>) => {
+  const normalizedCandidates = candidates
+    .filter((candidate): candidate is string => Boolean(candidate))
+    .map(normalizeLookupValue);
+
+  if (normalizedCandidates.length === 0) {
+    return undefined;
+  }
+
+  return TEAM_REFERENCES.find((reference) => {
+    const referenceCandidates = [reference.frontendId, reference.teamCode, reference.shortName, reference.fullName, ...reference.aliases]
+      .map(normalizeLookupValue);
+
+    return normalizedCandidates.some((candidate) => referenceCandidates.includes(candidate));
+  });
 };
 
 const parseApiDateTime = (value: string) => {
-  const [date = '', time = ''] = value.trim().split(' ');
+  const trimmedValue = value.trim();
+
+  if (!trimmedValue) {
+    return { date: '', time: '' };
+  }
+
+  const normalized = trimmedValue.includes('T') ? trimmedValue : trimmedValue.replace(' ', 'T');
+  const parsedDate = new Date(normalized);
+
+  if (!Number.isNaN(parsedDate.getTime())) {
+    const year = parsedDate.getFullYear();
+    const month = String(parsedDate.getMonth() + 1).padStart(2, '0');
+    const day = String(parsedDate.getDate()).padStart(2, '0');
+    const hour = String(parsedDate.getHours()).padStart(2, '0');
+    const minute = String(parsedDate.getMinutes()).padStart(2, '0');
+
+    return {
+      date: `${year}-${month}-${day}`,
+      time: `${hour}:${minute}`,
+    };
+  }
+
+  const [date = '', time = ''] = trimmedValue.split(/[ T]/);
   return { date, time: time.slice(0, 5) };
 };
 
@@ -92,7 +159,7 @@ const formatOpenedAtInfo = (value?: string) => {
     return undefined;
   }
 
-  const [date = '', time = ''] = value.split(' ');
+  const { date, time } = parseApiDateTime(value);
   const [, month = '', day = ''] = date.split('-');
   const [hour = '', minute = ''] = time.split(':');
   const meridiem = Number(hour) < 12 ? '오전' : '오후';
@@ -149,8 +216,18 @@ const mapResellStatus = (ticketStatus: TicketStatus): ReselStatus => {
   }
 };
 
-const resolveVenueName = (stadiumId: string, homeTeamName: string) => {
-  return STADIUM_NAME_BY_ID[stadiumId] ?? homeTeamName;
+const resolveVenueNameFromGame = (game: GameScheduleResponse, homeTeamName: string) => {
+  const stadiumById = STADIUM_REFERENCES[game.stadiumId];
+
+  if (stadiumById) {
+    return stadiumById.displayName;
+  }
+
+  if (game.stadiumName) {
+    return game.stadiumName;
+  }
+
+  return homeTeamName;
 };
 
 const isSameCalendarDate = (date: string, target: Date) => {
@@ -165,10 +242,12 @@ const isSameCalendarDate = (date: string, target: Date) => {
 
 const normalizeScheduleGame = (game: GameScheduleResponse): NormalizedScheduleGame => {
   const { date, time } = parseApiDateTime(game.startAt);
-  const homeTeam = findTeamReference(game.homeTeamId);
-  const awayTeam = findTeamReference(game.awayTeamId);
+  const homeTeam = findTeamReference(game.homeTeamCode, game.homeTeamName, game.homeTeamId);
+  const awayTeam = findTeamReference(game.awayTeamCode, game.awayTeamName, game.awayTeamId);
   const status = mapGameStatus(game.gameStatus);
   const ticket = mapTicketStatus(game.ticketingStatus);
+  const fallbackHomeName = game.homeTeamName ?? game.homeTeamCode ?? game.homeTeamId;
+  const fallbackAwayName = game.awayTeamName ?? game.awayTeamCode ?? game.awayTeamId;
 
   return {
     id: game.gameId,
@@ -176,14 +255,14 @@ const normalizeScheduleGame = (game: GameScheduleResponse): NormalizedScheduleGa
     serverAwayTeamId: game.awayTeamId,
     homeTeamId: homeTeam?.frontendId,
     awayTeamId: awayTeam?.frontendId,
-    homeTeamName: homeTeam?.shortName ?? game.homeTeamId,
-    awayTeamName: awayTeam?.shortName ?? game.awayTeamId,
-    homeTeamFullName: homeTeam?.fullName ?? game.homeTeamId,
-    awayTeamFullName: awayTeam?.fullName ?? game.awayTeamId,
+    homeTeamName: homeTeam?.shortName ?? fallbackHomeName,
+    awayTeamName: awayTeam?.shortName ?? fallbackAwayName,
+    homeTeamFullName: homeTeam?.fullName ?? fallbackHomeName,
+    awayTeamFullName: awayTeam?.fullName ?? fallbackAwayName,
     date,
     dateLabel: toDateLabel(date),
     time,
-    venue: resolveVenueName(game.stadiumId, homeTeam?.shortName ?? game.homeTeamId),
+    venue: resolveVenueNameFromGame(game, homeTeam?.shortName ?? fallbackHomeName),
     stadiumId: game.stadiumId,
     queueTokenJti: buildMockQueueTokenJti(game.gameId),
     score: status === '종료' ? `${game.awayTeamScore}:${game.homeTeamScore}` : null,
@@ -281,7 +360,7 @@ export const getPopularMatches = (games: NormalizedScheduleGame[], limit = 5) =>
 
 export const useGameSchedules = (params: FetchGameSchedulesParams = {}) => {
   return useQuery({
-    queryKey: ['game-schedules', params.year ?? null, params.month ?? null, params.today ?? null],
+    queryKey: ['game-schedules', params.teamId ?? null, params.year ?? null, params.month ?? null, params.week ?? null, params.today ?? null],
     queryFn: async () => {
       const schedules = await fetchGameSchedules(params);
       return schedules.map(normalizeScheduleGame).sort(sortByStartAt);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,12 +3,36 @@ import ReactDOM from 'react-dom/client';
 import { isMswEnabled } from '@/shared/config/runtime';
 import App from './App';
 
+const waitForServiceWorkerControl = async () => {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+    return;
+  }
+
+  if (navigator.serviceWorker.controller) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const timeoutId = window.setTimeout(resolve, 1500);
+
+    navigator.serviceWorker.addEventListener(
+      'controllerchange',
+      () => {
+        window.clearTimeout(timeoutId);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+};
+
 const startMocks = async () => {
   if (!isMswEnabled) return;
   const { worker } = await import('@/shared/api/mocks/browser');
   await worker.start({
     onUnhandledRequest: 'bypass',
   });
+  await waitForServiceWorkerControl();
 };
 
 const rootEl = document.getElementById('root');

--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -153,20 +153,70 @@ export const mapSeatSectionsToZones = ({
    teamId?: string;
 }): ZoneItem[] => {
    const gradeById = Object.fromEntries(grades.map((grade) => [grade.seatGradeId, grade]));
+   const aggregatedZones = new Map<string, ZoneItem>();
+   const unmatchedZones: ZoneItem[] = [];
 
-   return sections.map((section) => {
+   sections.forEach((section) => {
       const matchedZone = resolveZoneTemplate(teamId, section.sectionCode);
       const grade = gradeById[section.gradeId];
-      const displayName = matchedZone?.name ?? (grade ? `${grade.name} ${section.sectionCode}` : section.sectionCode);
+      if (matchedZone) {
+         const existingZone = aggregatedZones.get(matchedZone.id);
 
-      return {
+         if (existingZone) {
+            aggregatedZones.set(matchedZone.id, {
+               ...existingZone,
+               remaining: existingZone.remaining + section.capacity,
+            });
+            return;
+         }
+
+         aggregatedZones.set(matchedZone.id, {
+            ...matchedZone,
+            remaining: section.capacity,
+            color: grade?.displayColorHex ?? matchedZone.color ?? DEFAULT_ZONE_COLOR,
+         });
+         return;
+      }
+
+      const displayName = grade ? `${grade.name} ${section.sectionCode}` : section.sectionCode;
+      unmatchedZones.push({
          id: section.sectionId,
          name: displayName,
-         price: matchedZone?.price ?? 0,
+         price: 0,
          remaining: section.capacity,
-         color: grade?.displayColorHex ?? matchedZone?.color ?? DEFAULT_ZONE_COLOR,
-         hotspot: matchedZone?.hotspot ?? [],
+         color: grade?.displayColorHex ?? DEFAULT_ZONE_COLOR,
+         hotspot: [],
          sectionCode: section.sectionCode,
+      } satisfies ZoneItem);
+   });
+
+   return [...aggregatedZones.values(), ...unmatchedZones];
+};
+
+export const mergeBookingZones = ({
+   localZones,
+   apiZones,
+}: {
+   localZones: ZoneItem[];
+   apiZones?: ZoneItem[];
+}): ZoneItem[] => {
+   if (!apiZones?.length) {
+      return localZones;
+   }
+
+   const apiZoneById = new Map(apiZones.map((zone) => [zone.id, zone]));
+
+   return localZones.map((localZone) => {
+      const apiZone = apiZoneById.get(localZone.id);
+
+      if (!apiZone) {
+         return localZone;
+      }
+
+      return {
+         ...localZone,
+         remaining: apiZone.remaining,
+         color: apiZone.color,
       } satisfies ZoneItem;
    });
 };

--- a/src/pages/books/model/zoneData.ts
+++ b/src/pages/books/model/zoneData.ts
@@ -55,7 +55,7 @@ const SAMSUNG_BOOKING_ZONES: ZoneItem[] = [
 const BOOKING_TEAM_CONFIGS: Record<BookingTeamId, BookingTeamConfig> = {
    kia: {
       displayName: 'KIA 타이거즈',
-      stadiumName: '광주 기아 챔피언스 필드',
+      stadiumName: '기아 챔피언스필드',
       stadiumImage: '/baseball/seat/kia.png',
       stadiumImageAlt: '기아 챔피언스필드 구역도',
       zoneDisplayOrder: [
@@ -82,9 +82,9 @@ const BOOKING_TEAM_CONFIGS: Record<BookingTeamId, BookingTeamConfig> = {
    },
    samsung: {
       displayName: '삼성 라이온즈',
-      stadiumName: '대구 삼성라이온즈파크',
+      stadiumName: '대구 삼성 라이온즈 파크',
       stadiumImage: '/baseball/seat/samsung.png',
-      stadiumImageAlt: '대구 삼성라이온즈파크 구역도',
+      stadiumImageAlt: '대구 삼성 라이온즈 파크 구역도',
       zoneDisplayOrder: [
          'samsung-first-base-exciting',
          'samsung-third-base-exciting',

--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchSeatGrades, fetchSeatSections, mapSeatSectionsToZones } from '@/pages/books/api/bookingApi';
+import { fetchSeatGrades, fetchSeatSections, mapSeatSectionsToZones, mergeBookingZones } from '@/pages/books/api/bookingApi';
 import { getBookingTeamConfig, getZoneDisplayOrder, getBookingZones } from '@/pages/books/model/zoneData';
 import type { ZoneItem } from '@/pages/books/model/types';
 import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
@@ -55,16 +55,15 @@ const BooksPage = () => {
       },
    });
    const zones = useMemo<ZoneItem[]>(() => {
-      if (bookingEntryState?.bookingZones?.length) {
-         return bookingEntryState.bookingZones;
-      }
+      const mergedZones = mergeBookingZones({
+         localZones,
+         apiZones,
+      });
 
-      if (apiZones?.length) {
-         return [...apiZones].sort((left, right) => right.remaining - left.remaining || left.name.localeCompare(right.name, 'ko-KR'));
-      }
-
-      return localZones;
-   }, [apiZones, bookingEntryState?.bookingZones, localZones]);
+      return [...mergedZones].sort(
+         (left, right) => right.remaining - left.remaining || left.name.localeCompare(right.name, 'ko-KR'),
+      );
+   }, [apiZones, localZones]);
 
    const [selectedZoneId, setSelectedZoneId] = useState(zones[0]?.id ?? '');
    const [isCaptchaOpen, setIsCaptchaOpen] = useState(requiresCaptcha);

--- a/src/pages/home/ui/FavoriteTeamMatchCard.tsx
+++ b/src/pages/home/ui/FavoriteTeamMatchCard.tsx
@@ -11,7 +11,7 @@ import { useBookingEntryFlow } from '@/shared/lib/use-booking-entry-flow';
 
 const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
    const { openBookingEntry, bookingGuideDialog } = useBookingEntryFlow();
-   const { data } = useGameSchedules();
+   const { data, isPending } = useGameSchedules();
    const match = getClosestMatch(data ?? [], team.id);
 
    /** 헤더 — 경기 없을 때도 공통 사용 */
@@ -38,6 +38,17 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
          </Button>
       </div>
    );
+
+   if (isPending) {
+      return (
+         <div className="bg-white border border-[#e9ebee] rounded-2xl overflow-hidden shadow-[0px_20px_50px_-12px_rgba(0,0,0,0.25)]">
+            {Header}
+            <div className="flex items-center justify-center h-20 text-[14px] text-(--text-tertiary)">
+               경기 일정을 불러오는 중입니다.
+            </div>
+         </div>
+      );
+   }
 
    if (!match) {
       return (

--- a/src/pages/home/ui/GameSchedule.tsx
+++ b/src/pages/home/ui/GameSchedule.tsx
@@ -46,15 +46,17 @@ const GameSchedule = () => {
 
    const filteredData = useMemo(
       () =>
-         filterScheduleData(scheduleData, {
-            activeTab,
-            weekYear,
-            weekMonth,
-            selectedWeek,
-            allYear,
-            allMonth,
-         }),
-      [activeTab, weekYear, weekMonth, selectedWeek, allYear, allMonth],
+         activeTab === TAB_TODAY
+            ? scheduleData.filter(day => day.games.length > 0)
+            : filterScheduleData(scheduleData, {
+                 activeTab,
+                 weekYear,
+                 weekMonth,
+                 selectedWeek,
+                 allYear,
+                 allMonth,
+              }),
+      [activeTab, weekYear, weekMonth, selectedWeek, allYear, allMonth, scheduleData],
    );
 
    const prevWeekMonth = () => {
@@ -143,7 +145,11 @@ const GameSchedule = () => {
                />
             )}
 
-            {scheduleQuery.isError ? (
+            {scheduleQuery.isPending ? (
+               <div className="rounded-[10px] border border-border bg-surface px-5 py-10 text-center text-body-1-medium text-muted-foreground">
+                  경기 일정을 불러오는 중입니다.
+               </div>
+            ) : scheduleQuery.isError ? (
                <div className="rounded-[10px] border border-border bg-surface px-5 py-10 text-center text-body-1-medium text-muted-foreground">
                   경기 일정을 불러오지 못했습니다.
                </div>

--- a/src/pages/home/ui/PopularGames.tsx
+++ b/src/pages/home/ui/PopularGames.tsx
@@ -2,12 +2,8 @@ import { Calendar, MapPin } from 'lucide-react';
 import { getPopularMatches, useGameSchedules } from '@/entities/game/model/schedule';
 
 const PopularGames = () => {
-   const { data } = useGameSchedules();
+   const { data, isPending } = useGameSchedules();
    const matches = getPopularMatches(data ?? [], 5);
-
-   if (!data) {
-      return null;
-   }
 
    return (
       <section className="flex flex-col gap-5 w-full">
@@ -16,62 +12,60 @@ const PopularGames = () => {
             <h2 className="text-heading-1-bold text-foreground leading-normal">인기 경기</h2>
          </div>
 
-         {/* 카드 리스트 (가로 스크롤) */}
-         <div className="flex gap-6 overflow-x-auto pb-1 scrollbar-hide">
-            {matches.map((match, i) => (
-               <div
-                  key={match.id}
-                  className="shrink-0 w-75 border border-border rounded-[14px] overflow-hidden bg-background"
-               >
-                  {/* 이미지 영역 */}
-                  <div className="relative h-50 border-b border-border overflow-hidden bg-white">
-                     {/* 경기 배경 이미지 */}
-                     <img
-                        src={`/images/${i + 1}번 인기경기.png`}
-                        alt=""
-                        className="absolute inset-0 w-full h-full object-cover"
-                        draggable={false}
-                     />
-                     {/* 이미지 오버레이 */}
-                     <div className="absolute inset-0 bg-[#000000]/20" />
-                     {/* 순위 번호 */}
-                     <span className="absolute left-2.75 bottom-0 text-display-1-bold leading-[1.33] tracking-[-0.05px] text-white">
-                        {i + 1}
-                     </span>
-                  </div>
-
-                  {/* 정보 영역 */}
-                  <div className="flex flex-col gap-4 p-6">
-                     {/* 팀 매치업 */}
-                     <div className="flex items-center justify-between h-7">
-                        <span className="w-17.5 text-[18px] font-bold leading-[1.55] text-foreground">
-                           {match.awayTeamName}
-                        </span>
-                        <span className="text-[14px] font-bold text-(--text-tertiary)">vs</span>
-                        <span className="w-17.5 text-[18px] font-bold leading-[1.55] text-foreground text-right">
-                           {match.homeTeamName}
+         {isPending ? (
+            <div className="flex h-40 items-center justify-center rounded-[14px] border border-border bg-surface text-body-1-medium text-muted-foreground">
+               인기 경기를 불러오는 중입니다.
+            </div>
+         ) : (
+            <div className="flex gap-6 overflow-x-auto pb-1 scrollbar-hide">
+               {matches.map((match, i) => (
+                  <div
+                     key={match.id}
+                     className="shrink-0 w-75 border border-border rounded-[14px] overflow-hidden bg-background"
+                  >
+                     <div className="relative h-50 border-b border-border overflow-hidden bg-white">
+                        <img
+                           src={`/images/${i + 1}번 인기경기.png`}
+                           alt=""
+                           className="absolute inset-0 w-full h-full object-cover"
+                           draggable={false}
+                        />
+                        <div className="absolute inset-0 bg-[#000000]/20" />
+                        <span className="absolute left-2.75 bottom-0 text-display-1-bold leading-[1.33] tracking-[-0.05px] text-white">
+                           {i + 1}
                         </span>
                      </div>
 
-                     {/* 날짜/시간 + 장소 */}
-                     <div className="flex flex-col gap-2">
-                        <div className="flex items-center gap-2 h-5">
-                           <Calendar className="size-4 text-(--text-tertiary) shrink-0" />
-                           <div className="flex items-center gap-2.5 text-label-2-medium text-(--text-tertiary)">
-                              <span>{match.date.replace(/-/g, '.')}</span>
-                              <span className="w-px h-3 bg-border" />
-                              <span>{match.time}</span>
+                     <div className="flex flex-col gap-4 p-6">
+                        <div className="flex items-center justify-between h-7">
+                           <span className="w-17.5 text-[18px] font-bold leading-[1.55] text-foreground">
+                              {match.awayTeamName}
+                           </span>
+                           <span className="text-[14px] font-bold text-(--text-tertiary)">vs</span>
+                           <span className="w-17.5 text-[18px] font-bold leading-[1.55] text-foreground text-right">
+                              {match.homeTeamName}
+                           </span>
+                        </div>
+
+                        <div className="flex flex-col gap-2">
+                           <div className="flex items-center gap-2 h-5">
+                              <Calendar className="size-4 text-(--text-tertiary) shrink-0" />
+                              <div className="flex items-center gap-2.5 text-label-2-medium text-(--text-tertiary)">
+                                 <span>{match.date.replace(/-/g, '.')}</span>
+                                 <span className="w-px h-3 bg-border" />
+                                 <span>{match.time}</span>
+                              </div>
+                           </div>
+                           <div className="flex items-center gap-2 h-5">
+                              <MapPin className="size-4 text-(--text-tertiary) shrink-0" />
+                              <span className="text-label-2-medium text-(--text-tertiary)">{match.venue}</span>
                            </div>
                         </div>
-                        <div className="flex items-center gap-2 h-5">
-                           <MapPin className="size-4 text-(--text-tertiary) shrink-0" />
-                           <span className="text-label-2-medium text-(--text-tertiary)">{match.venue}</span>
-                        </div>
                      </div>
                   </div>
-               </div>
-            ))}
-         </div>
+               ))}
+            </div>
+         )}
       </section>
    );
 };

--- a/src/pages/home/ui/game-schedule/ScheduleList.tsx
+++ b/src/pages/home/ui/game-schedule/ScheduleList.tsx
@@ -7,6 +7,24 @@ import { TAB_TODAY, TEAM_IDS, statusColor, teamLogos } from './constants';
 import type { DaySchedule, GameRow } from './types';
 import { getGameResultTexts } from './utils';
 
+const VENUE_REGION_LABELS: Record<string, string> = {
+  '기아 챔피언스필드': '광주',
+  '광주 기아 챔피언스 필드': '광주',
+  '대구 삼성 라이온즈 파크': '대구',
+  '대구 삼성라이온즈파크': '대구',
+  '잠실 야구장': '잠실',
+  '사직 야구장': '사직',
+  '창원 NC파크': '창원',
+  '고척 스카이돔': '고척',
+  '수원 KT위즈파크': '수원',
+  '대전 한화생명 볼파크': '대전',
+  '인천 SSG 랜더스필드': '인천',
+};
+
+const toVenueRegionLabel = (venue: string) => {
+  return VENUE_REGION_LABELS[venue] ?? venue;
+};
+
 function ScoreDisplay({ game }: { game: GameRow }) {
   const scoreText = game.score ?? 'VS';
 
@@ -236,6 +254,7 @@ function MobileGameRow({
   const isEnded = game.status === '종료';
   const textDisabled = isEnded ? 'text-[#acb4bb]' : 'text-(--text-primary)';
   const resultText = getGameResultTexts(game.score, isEnded);
+  const venueLabel = toVenueRegionLabel(game.venue);
 
   return (
     <div
@@ -251,7 +270,7 @@ function MobileGameRow({
         </span>
         <span className="text-[14px] leading-[1.5] whitespace-nowrap text-[#acb4bb]">|</span>
         <span className={cn('text-[14px] font-semibold leading-[1.5] whitespace-nowrap', textDisabled)}>
-          {game.venue}
+          {venueLabel}
         </span>
       </div>
 
@@ -295,6 +314,7 @@ function DesktopGameRow({
   const isEnded = game.status === '종료';
   const textDisabled = isEnded ? 'text-[#acb4bb]' : 'text-(--text-primary)';
   const resultText = getGameResultTexts(game.score, isEnded);
+  const venueLabel = toVenueRegionLabel(game.venue);
 
   return (
     <div
@@ -312,7 +332,7 @@ function DesktopGameRow({
         </div>
         <div className="flex items-center justify-center w-[40px]">
           <span className={cn('text-[20px] font-semibold text-center leading-[1.5] whitespace-nowrap', textDisabled)}>
-            {game.venue}
+            {venueLabel}
           </span>
         </div>
       </div>

--- a/src/pages/tickets/api/paymentApi.ts
+++ b/src/pages/tickets/api/paymentApi.ts
@@ -321,10 +321,9 @@ export const submitTicketOrder = async (payload: TicketCheckoutRequest): Promise
       ordererEmail: payload.ordererEmail,
    });
 
-   // 테스트를 위해 일반 예매 결제의 사용자 ID 검증을 잠시 비활성화합니다.
-   // if (!payload.userId) {
-   //    throw new Error('결제 사용자 ID가 없어 주문 확정을 진행할 수 없습니다. 로그인 정보를 다시 확인해 주세요.');
-   // }
+   if (!payload.userId) {
+      throw new Error('결제 사용자 ID가 없어 주문 확정을 진행할 수 없습니다. 로그인 정보를 다시 확인해 주세요.');
+   }
 
    const payment = await createOrderPayment(order.orderId, {
       paymentMethod: toPaymentMethodCode(payload.paymentMethod),
@@ -332,7 +331,7 @@ export const submitTicketOrder = async (payload: TicketCheckoutRequest): Promise
    });
 
    const confirmation = await confirmOrderPayment(order.orderId, {
-      userId: payload.userId ?? '8df84c70-833e-4374-85ad-fa52f92f939e',
+      userId: payload.userId,
       paymentId: payment.paymentId,
       pgTid: payment.pgTid,
    });

--- a/src/pages/tickets/api/paymentApi.ts
+++ b/src/pages/tickets/api/paymentApi.ts
@@ -228,7 +228,7 @@ const toPaymentMethodLabel = (paymentMethod: PaymentMethod) => {
 
 const holdSeat = async (seatId: string, payload: HoldSeatRequest) => {
    const response = await apiClient.post<ApiEnvelope<HoldSeatResponse>>(
-      `/api/v1/seat-reservations/seats/${seatId}`,
+      `/api/v1/seat-reservations/seats/${encodeURIComponent(seatId)}`,
       payload,
    );
 

--- a/src/pages/tickets/ui/GameCard.tsx
+++ b/src/pages/tickets/ui/GameCard.tsx
@@ -2,6 +2,7 @@
 
 import { CalendarDays, MapPin, Ticket } from 'lucide-react';
 
+import { formatBookingCardDateTime } from '@/shared/lib/bookingDateTime';
 import { cn } from '@/shared/lib/utils';
 
 import type { GameItem, TabType } from './types';
@@ -52,6 +53,7 @@ export function GameCard({ game, activeTab, onBookingClick }: GameCardProps) {
    const status = activeTab === '예매' ? game.bookingStatus : game.resellStatus;
    const { label: buttonLabel, isActive } = getButtonConfig(status, activeTab);
    const showPrice = game.minPrice > 0;
+   const formattedDateTime = formatBookingCardDateTime(game.dateTime);
 
    const formatPrice = (price: number) => price.toLocaleString('ko-KR') + '원';
 
@@ -73,7 +75,7 @@ export function GameCard({ game, activeTab, onBookingClick }: GameCardProps) {
             <div className="flex items-center gap-4 flex-wrap">
                <div className="flex items-center gap-2 h-5">
                   <CalendarDays className="size-4 text-muted-foreground shrink-0" />
-                  <span className="text-body-2-regular text-muted-foreground whitespace-nowrap">{game.dateTime}</span>
+                  <span className="text-body-2-regular text-muted-foreground whitespace-nowrap">{formattedDateTime}</span>
                </div>
                <div className="flex items-center gap-2 h-5">
                   <MapPin className="size-4 text-muted-foreground shrink-0" />

--- a/src/pages/tickets/ui/payment/ResellPaymentPage.tsx
+++ b/src/pages/tickets/ui/payment/ResellPaymentPage.tsx
@@ -101,7 +101,7 @@ export default function ResellPaymentPage() {
    // 무통장 입금 + 미발행이 아닌 경우 현금영수증 번호 필수
    const isCashReceiptValid = paymentMethod !== 'bank' || cashReceiptType === 'none' || !!cashReceiptNum;
    const isFormValid = !!name && phone.length === 11 && !!email && isCashReceiptValid && agreedPrivacy && agreedResell;
-   const resolvedBuyerId = resellEntryState?.buyerId ?? resolveUserIdFromAccessToken(accessToken) ?? resaleEntry.buyerId;
+   const resolvedBuyerId = resellEntryState?.buyerId ?? resolveUserIdFromAccessToken(accessToken);
 
    const orderInfo = {
       matchTitle: resellEntryState?.matchTitle ?? MOCK_GAME.matchTitle,
@@ -117,11 +117,10 @@ export default function ResellPaymentPage() {
    const ticketPrice = Math.max(totalPayment - fee, 0);
 
    const handlePay = () => {
-      // 테스트를 위해 리셀 결제 단계의 로그인 사용자 확인을 잠시 비활성화합니다.
-      // if (!resolvedBuyerId) {
-      //    window.alert('구매자 정보를 확인할 수 없습니다. 다시 로그인한 뒤 시도해 주세요.');
-      //    return;
-      // }
+      if (!resolvedBuyerId) {
+         window.alert('구매자 정보를 확인할 수 없습니다. 다시 로그인한 뒤 시도해 주세요.');
+         return;
+      }
 
       const paymentRequest: ResaleCheckoutRequest = {
          buyerId: resolvedBuyerId,

--- a/src/pages/tickets/ui/payment/TicketPaymentPage.tsx
+++ b/src/pages/tickets/ui/payment/TicketPaymentPage.tsx
@@ -214,11 +214,10 @@ export default function TicketPaymentPage() {
          return;
       }
 
-      // 테스트를 위해 결제 단계의 로그인 사용자 확인을 잠시 비활성화합니다.
-      // if (!resolvedUserId) {
-      //    window.alert('결제 사용자 정보를 확인할 수 없습니다. 다시 로그인한 뒤 시도해 주세요.');
-      //    return;
-      // }
+      if (!resolvedUserId) {
+         window.alert('결제 사용자 정보를 확인할 수 없습니다. 다시 로그인한 뒤 시도해 주세요.');
+         return;
+      }
 
       const paymentRequest: TicketCheckoutRequest = {
          gameId: bookingEntryState.gameId,

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -400,7 +400,7 @@ export const paymentHandlers = [
          gameId?: string;
          queueTokenJti?: string;
       }>(request);
-      const seatId = String(params.seatId);
+      const seatId = decodeURIComponent(String(params.seatId));
       const gameId = body?.gameId?.trim() || 'mock-game-id';
       const queueTokenJti = body?.queueTokenJti?.trim() || `mock-queue-token-${seatId}`;
 

--- a/src/shared/lib/bookingDateTime.ts
+++ b/src/shared/lib/bookingDateTime.ts
@@ -1,0 +1,83 @@
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+type BookingDateTimeFormat = 'header' | 'card';
+
+export const parseBookingDateTime = (value: string) => {
+   const normalizedValue = value.trim();
+   const fullDateMatch = normalizedValue.match(
+      /^(\d{4})[.-](\d{1,2})[.-](\d{1,2})(?:\s*\(([일월화수목금토])\))?\s+(?:(오전|오후)\s*)?(\d{1,2}):(\d{2})$/,
+   );
+
+   if (fullDateMatch) {
+      const [, year, month, day, , meridiem, hour, minute] = fullDateMatch;
+      const parsedHour = Number(hour);
+      const normalizedHour =
+         meridiem === '오전' && parsedHour === 12
+            ? 0
+            : meridiem === '오후' && parsedHour < 12
+              ? parsedHour + 12
+              : parsedHour;
+      const parsed = new Date(Number(year), Number(month) - 1, Number(day), normalizedHour, Number(minute));
+
+      if (!Number.isNaN(parsed.getTime())) {
+         return parsed;
+      }
+   }
+
+   const figmaStyleMatch = normalizedValue.match(
+      /^(\d{1,2})\.(\d{1,2})\s+\(([일월화수목금토])\)\s+(오전|오후)\s+(\d{1,2}):(\d{2})$/,
+   );
+
+   if (!figmaStyleMatch) {
+      return null;
+   }
+
+   const [, month, day, , meridiem, hour, minute] = figmaStyleMatch;
+   const parsedHour = Number(hour);
+   const normalizedHour =
+      meridiem === '오전' && parsedHour === 12
+         ? 0
+         : meridiem === '오후' && parsedHour < 12
+           ? parsedHour + 12
+           : parsedHour;
+   const parsed = new Date(new Date().getFullYear(), Number(month) - 1, Number(day), normalizedHour, Number(minute));
+
+   return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const formatBookingDateTime = (value: string, format: BookingDateTimeFormat) => {
+   const normalizedValue = value.trim();
+   const parsed = parseBookingDateTime(normalizedValue);
+
+   if (!parsed) {
+      return normalizedValue;
+   }
+
+   const year = String(parsed.getFullYear());
+   const month = String(parsed.getMonth() + 1).padStart(2, '0');
+   const day = String(parsed.getDate()).padStart(2, '0');
+   const dayLabel = DAY_LABELS[parsed.getDay()];
+   const hours = parsed.getHours();
+   const meridiem = hours < 12 ? '오전' : '오후';
+   const displayHour = String(hours).padStart(2, '0');
+   const minutes = String(parsed.getMinutes()).padStart(2, '0');
+
+   switch (format) {
+      case 'header':
+         return `${Number(month)}.${day} (${dayLabel}) ${meridiem} ${displayHour}:${minutes}`;
+      case 'card':
+         return `${year}.${month}.${day} (${dayLabel}) ${displayHour}:${minutes}`;
+   }
+};
+
+export const formatBookingHeaderDateTime = (value?: string) => {
+   if (!value) {
+      return undefined;
+   }
+
+   return formatBookingDateTime(value, 'header');
+};
+
+export const formatBookingCardDateTime = (value: string) => {
+   return formatBookingDateTime(value, 'card');
+};

--- a/src/shared/lib/use-booking-entry-flow.tsx
+++ b/src/shared/lib/use-booking-entry-flow.tsx
@@ -27,11 +27,10 @@ export function useBookingEntryFlow() {
   const [pendingEntryState, setPendingEntryState] = useState<BookingEntryState | null>(null);
 
   const openBookingEntry = (options?: OpenBookingEntryOptions) => {
-    // 테스트를 위해 예매 진입 단계의 로그인 여부 확인을 잠시 비활성화합니다.
-    // if (!accessToken) {
-    //   navigate('/auth/login');
-    //   return;
-    // }
+    if (!accessToken) {
+      navigate('/auth/login');
+      return;
+    }
 
     const nextEntryState = {
       requireCaptcha: true,

--- a/src/shared/widgets/layout/books/BooksHeader.tsx
+++ b/src/shared/widgets/layout/books/BooksHeader.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { ChevronLeft, HelpCircle, User } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { getBookingTeamConfig } from '@/pages/books/model/zoneData';
+import { formatBookingHeaderDateTime } from '@/shared/lib/bookingDateTime';
 import { useSeatSelectionStore } from '@/pages/books/model/useSeatSelectionStore';
 import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import { DEFAULT_BOOKING_TIMER_SECONDS, useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
@@ -101,7 +102,7 @@ const BooksHeader = ({
    const resolvedMatchTitle =
       matchTitle ?? bookingEntryState?.matchTitle ?? `${bookingTeamConfig.displayName} 홈경기`;
    const resolvedVenue = venue ?? bookingEntryState?.venue ?? bookingTeamConfig.stadiumName;
-   const resolvedDateTime = dateTime ?? bookingEntryState?.dateTime ?? DEFAULT_MATCH_INFO.dateTime;
+   const resolvedDateTime = formatBookingHeaderDateTime(dateTime ?? bookingEntryState?.dateTime ?? DEFAULT_MATCH_INFO.dateTime);
 
    useEffect(() => {
       if (!showTimer || expiresAt === null || remainingSeconds > 0) {
@@ -184,7 +185,7 @@ const BooksHeader = ({
                   <p className="text-body-1-bold text-foreground">{resolvedMatchTitle}</p>
                   <div className="flex flex-wrap items-center gap-1 text-caption-1-medium text-secondary">
                      <span>{resolvedVenue}</span>
-                     <span aria-hidden="true">·</span>
+                     <span aria-hidden="true">∙</span>
                      <span>{resolvedDateTime}</span>
                   </div>
                </div>
@@ -247,7 +248,7 @@ const BooksHeader = ({
                   ) : null}
                   <h1 className="mr-2 text-heading-2-bold text-foreground">{resolvedMatchTitle}</h1>
                   <span>{resolvedVenue}</span>
-                  <span aria-hidden="true">·</span>
+                  <span aria-hidden="true">∙</span>
                   <span>{resolvedDateTime}</span>
                </div>
                <ol className="flex flex-wrap items-center gap-1 lg:gap-2" aria-label="예매 진행 단계">


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #118

<br/>

## 🔎 개요
- 경기장명 및 예매 일시 표기 통일화
- 경기 일정 최초 조회 이후 뷰에서 경기일정이 보이지 않는 문제 해결
- 예매 구역 API 응답 병합을 통한 좌석 섹션 누락 문제 해결

<br/>

## 📋 작업 내용
- 경기장명 및 예매 일시 표기 통일화
- 경기 일정 최초 조회 이후 뷰에서 경기일정이 보이지 않는 문제 해결
- 예매 구역 API 응답 병합을 통한 좌석 섹션 누락 문제 해결
- 좌석 점유 seatId path 인코딩 처리(/등 특수문자로 인한 url 오류를 막기 위함)

<br/>
