### PR TITLE
[bug] 결제 진행 이후 완료 화면 이동하지 않는 버그 해결 

### DIFF
--- a/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
@@ -23,9 +23,10 @@ export default function PaymentProcessingPage() {
    const { state } = useLocation();
    const locationState = state as { request: TicketCheckoutRequest | ResaleCheckoutRequest; amount: number } | null;
    const hasStartedRef = useRef(false);
+   const isMountedRef = useRef(false);
 
    useEffect(() => {
-      let isActive = true;
+      isMountedRef.current = true;
 
       if (!locationState?.request) {
          navigate('/tickets/payment', { replace: true });
@@ -49,14 +50,14 @@ export default function PaymentProcessingPage() {
                submitOrder(paymentRequest),
                new Promise(resolve => setTimeout(resolve, 1000)),
             ]);
-            if (isActive && isStillOnProcessingPage()) {
+            if (isMountedRef.current && isStillOnProcessingPage()) {
                navigate(
                   `/tickets/payment/complete?delivery=${paymentRequest.deliveryMethod}`,
                   { state: { ...result, amount: clientAmount }, replace: true },
                );
             }
          } catch (error) {
-            if (isStillOnProcessingPage()) {
+            if (isMountedRef.current && isStillOnProcessingPage()) {
                const message =
                   error instanceof ApiError
                      ? error.message
@@ -70,7 +71,7 @@ export default function PaymentProcessingPage() {
       process();
 
       return () => {
-         isActive = false;
+         isMountedRef.current = false;
       };
    }, [locationState, navigate]);
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #125

<br/>

## 🔎 개요
React.StrictMode에서 PaymentProcessingPage의 useEffect가 개발 환경에서 재실행될 때, 첫 실행의 cleanup이 isActive = false로 바꿔 놓고 두 번째 실행은 hasStartedRef 때문에 실제 처리 없이 끝나서, 결제 API가 성공해도 완료 페이지로 navigate하지 못하던 구조 수정

<br/>

## 📋 작업 내용
- React.StrictMode에서 PaymentProcessingPage의 useEffect가 개발 환경에서 재실행될 때, 첫 실행의 cleanup이 isActive = false로 바꿔 놓고 두 번째 실행은 hasStartedRef 때문에 실제 처리 없이 끝나서, 결제 API가 성공해도 완료 페이지로 navigate하지 못하던 구조 수정


<br/>
