### PR TITLE
[feat] 리셀 예매 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.90.20",
         "@tanstack/react-table": "^8.21.3",
         "antd": "^6.2.2",
+        "apexcharts": "^5.10.4",
         "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2762,7 +2763,6 @@
       "integrity": "sha512-VAFO6cM+cyg2ntxNW6g3tB2Jc5J5mpLjLluvm7VtW2uceNzyUlVv41o66Yp1t1ikxd3ljtqegViXem62JqzveA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rspack/core": "~1.7.1",
         "@rspack/lite-tapable": "~1.1.0",
@@ -3018,7 +3018,6 @@
       "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -3445,7 +3444,6 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3456,7 +3454,6 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3467,7 +3464,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3587,6 +3583,12 @@
         "react-dom": ">=18.0.0"
       }
     },
+    "node_modules/apexcharts": {
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.10.4.tgz",
+      "integrity": "sha512-gt0VUqZ2+mr25ScbUcKZgJr96jKYm4vjOcxEWCEh/E5F4dWqhyo3dBhPRvNNnkKiWxkMd2cBwj3ZYH3rK39fkA==",
+      "license": "SEE LICENSE IN LICENSE"
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmmirror.com/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -3683,7 +3685,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3985,8 +3986,7 @@
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -4886,7 +4886,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4991,7 +4990,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5001,7 +4999,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5014,7 +5011,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5038,7 +5034,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5063,7 +5058,6 @@
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5209,8 +5203,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5478,7 +5471,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "pixi.js": "^8.15.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.3",
+        "react-apexcharts": "^2.1.0",
         "react-dom": "^19.2.3",
         "react-hook-form": "^7.71.1",
         "react-router-dom": "^7.3.0",
@@ -4421,6 +4422,12 @@
       "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
       "license": "MIT"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/json2mq": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
@@ -4691,6 +4698,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "0.563.0",
       "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-0.563.0.tgz",
@@ -4819,6 +4838,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -4900,6 +4928,23 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
@@ -4992,6 +5037,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-apexcharts": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-apexcharts/-/react-apexcharts-2.1.0.tgz",
+      "integrity": "sha512-xrmeTKRKHh3cvvLc8SasqFjlOgIqGpyHc81qjnRtcjUM0Fu7qEjgVRWGPokGFjqhwRZVgEym8zmuEyYr5LMYIg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "apexcharts": ">=5.10.1",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "pixi.js": "^8.15.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.3",
+    "react-apexcharts": "^2.1.0",
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.71.1",
     "react-router-dom": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-table": "^8.21.3",
     "antd": "^6.2.2",
+    "apexcharts": "^5.10.4",
     "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/pages/books/model/resellData.ts
+++ b/src/pages/books/model/resellData.ts
@@ -1,8 +1,11 @@
-import type { ZoneItem } from './types';
+import type { SeatItem, ZoneItem } from './types';
+
+export type ResellTradeRange = 'minute' | 'day';
 
 type PricePoint = {
    time: string;
    price: number;
+   occurredAt: string;
 };
 
 type TradeHistoryItem = {
@@ -12,11 +15,19 @@ type TradeHistoryItem = {
    tradedAt: string;
 };
 
-type ListingItem = {
-   id: string;
+export type ResellListingItem = {
+   listingId: string;
+   sellerId: string;
+   seatId: string;
+   seatInfo: string;
    seatLabel: string;
-   seller: string;
-   price: number;
+   listingPrice: number;
+   totalAmount: number;
+   totalBuyerFee: number;
+   totalSellerFee: number;
+   settlementAmount: number;
+   listedAt: string;
+   isPurchasable: boolean;
 };
 
 export type ResellZoneInsights = {
@@ -26,105 +37,132 @@ export type ResellZoneInsights = {
    recentTrade: number;
    dayLow: number;
    dayHigh: number;
-   pricePoints: PricePoint[];
+   pricePointsByRange: Record<ResellTradeRange, PricePoint[]>;
    tradeHistory: TradeHistoryItem[];
-   listings: ListingItem[];
+   listings: ResellListingItem[];
 };
 
-const timeLabels = ['14:00', '14:45', '15:30', '16:15', '17:00', '17:45', '18:30'];
+const minuteLabels = ['14:00', '14:45', '15:30', '16:15', '17:00', '17:45', '18:30'];
+const dayLabels = ['03/14', '03/15', '03/16', '03/17', '03/18', '03/19', '03/20'];
+const minuteOccurredAt = [
+   '2026-03-20T14:00:00+09:00',
+   '2026-03-20T14:45:00+09:00',
+   '2026-03-20T15:30:00+09:00',
+   '2026-03-20T16:15:00+09:00',
+   '2026-03-20T17:00:00+09:00',
+   '2026-03-20T17:45:00+09:00',
+   '2026-03-20T18:30:00+09:00',
+];
+const dayOccurredAt = [
+   '2026-03-14T18:00:00+09:00',
+   '2026-03-15T18:00:00+09:00',
+   '2026-03-16T18:00:00+09:00',
+   '2026-03-17T18:00:00+09:00',
+   '2026-03-18T18:00:00+09:00',
+   '2026-03-19T18:00:00+09:00',
+   '2026-03-20T18:00:00+09:00',
+];
 
-function createPricePoints(basePrice: number, delta: number): PricePoint[] {
-   const prices = [
-      basePrice - delta,
-      basePrice - Math.round(delta * 0.45),
-      basePrice + Math.round(delta * 0.3),
-      basePrice + Math.round(delta * 0.9),
-      basePrice + Math.round(delta * 0.55),
-      basePrice + Math.round(delta * 1.15),
-      basePrice + delta,
-   ];
+const formatSeatInfo = (zone: ZoneItem, seat: SeatItem) => `${zone.name} ${seat.rowLabel} ${seat.seatNumber}번`;
 
-   return timeLabels.map((time, index) => ({
+const formatSeatLabel = (zone: ZoneItem, seat: SeatItem) => `${zone.sectionCode}구역 ${seat.rowLabel} ${seat.seatNumber}번`;
+
+const createPricePoints = (labels: string[], prices: number[], occurredAtList: string[]): PricePoint[] => {
+   return labels.map((time, index) => ({
       time,
-      price: Math.max(5000, prices[index] ?? basePrice),
+      price: prices[index] ?? prices[prices.length - 1] ?? 0,
+      occurredAt: occurredAtList[index] ?? occurredAtList[occurredAtList.length - 1] ?? '',
    }));
-}
+};
 
-function createTradeHistory(zone: ZoneItem, basePrice: number, delta: number): TradeHistoryItem[] {
-   return [
-      {
-         id: `${zone.id}-history-1`,
-         price: basePrice + delta,
-         seatLabel: `${zone.sectionCode}구역 0열 0번`,
-         tradedAt: '40분 전',
-      },
-      {
-         id: `${zone.id}-history-2`,
-         price: basePrice + Math.round(delta * 0.6),
-         seatLabel: `${zone.sectionCode}구역 10열 11번`,
-         tradedAt: '6시간 전',
-      },
-      {
-         id: `${zone.id}-history-3`,
-         price: basePrice + Math.round(delta * 1.75),
-         seatLabel: `${zone.sectionCode}구역 27열 9번`,
-         tradedAt: '03/07 14:23',
-      },
-      {
-         id: `${zone.id}-history-4`,
-         price: basePrice,
-         seatLabel: `${zone.sectionCode}구역 4열 5번`,
-         tradedAt: '03/05 19:02',
-      },
-   ];
-}
+const createListingPrice = (zonePrice: number, seat: SeatItem, index: number) => {
+   const basePrice = Math.max(zonePrice, 10000);
+   const rowPremium = Math.max(0, 6 - Math.min(6, Number.parseInt(seat.rowLabel, 10) || 6)) * 1000;
+   const seatPremium = (seat.seatNumber % 5) * 500;
 
-function createListings(zone: ZoneItem, basePrice: number, delta: number): ListingItem[] {
-   return [
-      {
-         id: `${zone.id}-listing-1`,
-         seatLabel: `${zone.sectionCode}구역 0열 0번`,
-         seller: '실시간 등록',
-         price: basePrice + delta,
-      },
-      {
-         id: `${zone.id}-listing-2`,
-         seatLabel: `${zone.sectionCode}구역 2열 4번`,
-         seller: '즉시 구매 가능',
-         price: basePrice + Math.round(delta * 0.8),
-      },
-      {
-         id: `${zone.id}-listing-3`,
-         seatLabel: `${zone.sectionCode}구역 8열 12번`,
-         seller: '모바일 티켓',
-         price: basePrice + Math.round(delta * 0.55),
-      },
-      {
-         id: `${zone.id}-listing-4`,
-         seatLabel: `${zone.sectionCode}구역 14열 3번`,
-         seller: '안전결제',
-         price: basePrice + Math.round(delta * 0.35),
-      },
-   ];
-}
+   return basePrice + rowPremium + seatPremium + index * 500;
+};
 
-export function getResellZoneInsights(zone: ZoneItem): ResellZoneInsights {
-   const basePrice = Math.max(zone.price, 10000);
-   const changeAmount = Math.max(2000, Math.round(basePrice * 0.25 / 1000) * 1000);
-   const previousClose = Math.max(5000, basePrice - changeAmount);
-   const recentTrade = basePrice + Math.round(changeAmount * 0.65);
+export function getResellZoneInsights({
+   zone,
+   seats,
+}: {
+   zone: ZoneItem;
+   seats: SeatItem[];
+}): ResellZoneInsights {
+   const listedSeats = seats
+      .filter((seat) => seat.status === 'available')
+      .sort(
+         (left, right) =>
+            left.block.localeCompare(right.block, 'ko-KR', { numeric: true, sensitivity: 'base' }) ||
+            left.rowLabel.localeCompare(right.rowLabel, 'ko-KR', { numeric: true, sensitivity: 'base' }) ||
+            left.seatNumber - right.seatNumber,
+      )
+      .slice(0, 8);
+
+   const listings = listedSeats.map((seat, index) => {
+      const listingPrice = createListingPrice(zone.price, seat, index);
+      const totalBuyerFee = 2000;
+      const totalSellerFee = Math.max(1000, Math.round(listingPrice * 0.05 / 1000) * 1000);
+
+      return {
+         listingId: `listing-${seat.id}`,
+         sellerId: `seller-${zone.id}-${index + 1}`,
+         seatId: seat.id,
+         seatInfo: formatSeatInfo(zone, seat),
+         seatLabel: formatSeatLabel(zone, seat),
+         listingPrice,
+         totalAmount: listingPrice + totalBuyerFee,
+         totalBuyerFee,
+         totalSellerFee,
+         settlementAmount: Math.max(0, listingPrice - totalSellerFee),
+         listedAt: `2026-03-20T0${Math.min(index, 9)}:00:00.000Z`,
+         isPurchasable: true,
+      } satisfies ResellListingItem;
+   });
+
+   const previousClose = Math.max(zone.price, 10000);
+   const recentTrade = listings[0]?.listingPrice ?? previousClose;
+   const changeAmount = recentTrade - previousClose;
    const dayLow = Math.max(5000, previousClose - Math.round(previousClose * 0.3));
-   const dayHigh = recentTrade + Math.round(changeAmount * 0.2);
+   const dayHigh = Math.max(recentTrade, previousClose + Math.round(previousClose * 0.3));
+   const minutePrices = [
+      previousClose - 2000,
+      previousClose + 500,
+      previousClose + 3500,
+      previousClose + 6000,
+      previousClose + 4500,
+      previousClose + 8000,
+      previousClose + 7000,
+   ];
+   const dayPrices = [
+      previousClose - 3000,
+      previousClose - 1500,
+      previousClose + 500,
+      previousClose + 1500,
+      previousClose + 2800,
+      previousClose + 4200,
+      recentTrade,
+   ];
+   const tradeHistory = listings.slice(0, 4).map((listing, index) => ({
+      id: `${listing.listingId}-history`,
+      price: listing.listingPrice,
+      seatLabel: listing.seatLabel,
+      tradedAt: ['40분 전', '6시간 전', '03/07 14:23', '03/07 14:23'][index] ?? '방금 전',
+   }));
 
    return {
       changeAmount,
-      changeRate: Number(((changeAmount / previousClose) * 100).toFixed(2)),
+      changeRate: previousClose > 0 ? Number(((changeAmount / previousClose) * 100).toFixed(2)) : 0,
       previousClose,
       recentTrade,
       dayLow,
       dayHigh,
-      pricePoints: createPricePoints(basePrice, changeAmount),
-      tradeHistory: createTradeHistory(zone, basePrice, changeAmount),
-      listings: createListings(zone, basePrice, changeAmount),
+      pricePointsByRange: {
+         minute: createPricePoints(minuteLabels, minutePrices, minuteOccurredAt),
+         day: createPricePoints(dayLabels, dayPrices, dayOccurredAt),
+      },
+      tradeHistory,
+      listings,
    };
 }

--- a/src/pages/books/model/resellData.ts
+++ b/src/pages/books/model/resellData.ts
@@ -1,0 +1,130 @@
+import type { ZoneItem } from './types';
+
+type PricePoint = {
+   time: string;
+   price: number;
+};
+
+type TradeHistoryItem = {
+   id: string;
+   price: number;
+   seatLabel: string;
+   tradedAt: string;
+};
+
+type ListingItem = {
+   id: string;
+   seatLabel: string;
+   seller: string;
+   price: number;
+};
+
+export type ResellZoneInsights = {
+   changeAmount: number;
+   changeRate: number;
+   previousClose: number;
+   recentTrade: number;
+   dayLow: number;
+   dayHigh: number;
+   pricePoints: PricePoint[];
+   tradeHistory: TradeHistoryItem[];
+   listings: ListingItem[];
+};
+
+const timeLabels = ['14:00', '14:45', '15:30', '16:15', '17:00', '17:45', '18:30'];
+
+function createPricePoints(basePrice: number, delta: number): PricePoint[] {
+   const prices = [
+      basePrice - delta,
+      basePrice - Math.round(delta * 0.45),
+      basePrice + Math.round(delta * 0.3),
+      basePrice + Math.round(delta * 0.9),
+      basePrice + Math.round(delta * 0.55),
+      basePrice + Math.round(delta * 1.15),
+      basePrice + delta,
+   ];
+
+   return timeLabels.map((time, index) => ({
+      time,
+      price: Math.max(5000, prices[index] ?? basePrice),
+   }));
+}
+
+function createTradeHistory(zone: ZoneItem, basePrice: number, delta: number): TradeHistoryItem[] {
+   return [
+      {
+         id: `${zone.id}-history-1`,
+         price: basePrice + delta,
+         seatLabel: `${zone.sectionCode}구역 0열 0번`,
+         tradedAt: '40분 전',
+      },
+      {
+         id: `${zone.id}-history-2`,
+         price: basePrice + Math.round(delta * 0.6),
+         seatLabel: `${zone.sectionCode}구역 10열 11번`,
+         tradedAt: '6시간 전',
+      },
+      {
+         id: `${zone.id}-history-3`,
+         price: basePrice + Math.round(delta * 1.75),
+         seatLabel: `${zone.sectionCode}구역 27열 9번`,
+         tradedAt: '03/07 14:23',
+      },
+      {
+         id: `${zone.id}-history-4`,
+         price: basePrice,
+         seatLabel: `${zone.sectionCode}구역 4열 5번`,
+         tradedAt: '03/05 19:02',
+      },
+   ];
+}
+
+function createListings(zone: ZoneItem, basePrice: number, delta: number): ListingItem[] {
+   return [
+      {
+         id: `${zone.id}-listing-1`,
+         seatLabel: `${zone.sectionCode}구역 0열 0번`,
+         seller: '실시간 등록',
+         price: basePrice + delta,
+      },
+      {
+         id: `${zone.id}-listing-2`,
+         seatLabel: `${zone.sectionCode}구역 2열 4번`,
+         seller: '즉시 구매 가능',
+         price: basePrice + Math.round(delta * 0.8),
+      },
+      {
+         id: `${zone.id}-listing-3`,
+         seatLabel: `${zone.sectionCode}구역 8열 12번`,
+         seller: '모바일 티켓',
+         price: basePrice + Math.round(delta * 0.55),
+      },
+      {
+         id: `${zone.id}-listing-4`,
+         seatLabel: `${zone.sectionCode}구역 14열 3번`,
+         seller: '안전결제',
+         price: basePrice + Math.round(delta * 0.35),
+      },
+   ];
+}
+
+export function getResellZoneInsights(zone: ZoneItem): ResellZoneInsights {
+   const basePrice = Math.max(zone.price, 10000);
+   const changeAmount = Math.max(2000, Math.round(basePrice * 0.25 / 1000) * 1000);
+   const previousClose = Math.max(5000, basePrice - changeAmount);
+   const recentTrade = basePrice + Math.round(changeAmount * 0.65);
+   const dayLow = Math.max(5000, previousClose - Math.round(previousClose * 0.3));
+   const dayHigh = recentTrade + Math.round(changeAmount * 0.2);
+
+   return {
+      changeAmount,
+      changeRate: Number(((changeAmount / previousClose) * 100).toFixed(2)),
+      previousClose,
+      recentTrade,
+      dayLow,
+      dayHigh,
+      pricePoints: createPricePoints(basePrice, changeAmount),
+      tradeHistory: createTradeHistory(zone, basePrice, changeAmount),
+      listings: createListings(zone, basePrice, changeAmount),
+   };
+}

--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchSeatGrades, fetchSeatSections, mapSeatSectionsToZones, mergeBookingZones } from '@/pages/books/api/bookingApi';
 import { getBookingTeamConfig, getZoneDisplayOrder, getBookingZones } from '@/pages/books/model/zoneData';
 import type { ZoneItem } from '@/pages/books/model/types';
+import { getBookingFlowMode } from '@/shared/lib/booking-flow';
 import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import { Drawer, DrawerContent, DrawerTrigger } from '@/shared/ui/drawer';
 
@@ -24,6 +25,7 @@ const BooksPage = () => {
    const navigate = useNavigate();
    const location = useLocation();
    const routeBookingEntryState = location.state as BookingEntryState | null;
+   const bookingFlowMode = getBookingFlowMode(location.search);
    const bookingEntryState = useBookingEntryStore((state) => state.entry) ?? routeBookingEntryState;
    const setBookingEntry = useBookingEntryStore((state) => state.setEntry);
    const patchBookingEntry = useBookingEntryStore((state) => state.patchEntry);
@@ -141,7 +143,10 @@ const BooksPage = () => {
 
    const handleSelectZone = (zoneId: string) => {
       setSelectedZoneId(zoneId);
-      navigate(`/books/seats/${zoneId}`, {
+      navigate({
+         pathname: `/books/seats/${zoneId}`,
+         search: location.search,
+      }, {
          state: resolvedBookingEntryState,
       });
    };
@@ -160,7 +165,10 @@ const BooksPage = () => {
       setIsCaptchaOpen(false);
       setCaptchaInput('');
       setCaptchaError('');
-      navigate(location.pathname, {
+      navigate({
+         pathname: location.pathname,
+         search: location.search,
+      }, {
          replace: true,
          state: resolvedBookingEntryState,
       });
@@ -217,7 +225,9 @@ const BooksPage = () => {
                                  <div className="h-1 w-9 rounded-full bg-border-light" />
                               </div>
                               <div className="flex items-center justify-between gap-3">
-                                 <span className="text-heading-3-bold text-foreground">좌석 등급/잔여석</span>
+                                 <span className="text-heading-3-bold text-foreground">
+                                    {bookingFlowMode === 'resell' ? '리셀 좌석 구역' : '좌석 등급/잔여석'}
+                                 </span>
                                  <span className="text-body-1-medium text-tertiary">{zones.length}개 구역</span>
                               </div>
                            </button>

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -3,14 +3,16 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 
 import { createSeatsForZone } from '@/pages/books/model/seatData';
-import { getSelectedSeatPaymentSummary } from '@/pages/books/model/getSelectedSeatPaymentSummary';
+import { getResellZoneInsights, type ResellListingItem } from '@/pages/books/model/resellData';
 import { useSeatMapData } from '@/pages/books/model/useSeatMapData';
 import { useSeatSelectionStore } from '@/pages/books/model/useSeatSelectionStore';
 import { formatPrice, getBookingZones, getZoneOverviewImage, getStadiumName } from '@/pages/books/model/zoneData';
 import type { SeatItem } from '@/pages/books/model/types';
+import { getBookingFlowMode } from '@/shared/lib/booking-flow';
 import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import { Drawer, DrawerContent, DrawerTrigger } from '@/shared/ui/drawer';
 import SeatMapStage from './components/SeatMapStage';
+import ResellSeatSidebar from './components/ResellSeatSidebar';
 import SelectedSeatSummaryList, { type SelectedSeatSummaryItem } from './components/SelectedSeatSummaryList';
 import { useBotDetector } from '@/shared/lib/useBotDetector';
 
@@ -31,6 +33,8 @@ function SeatsPage() {
    const navigate = useNavigate();
    const location = useLocation();
    const { zoneId = '' } = useParams();
+   const bookingFlowMode = getBookingFlowMode(location.search);
+   const isResellMode = bookingFlowMode === 'resell';
    const routeBookingEntryState = location.state as BookingEntryState | null;
    const bookingEntryState = useBookingEntryStore((state) => state.entry) ?? routeBookingEntryState;
    const setBookingEntry = useBookingEntryStore((state) => state.setEntry);
@@ -121,6 +125,14 @@ function SeatsPage() {
       };
    }, []);
 
+   useEffect(() => {
+      if (!isResellMode) {
+         return;
+      }
+
+      clearAllSelections();
+   }, [clearAllSelections, isResellMode, zone.id]);
+
    const seats = useMemo(() => {
       if (!zoneSeatState) {
          return initialSeats;
@@ -154,14 +166,76 @@ function SeatsPage() {
    }, [bookingZones, zonesState]);
 
    const selectedPrice = selectedSeats.reduce((total, item) => total + item.price, 0);
-   const bookingButtonLabel = `${selectedSeats.length}매 예매하기`;
-   const paymentSummary = useMemo(
-      () => getSelectedSeatPaymentSummary(zonesState, bookingZones),
-      [bookingZones, zonesState],
+   const resellInsights = useMemo(
+      () =>
+         isResellMode
+            ? getResellZoneInsights({
+                 zone,
+                 seats,
+              })
+            : null,
+      [isResellMode, seats, zone],
    );
+   const resellListingBySeatId = useMemo(
+      () => new Map((resellInsights?.listings ?? []).map((listing) => [listing.seatId, listing])),
+      [resellInsights?.listings],
+   );
+   const selectedResellListing = useMemo(() => {
+      if (!isResellMode) {
+         return null;
+      }
+
+      const selectedSeatId = selectedSeats[0]?.seat.id;
+
+      return selectedSeatId ? resellListingBySeatId.get(selectedSeatId) ?? null : null;
+   }, [isResellMode, resellListingBySeatId, selectedSeats]);
+   const summaryPrice = isResellMode
+      ? (selectedResellListing?.totalAmount ?? selectedResellListing?.listingPrice ?? 0)
+      : selectedPrice;
+   const bookingButtonLabel = isResellMode ? '예매하기' : `${selectedSeats.length}매 예매하기`;
+   const displaySeats = useMemo(() => {
+      if (!isResellMode) {
+         return seats;
+      }
+
+      return seats.map((seat) => {
+         if (resellListingBySeatId.has(seat.id)) {
+            return seat;
+         }
+
+         return {
+            ...seat,
+            status: 'disabled',
+         } satisfies SeatItem;
+      });
+   }, [isResellMode, resellListingBySeatId, seats]);
 
    const handleProceedToPayment = () => {
       const botData = getBotReport();
+
+      if (isResellMode) {
+         if (!selectedResellListing) {
+            return;
+         }
+
+         navigate('/tickets/resell-payment', {
+            state: {
+               listingId: selectedResellListing.listingId,
+               queueTokenJti: bookingEntryState?.queueTokenJti,
+               sellerId: selectedResellListing.sellerId,
+               settlementAmount: selectedResellListing.settlementAmount,
+               totalAmount: selectedResellListing.totalAmount,
+               totalBuyerFee: selectedResellListing.totalBuyerFee,
+               totalSellerFee: selectedResellListing.totalSellerFee,
+               seatInfo: selectedResellListing.seatInfo,
+               matchTitle: bookingEntryState?.matchTitle,
+               venue: bookingEntryState?.venue,
+               dateTime: bookingEntryState?.dateTime,
+               botData,
+            },
+         });
+         return;
+      }
 
       navigate('/tickets/payment', {
          state: {
@@ -282,7 +356,32 @@ function SeatsPage() {
          return;
       }
 
+      if (isResellMode) {
+         if (!resellListingBySeatId.has(seat.id)) {
+            return;
+         }
+
+         const isAlreadySelected = selectedSeatIds.includes(seat.id);
+
+         if (!isAlreadySelected) {
+            clearAllSelections();
+         }
+
+         toggleSelectedSeat(zone.id, seat.id);
+         return;
+      }
+
       toggleSelectedSeat(zone.id, seat.id);
+   };
+
+   const handleSelectResellListing = (listing: ResellListingItem) => {
+      const isAlreadySelected = selectedSeatIds.includes(listing.seatId);
+
+      if (!isAlreadySelected) {
+         clearAllSelections();
+      }
+
+      toggleSelectedSeat(zone.id, listing.seatId);
    };
 
    const handleMapPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -317,16 +416,6 @@ function SeatsPage() {
       if (event.currentTarget.hasPointerCapture(event.pointerId)) {
          event.currentTarget.releasePointerCapture(event.pointerId);
       }
-   };
-   // 🔴 2. 예매 페이지로 넘어가기 전 봇 데이터를 추출하는 핸들러 추가
-   const handleNavigateToPayment = () => {
-      const botReport = getBotReport();
-
-      console.log('수집된 봇 데이터:', botReport);
-
-      // 옵션 A: 여기서 좌석 선점(Hold) API를 쏠 때 botReport를 같이 보냄
-      // 옵션 B: React Router의 state를 이용해 결제 페이지로 데이터를 넘겨서 최종 결제 시 서버로 보냄
-      navigate('/tickets/payment', { state: { botData: botReport } });
    };
 
    return (
@@ -378,7 +467,7 @@ function SeatsPage() {
                      seatBlocks={seatBlocks}
                      seatMapOffset={seatMapOffset}
                      seatMapScale={seatMapScale}
-                     seats={seats}
+                     seats={displaySeats}
                      selectedSeatIds={selectedSeatIds}
                      zoneColor={zone.color}
                      zoneName={zone.name}
@@ -404,11 +493,11 @@ function SeatsPage() {
                               </div>
                               <div className="flex items-center justify-between gap-3">
                                  <div className="flex items-center gap-1 text-heading-3-bold text-foreground">
-                                    <span>선택 좌석</span>
+                                    <span>{isResellMode ? '리셀 예매' : '선택 좌석'}</span>
                                     <span className="text-primary">{selectedSeats.length}</span>
                                  </div>
                                  <span className="text-body-1-medium text-tertiary">
-                                    {selectedSeats.length > 0 ? bookingButtonLabel : '열기'}
+                                    {selectedSeats.length > 0 ? formatPrice(summaryPrice) : '열기'}
                                  </span>
                               </div>
                            </button>
@@ -424,113 +513,181 @@ function SeatsPage() {
                      className="overflow-hidden border-none p-0 xl:hidden"
                   >
                      <div className="h-full overflow-y-auto">
-                        <div className="flex items-center justify-between gap-3 px-5 py-4">
-                           <div className="flex items-center gap-1 text-heading-3-bold text-foreground">
-                              <h2>선택 좌석</h2>
-                              <span className="text-primary">{selectedSeats.length}</span>
-                           </div>
-                           {selectedSeats.length > 0 ? (
-                              <button
-                                 type="button"
-                                 onClick={clearAllSelections}
-                                 className="text-body-1-medium text-tertiary transition-colors hover:text-foreground"
-                              >
-                                 전체 삭제
-                              </button>
-                           ) : null}
-                        </div>
+                        {isResellMode ? (
+                           <>
+                              <div className="px-5 py-4">
+                                 <div className="flex items-center gap-1 text-heading-3-bold text-foreground">
+                                    <h2>판매 중인 좌석</h2>
+                                    <span className="text-primary">{resellInsights?.listings.length ?? 0}</span>
+                                 </div>
+                              </div>
 
-                        <div className="px-5 pb-4">
-                           <SelectedSeatSummaryList
-                              items={selectedSeats}
-                              onRemove={toggleSelectedSeat}
-                              emptyClassName="h-full min-h-[220px] bg-transparent"
-                           />
-                        </div>
+                              <div className="space-y-3 px-5 pb-4">
+                                 {resellInsights?.listings.map((listing) => {
+                                    const isSelected = selectedResellListing?.listingId === listing.listingId;
 
-                        <div className="px-5 pb-5">
-                           <div className="flex items-center justify-between gap-3 px-1 pb-5 text-heading-4-medium text-secondary">
-                              <span>총 결제 금액</span>
-                              <span className="text-heading-4-bold text-primary">{formatPrice(selectedPrice)}</span>
-                           </div>
-                           <button
-                              type="button"
-                              disabled={selectedSeats.length === 0}
-                              onClick={handleProceedToPayment}
-                              className={[
-                                 'h-12 w-full rounded-[8px] text-label-1-bold transition-colors',
-                                 selectedSeats.length === 0
-                                    ? 'bg-fill-disabled text-disabled-foreground'
-                                    : 'bg-primary text-white hover:bg-primary-strong',
-                              ].join(' ')}
-                           >
-                              {bookingButtonLabel}
-                           </button>
-                        </div>
+                                    return (
+                                       <button
+                                          key={listing.listingId}
+                                          type="button"
+                                          onClick={() => handleSelectResellListing(listing)}
+                                          className={[
+                                             'flex w-full items-start justify-between gap-4 rounded-[12px] border px-4 py-4 text-left transition-colors',
+                                             isSelected ? 'border-primary bg-primary/5' : 'border-border-light bg-background',
+                                          ].join(' ')}
+                                       >
+                                          <span className="text-body-1-semibold text-secondary">{listing.seatLabel}</span>
+                                          <span className="shrink-0 text-body-1-bold text-secondary">
+                                             {formatPrice(listing.listingPrice)}
+                                          </span>
+                                       </button>
+                                    );
+                                 })}
+                              </div>
+
+                              <div className="px-5 pb-5">
+                                 <div className="flex items-center justify-between gap-3 px-1 pb-5 text-heading-4-medium text-secondary">
+                                    <span>총 결제 금액</span>
+                                    <span className="text-heading-4-bold text-primary">{formatPrice(summaryPrice)}</span>
+                                 </div>
+                                 <button
+                                    type="button"
+                                    disabled={!selectedResellListing}
+                                    onClick={handleProceedToPayment}
+                                    className={[
+                                       'h-12 w-full rounded-[8px] text-label-1-bold transition-colors',
+                                       !selectedResellListing
+                                          ? 'bg-fill-disabled text-disabled-foreground'
+                                          : 'bg-primary text-white hover:bg-primary-strong',
+                                    ].join(' ')}
+                                 >
+                                    {bookingButtonLabel}
+                                 </button>
+                              </div>
+                           </>
+                        ) : (
+                           <>
+                              <div className="flex items-center justify-between gap-3 px-5 py-4">
+                                 <div className="flex items-center gap-1 text-heading-3-bold text-foreground">
+                                    <h2>선택 좌석</h2>
+                                    <span className="text-primary">{selectedSeats.length}</span>
+                                 </div>
+                                 {selectedSeats.length > 0 ? (
+                                    <button
+                                       type="button"
+                                       onClick={clearAllSelections}
+                                       className="text-body-1-medium text-tertiary transition-colors hover:text-foreground"
+                                    >
+                                       전체 삭제
+                                    </button>
+                                 ) : null}
+                              </div>
+
+                              <div className="px-5 pb-4">
+                                 <SelectedSeatSummaryList
+                                    items={selectedSeats}
+                                    onRemove={toggleSelectedSeat}
+                                    emptyClassName="h-full min-h-[220px] bg-transparent"
+                                 />
+                              </div>
+
+                              <div className="px-5 pb-5">
+                                 <div className="flex items-center justify-between gap-3 px-1 pb-5 text-heading-4-medium text-secondary">
+                                    <span>총 결제 금액</span>
+                                    <span className="text-heading-4-bold text-primary">{formatPrice(summaryPrice)}</span>
+                                 </div>
+                                 <button
+                                    type="button"
+                                    disabled={selectedSeats.length === 0}
+                                    onClick={handleProceedToPayment}
+                                    className={[
+                                       'h-12 w-full rounded-[8px] text-label-1-bold transition-colors',
+                                       selectedSeats.length === 0
+                                          ? 'bg-fill-disabled text-disabled-foreground'
+                                          : 'bg-primary text-white hover:bg-primary-strong',
+                                    ].join(' ')}
+                                 >
+                                    {bookingButtonLabel}
+                                 </button>
+                              </div>
+                           </>
+                        )}
                      </div>
                   </DrawerContent>
                </Drawer>
             </section>
 
-            <aside className="hidden w-full shrink-0 flex-col border-l border-border-light bg-background xl:flex xl:w-[420px]">
-               <div className="relative h-[220px] overflow-hidden border-b border-border-light bg-[#e9ebee] px-5 py-4">
-                  <div className="relative mx-auto h-[188px] w-[260px] shrink-0">
-                     <img
-                        src={zoneOverviewImage}
-                        alt={`${zone.name} 선택 상태가 반영된 ${stadiumName} 좌석도`}
-                        className="h-full w-full object-contain"
-                        draggable={false}
-                     />
+            {isResellMode && resellInsights ? (
+               <ResellSeatSidebar
+                  insights={resellInsights}
+                  selectedListingId={selectedResellListing?.listingId}
+                  zone={zone}
+                  zoneOverviewImage={zoneOverviewImage}
+                  stadiumName={stadiumName}
+                  onSelectListing={handleSelectResellListing}
+                  onSubmit={handleProceedToPayment}
+               />
+            ) : (
+               <aside className="hidden w-full shrink-0 flex-col border-l border-border-light bg-background xl:flex xl:w-[420px]">
+                  <div className="relative h-[220px] overflow-hidden border-b border-border-light bg-[#e9ebee] px-5 py-4">
+                     <div className="relative mx-auto h-[188px] w-[260px] shrink-0">
+                        <img
+                           src={zoneOverviewImage}
+                           alt={`${zone.name} 선택 상태가 반영된 ${stadiumName} 좌석도`}
+                           className="h-full w-full object-contain"
+                           draggable={false}
+                        />
+                     </div>
                   </div>
-               </div>
 
-               <div className="flex items-center justify-between px-5 py-5">
-                  <div className="flex items-center gap-2">
-                     <h2 className="text-heading-3-bold text-foreground">선택 좌석</h2>
+                  <div className="flex items-center justify-between px-5 py-5">
+                     <div className="flex items-center gap-2">
+                        <h2 className="text-heading-3-bold text-foreground">선택 좌석</h2>
+                        {selectedSeats.length > 0 ? (
+                           <span className="text-heading-4-bold text-primary">{selectedSeats.length}</span>
+                        ) : null}
+                     </div>
                      {selectedSeats.length > 0 ? (
-                        <span className="text-heading-4-bold text-primary">{selectedSeats.length}</span>
+                        <button
+                           type="button"
+                           onClick={clearAllSelections}
+                           className="text-body-2-medium text-muted-foreground transition-colors hover:text-foreground"
+                        >
+                           전체 삭제
+                        </button>
                      ) : null}
                   </div>
-                  {selectedSeats.length > 0 ? (
+
+                  <div className="flex flex-1 flex-col px-5 pb-5">
+                     <div className="flex-1 overflow-y-auto rounded-2xl bg-background">
+                        <SelectedSeatSummaryList
+                           items={selectedSeats}
+                           onRemove={toggleSelectedSeat}
+                           emptyClassName="h-full min-h-[220px] bg-transparent"
+                        />
+                     </div>
+
+                     <div className="flex items-center justify-between gap-3 px-1 pb-5 pt-6 text-heading-4-medium text-secondary">
+                        <span>총 결제 금액</span>
+                        <span className="text-heading-4-bold text-primary">{formatPrice(summaryPrice)}</span>
+                     </div>
+
                      <button
                         type="button"
-                        onClick={clearAllSelections}
-                        className="text-body-2-medium text-muted-foreground transition-colors hover:text-foreground"
+                        disabled={selectedSeats.length === 0}
+                        onClick={handleProceedToPayment}
+                        className={[
+                           'h-[56px] w-full rounded-[8px] text-label-1-bold transition-colors',
+                           selectedSeats.length === 0
+                              ? 'bg-fill-disabled text-disabled-foreground'
+                              : 'bg-primary text-white hover:bg-primary-strong',
+                        ].join(' ')}
                      >
-                        전체 삭제
+                        {bookingButtonLabel}
                      </button>
-                  ) : null}
-               </div>
-
-               <div className="flex flex-1 flex-col px-5 pb-5">
-                  <div className="flex-1 overflow-y-auto rounded-2xl bg-background">
-                     <SelectedSeatSummaryList
-                        items={selectedSeats}
-                        onRemove={toggleSelectedSeat}
-                        emptyClassName="h-full min-h-[220px] bg-transparent"
-                     />
                   </div>
-
-                  <div className="flex items-center justify-between gap-3 px-1 pb-5 pt-6 text-heading-4-medium text-secondary">
-                     <span>총 결제 금액</span>
-                     <span className="text-heading-4-bold text-primary">{formatPrice(selectedPrice)}</span>
-                  </div>
-
-                  <button
-                     type="button"
-                     disabled={selectedSeats.length === 0}
-                     onClick={handleProceedToPayment}
-                     className={[
-                        'h-[56px] w-full rounded-[8px] text-label-1-bold transition-colors',
-                        selectedSeats.length === 0
-                           ? 'bg-fill-disabled text-disabled-foreground'
-                           : 'bg-primary text-white hover:bg-primary-strong',
-                     ].join(' ')}
-                  >
-                     {bookingButtonLabel}
-                  </button>
-               </div>
-            </aside>
+               </aside>
+            )}
          </main>
       </div>
    );

--- a/src/pages/books/ui/components/ResellSeatSidebar.tsx
+++ b/src/pages/books/ui/components/ResellSeatSidebar.tsx
@@ -1,205 +1,336 @@
+import type { ApexOptions } from 'apexcharts';
+import { useMemo, useState } from 'react';
+import Chart from 'react-apexcharts';
+
 import { Button } from '@/shared/ui/button';
 import { formatPrice } from '@/pages/books/model/zoneData';
-import type { SeatItem, ZoneItem } from '@/pages/books/model/types';
-import type { ResellZoneInsights } from '@/pages/books/model/resellData';
-
-type SelectedSeatSummaryItem = {
-   seat: SeatItem;
-   zoneId: string;
-   zoneName: string;
-   price: number;
-};
+import type { ZoneItem } from '@/pages/books/model/types';
+import type { ResellListingItem, ResellTradeRange, ResellZoneInsights } from '@/pages/books/model/resellData';
+import { cn } from '@/shared/lib/utils';
 
 type ResellSeatSidebarProps = {
    insights: ResellZoneInsights;
-   selectedSeats: SelectedSeatSummaryItem[];
-   selectedPrice: number;
+   selectedListingId?: string;
    zone: ZoneItem;
    zoneOverviewImage: string;
-   onClearAllSelections: () => void;
-   onRemoveSeat: (zoneId: string, seatId: string) => void;
+   stadiumName: string;
+   onSelectListing: (listing: ResellListingItem) => void;
    onSubmit: () => void;
+};
+
+const tooltipWeekdayFormatter = new Intl.DateTimeFormat('ko-KR', {
+   weekday: 'short',
+   timeZone: 'Asia/Seoul',
+});
+
+const tooltipDateFormatter = new Intl.DateTimeFormat('sv-SE', {
+   year: 'numeric',
+   month: '2-digit',
+   day: '2-digit',
+   hour: '2-digit',
+   minute: '2-digit',
+   hour12: false,
+   timeZone: 'Asia/Seoul',
+});
+
+const formatTooltipTimestamp = (occurredAt: string) => {
+   const date = new Date(occurredAt);
+
+   return `${tooltipWeekdayFormatter.format(date)}, ${tooltipDateFormatter.format(date).replace(' ', ', ')}`;
+};
+
+const formatTooltipChangeRate = (price: number, previousClose: number) => {
+   if (previousClose <= 0) {
+      return '0.00%';
+   }
+
+   const changeRate = ((price - previousClose) / previousClose) * 100;
+
+   return `${changeRate >= 0 ? '+' : ''}${changeRate.toFixed(2)}%`;
 };
 
 function ResellSeatSidebar({
    insights,
-   selectedSeats,
-   selectedPrice,
+   selectedListingId,
    zone,
    zoneOverviewImage,
-   onClearAllSelections,
-   onRemoveSeat,
+   stadiumName,
+   onSelectListing,
    onSubmit,
 }: ResellSeatSidebarProps) {
-   const chartMin = Math.min(...insights.pricePoints.map((point) => point.price));
-   const chartMax = Math.max(...insights.pricePoints.map((point) => point.price));
-   const chartWidth = 300;
-   const chartHeight = 124;
-   const yRange = Math.max(1, chartMax - chartMin);
+   const [chartRange, setChartRange] = useState<ResellTradeRange>('minute');
+   const pricePoints = insights.pricePointsByRange[chartRange];
+   const priceValues = useMemo(() => pricePoints.map((point) => point.price), [pricePoints]);
+   const chartMin = Math.min(...priceValues);
+   const chartMax = Math.max(...priceValues);
+   const yAxisStep = useMemo(() => {
+      const range = Math.max(1, chartMax - chartMin);
+      const roughStep = range / 4;
 
-   const path = insights.pricePoints
-      .map((point, index) => {
-         const x = (index / Math.max(1, insights.pricePoints.length - 1)) * chartWidth;
-         const y = chartHeight - ((point.price - chartMin) / yRange) * chartHeight;
+      return Math.max(1000, Math.ceil(roughStep / 1000) * 1000);
+   }, [chartMax, chartMin]);
+   const yAxisMin = useMemo(() => {
+      return Math.max(0, Math.floor(chartMin / yAxisStep) * yAxisStep);
+   }, [chartMin, yAxisStep]);
+   const yAxisMax = useMemo(() => {
+      const nextMax = Math.ceil(chartMax / yAxisStep) * yAxisStep;
 
-         return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
-      })
-      .join(' ');
+      return nextMax === yAxisMin ? nextMax + yAxisStep : nextMax;
+   }, [chartMax, yAxisMin, yAxisStep]);
+   const chartOptions = useMemo<ApexOptions>(
+      () => ({
+         chart: {
+            type: 'area',
+            height: 200,
+            toolbar: { show: false },
+            zoom: { enabled: false },
+            sparkline: { enabled: false },
+            animations: { enabled: false },
+            fontFamily: 'inherit',
+            parentHeightOffset: 0,
+         },
+         series: [
+            {
+               name: '리셀 가격',
+               data: pricePoints.map((point) => point.price),
+            },
+         ],
+         colors: ['#2563eb'],
+         fill: {
+            type: 'gradient',
+            gradient: {
+               shade: 'light',
+               type: 'vertical',
+               shadeIntensity: 0,
+               inverseColors: false,
+               opacityFrom: 0.2,
+               opacityTo: 0,
+               stops: [0, 100],
+               colorStops: [
+                  [
+                     { offset: 0, color: '#2563eb', opacity: 0.2 },
+                     { offset: 100, color: '#2563eb', opacity: 0 },
+                  ],
+               ],
+            },
+         },
+         stroke: {
+            curve: 'straight',
+            width: 3,
+            lineCap: 'round',
+         },
+         markers: {
+            size: 4,
+            colors: ['#ffffff'],
+            strokeColors: '#2563eb',
+            strokeWidth: 2,
+            hover: { sizeOffset: 1 },
+         },
+         dataLabels: { enabled: false },
+         tooltip: {
+            enabled: true,
+            theme: 'dark',
+            x: { show: false },
+            y: { formatter: undefined, title: { formatter: () => '' } },
+            marker: { show: false },
+            custom: ({ dataPointIndex }) => {
+               const point = pricePoints[dataPointIndex];
+
+               if (!point) {
+                  return '';
+               }
+
+               return `
+                  <div style="border-radius:8px;background:#161d24;padding:4px 8px;color:#ffffff;font-size:12px;font-weight:700;line-height:1.5;">
+                     <div>체결 가격: ${point.price.toLocaleString('ko-KR')}(${formatTooltipChangeRate(point.price, insights.previousClose)})</div>
+                     <div>${formatTooltipTimestamp(point.occurredAt)}</div>
+                  </div>
+               `;
+            },
+         },
+         legend: { show: false },
+        grid: {
+            borderColor: '#d9dde3',
+            strokeDashArray: 4,
+            padding: {
+               top: 8,
+               right: 10,
+               bottom: 0,
+               left: 4,
+            },
+            xaxis: { lines: { show: false } },
+            yaxis: { lines: { show: true } },
+         },
+         xaxis: {
+            categories: pricePoints.map((point) => point.time),
+            axisBorder: { show: false },
+            axisTicks: { show: false },
+            crosshairs: { show: false },
+            tooltip: { enabled: false },
+            labels: {
+               style: {
+                  colors: Array.from({ length: pricePoints.length }, () => '#8a94a6'),
+                  fontSize: '12px',
+                  fontWeight: 400,
+               },
+            },
+         },
+         states: {
+            hover: {
+               filter: {
+                  type: 'none',
+               },
+            },
+            active: {
+               filter: {
+                  type: 'none',
+               },
+            },
+         },
+         yaxis: {
+            show: true,
+            min: yAxisMin,
+            max: yAxisMax,
+            tickAmount: Math.max(1, Math.round((yAxisMax - yAxisMin) / yAxisStep)),
+            stepSize: yAxisStep,
+            opposite: true,
+            decimalsInFloat: 0,
+            forceNiceScale: false,
+            labels: {
+               show: true,
+               minWidth: 44,
+               maxWidth: 44,
+               align: 'left',
+               offsetX: 6,
+               style: {
+                  colors: ['#8a94a6'],
+                  fontSize: '12px',
+                  fontWeight: 400,
+               },
+               formatter: (value) => value.toLocaleString('ko-KR'),
+            },
+         },
+      }),
+      [insights.previousClose, pricePoints, yAxisMax, yAxisMin, yAxisStep],
+   );
 
    return (
       <aside className="flex w-full shrink-0 flex-col border-l border-border-light bg-background xl:w-[420px]">
-         <div className="relative h-[160px] overflow-hidden border-b border-border-light bg-[#e9ebee] px-5 py-3">
-            <div className="relative mx-auto h-full w-[170px] shrink-0">
+         <div className="relative h-[220px] overflow-hidden border-b border-border-light bg-[#e9ebee] px-5 py-2.5">
+            <div className="relative mx-auto h-[200px] w-[200px] shrink-0">
                <img
                   src={zoneOverviewImage}
-                  alt={`${zone.name} 선택 상태가 반영된 기아 챔피언스필드 좌석도`}
-                  className="h-full w-full object-contain"
+                  alt={`${stadiumName} ${zone.name} 구역 좌석도`}
+                  className="h-full w-full object-contain opacity-70"
                   draggable={false}
                />
             </div>
          </div>
 
-         <div className="flex flex-1 flex-col gap-5 overflow-y-auto px-5 py-5">
-            <section className="space-y-4 rounded-[20px] border border-border-light bg-background p-4">
-               <div className="flex items-baseline gap-1.5">
+         <div className="flex flex-1 flex-col gap-12 overflow-y-auto pb-5">
+            <section className="space-y-6">
+               <div className="flex items-center gap-1 px-5 pt-5">
                   <h2 className="text-heading-3-bold text-foreground">거래 변동</h2>
-                  <span className="text-body-1-bold text-[#ef4444]">
-                     +{formatPrice(insights.changeAmount)} ({insights.changeRate}%)
+                  <span className={cn('text-label-2-semibold', insights.changeAmount >= 0 ? 'text-destructive' : 'text-primary')}>
+                     {insights.changeAmount >= 0 ? '+' : ''}
+                     {formatPrice(insights.changeAmount)} ({insights.changeRate}%)
                   </span>
                </div>
 
-               <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-body-2-regular">
+               <div className="grid grid-cols-2 gap-x-8 gap-y-1 px-5 text-caption-1-medium text-tertiary">
                   <Metric label="전일 종가" value={formatPrice(insights.previousClose)} />
                   <Metric label="최근 거래 체결가" value={formatPrice(insights.recentTrade)} />
                   <Metric label="금일 하한가" value={formatPrice(insights.dayLow)} valueClassName="text-primary" />
-                  <Metric label="금일 상한가" value={formatPrice(insights.dayHigh)} valueClassName="text-[#ef4444]" />
+                  <Metric label="금일 상한가" value={formatPrice(insights.dayHigh)} valueClassName="text-destructive" />
                </div>
 
-               <div className="rounded-[16px] border border-border-light bg-white px-3 py-3">
-                  <div className="relative">
-                     <svg viewBox={`0 0 ${chartWidth} ${chartHeight}`} className="h-[136px] w-full" role="img" aria-label={`${zone.name} 리셀 가격 추이`}>
-                        {[0, 1, 2, 3].map((line) => {
-                           const y = 8 + line * 30;
+               <div className="px-5">
+                  <div className="flex rounded-[12px] bg-[#f1f2f4] p-1">
+                     {([
+                        { key: 'minute', label: '1분' },
+                        { key: 'day', label: '1일' },
+                     ] as const).map((item) => (
+                        <button
+                           key={item.key}
+                           type="button"
+                           onClick={() => setChartRange(item.key)}
+                           className={cn(
+                              'flex-1 rounded-[8px] px-2.5 py-2 text-body-2-bold transition-colors',
+                              chartRange === item.key ? 'bg-background text-secondary' : 'text-disabled-foreground',
+                           )}
+                        >
+                           {item.label}
+                        </button>
+                     ))}
+                  </div>
+               </div>
 
-                           return (
-                              <line
-                                 key={line}
-                                 x1="0"
-                                 y1={y}
-                                 x2={chartWidth}
-                                 y2={y}
-                                 stroke="#d9dde3"
-                                 strokeDasharray="4 4"
-                              />
-                           );
-                        })}
-                        <path d={path} fill="none" stroke="#2563eb" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
-                        {insights.pricePoints.map((point, index) => {
-                           const x = (index / Math.max(1, insights.pricePoints.length - 1)) * chartWidth;
-                           const y = chartHeight - ((point.price - chartMin) / yRange) * chartHeight;
-
-                           return <circle key={point.time} cx={x} cy={y} r="4" fill="#2563eb" />;
-                        })}
-                     </svg>
-                     <div className="mt-2 flex justify-between text-[11px] font-medium leading-[1.45] text-[#7d8793]">
-                        {insights.pricePoints.map((point) => (
-                           <span key={point.time}>{point.time}</span>
-                        ))}
+               <div className="px-5">
+                  <div className="rounded-[8px] border border-border-light bg-background px-0 py-3">
+                     <div role="img" aria-label={`${zone.name} 리셀 가격 추이`}>
+                        <div className="pr-2">
+                           <Chart options={chartOptions} series={chartOptions.series ?? []} type="area" height={200} />
+                        </div>
                      </div>
                   </div>
                </div>
             </section>
 
-            <section className="space-y-3 rounded-[20px] border border-border-light bg-background p-4">
-               <h3 className="text-heading-3-bold text-foreground">최근 거래 내역</h3>
-               <ul className="space-y-2">
+            <section className="space-y-4">
+               <div className="px-5">
+                  <h3 className="text-heading-3-bold text-foreground">최근 거래 내역</h3>
+               </div>
+               <ul className="space-y-1 px-5">
                   {insights.tradeHistory.map((item) => (
-                     <li key={item.id} className="flex items-center justify-between gap-3 text-body-2-regular">
-                        <div className="min-w-0">
-                           <p className="text-body-2-semibold text-foreground">{formatPrice(item.price)}</p>
-                           <p className="truncate text-muted-foreground">{item.seatLabel}</p>
-                        </div>
-                        <span className="shrink-0 text-caption-1-medium text-[#7d8793]">{item.tradedAt}</span>
+                     <li key={item.id} className="grid grid-cols-[max-content_minmax(0,1fr)_88px] items-center gap-x-3 text-body-2-regular text-secondary">
+                        <span className="whitespace-nowrap text-body-2-semibold">{formatPrice(item.price)}</span>
+                        <span className="min-w-0 truncate text-right">{item.seatLabel}</span>
+                        <span className="whitespace-nowrap text-right text-caption-1-regular text-tertiary">{item.tradedAt}</span>
                      </li>
                   ))}
                </ul>
             </section>
 
-            <section className="space-y-3 rounded-[20px] border border-border-light bg-background p-4">
-               <div className="flex items-center gap-2">
-                  <h3 className="text-heading-3-bold text-foreground">리셀 매물</h3>
-                  <span className="text-heading-4-bold text-primary">{insights.listings.length}</span>
-               </div>
-               <ul className="space-y-3">
-                  {insights.listings.map((item) => (
-                     <li key={item.id} className="rounded-[16px] border border-border-light px-4 py-3">
-                        <div className="flex items-center justify-between gap-3">
-                           <div className="min-w-0">
-                              <p className="text-body-2-semibold text-foreground">{item.seatLabel}</p>
-                              <p className="text-caption-1-medium text-muted-foreground">{item.seller}</p>
-                           </div>
-                           <span className="shrink-0 text-body-2-bold text-primary">{formatPrice(item.price)}</span>
-                        </div>
-                     </li>
-                  ))}
-               </ul>
-            </section>
-
-            <section className="space-y-3 rounded-[20px] bg-surface p-4">
-               <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                     <h3 className="text-heading-3-bold text-foreground">선택 좌석</h3>
-                     {selectedSeats.length > 0 ? <span className="text-heading-4-bold text-primary">{selectedSeats.length}</span> : null}
-                  </div>
-                  {selectedSeats.length > 0 ? (
-                     <button
-                        type="button"
-                        onClick={onClearAllSelections}
-                        className="text-body-2-medium text-muted-foreground transition-colors hover:text-foreground"
-                     >
-                        전체 삭제
-                     </button>
-                  ) : null}
+            <section className="space-y-3">
+               <div className="flex items-center gap-1 px-5">
+                  <h3 className="text-heading-3-bold text-foreground">판매 중인 좌석</h3>
+                  <span className="text-heading-3-bold text-primary">{insights.listings.length}</span>
                </div>
 
-               {selectedSeats.length > 0 ? (
-                  <ul className="space-y-3">
-                     {selectedSeats.map((item) => (
-                        <li key={item.seat.id} className="flex items-center justify-between rounded-[16px] border border-border-light bg-background px-4 py-3">
-                           <div>
-                              <p className="text-body-2-semibold text-foreground">{item.zoneName}</p>
-                              <p className="text-body-2-regular text-muted-foreground">
-                                 {item.seat.block}구역 {item.seat.rowLabel} {item.seat.seatNumber}번
-                              </p>
-                           </div>
-                           <div className="flex items-center gap-3">
-                              <span className="text-body-2-semibold text-primary">{formatPrice(item.price)}</span>
-                              <button
-                                 type="button"
-                                 onClick={() => onRemoveSeat(item.zoneId, item.seat.id)}
-                                 className="text-caption-1-medium text-muted-foreground transition-colors hover:text-foreground"
-                              >
-                                 삭제
-                              </button>
-                           </div>
+               <ul className="space-y-3 px-5">
+                  {insights.listings.map((item) => {
+                     const isSelected = item.listingId === selectedListingId;
+
+                     return (
+                        <li key={item.listingId}>
+                           <button
+                              type="button"
+                              onClick={() => onSelectListing(item)}
+                              className={cn(
+                                 'flex w-full items-start gap-6 rounded-[12px] border px-4 py-4 text-left transition-colors',
+                                 isSelected ? 'border-primary bg-primary/5' : 'border-border-light bg-background hover:border-primary/40',
+                              )}
+                              aria-pressed={isSelected}
+                           >
+                              <span className="flex-1 text-body-1-semibold text-secondary">{item.seatLabel}</span>
+                              <span className="shrink-0 text-body-1-bold text-secondary">{formatPrice(item.listingPrice)}</span>
+                           </button>
                         </li>
-                     ))}
-                  </ul>
-               ) : (
-                  <div className="rounded-[16px] border border-dashed border-border-light bg-background px-4 py-6 text-center text-body-2-regular text-muted-foreground">
-                     선택한 좌석이 없습니다.
-                  </div>
-               )}
-
-               <div className="flex items-center justify-between text-body-1-semibold text-foreground">
-                  <span>예상 결제 금액</span>
-                  <span>{formatPrice(selectedPrice)}</span>
-               </div>
-
-               <Button type="button" disabled={selectedSeats.length === 0} className="h-14 w-full rounded-[8px]" onClick={onSubmit}>
-                  예매하기
-               </Button>
+                     );
+                  })}
+               </ul>
             </section>
+         </div>
+
+         <div className="px-5 pb-5">
+            <Button
+               type="button"
+               disabled={!selectedListingId}
+               className="h-12 w-full rounded-[8px]"
+               onClick={onSubmit}
+            >
+               예매하기
+            </Button>
          </div>
       </aside>
    );
@@ -215,9 +346,9 @@ function Metric({
    valueClassName?: string;
 }) {
    return (
-      <div className="flex items-center justify-between gap-2">
-         <span className="text-muted-foreground">{label}</span>
-         <span className={valueClassName ?? 'text-foreground'}>{value}</span>
+      <div className="flex min-w-0 items-center gap-2">
+         <span className="flex-1">{label}</span>
+         <span className={cn('shrink-0 text-caption-1-bold text-tertiary', valueClassName)}>{value}</span>
       </div>
    );
 }

--- a/src/pages/books/ui/components/ResellSeatSidebar.tsx
+++ b/src/pages/books/ui/components/ResellSeatSidebar.tsx
@@ -1,0 +1,225 @@
+import { Button } from '@/shared/ui/button';
+import { formatPrice } from '@/pages/books/model/zoneData';
+import type { SeatItem, ZoneItem } from '@/pages/books/model/types';
+import type { ResellZoneInsights } from '@/pages/books/model/resellData';
+
+type SelectedSeatSummaryItem = {
+   seat: SeatItem;
+   zoneId: string;
+   zoneName: string;
+   price: number;
+};
+
+type ResellSeatSidebarProps = {
+   insights: ResellZoneInsights;
+   selectedSeats: SelectedSeatSummaryItem[];
+   selectedPrice: number;
+   zone: ZoneItem;
+   zoneOverviewImage: string;
+   onClearAllSelections: () => void;
+   onRemoveSeat: (zoneId: string, seatId: string) => void;
+   onSubmit: () => void;
+};
+
+function ResellSeatSidebar({
+   insights,
+   selectedSeats,
+   selectedPrice,
+   zone,
+   zoneOverviewImage,
+   onClearAllSelections,
+   onRemoveSeat,
+   onSubmit,
+}: ResellSeatSidebarProps) {
+   const chartMin = Math.min(...insights.pricePoints.map((point) => point.price));
+   const chartMax = Math.max(...insights.pricePoints.map((point) => point.price));
+   const chartWidth = 300;
+   const chartHeight = 124;
+   const yRange = Math.max(1, chartMax - chartMin);
+
+   const path = insights.pricePoints
+      .map((point, index) => {
+         const x = (index / Math.max(1, insights.pricePoints.length - 1)) * chartWidth;
+         const y = chartHeight - ((point.price - chartMin) / yRange) * chartHeight;
+
+         return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
+      })
+      .join(' ');
+
+   return (
+      <aside className="flex w-full shrink-0 flex-col border-l border-border-light bg-background xl:w-[420px]">
+         <div className="relative h-[160px] overflow-hidden border-b border-border-light bg-[#e9ebee] px-5 py-3">
+            <div className="relative mx-auto h-full w-[170px] shrink-0">
+               <img
+                  src={zoneOverviewImage}
+                  alt={`${zone.name} 선택 상태가 반영된 기아 챔피언스필드 좌석도`}
+                  className="h-full w-full object-contain"
+                  draggable={false}
+               />
+            </div>
+         </div>
+
+         <div className="flex flex-1 flex-col gap-5 overflow-y-auto px-5 py-5">
+            <section className="space-y-4 rounded-[20px] border border-border-light bg-background p-4">
+               <div className="flex items-baseline gap-1.5">
+                  <h2 className="text-heading-3-bold text-foreground">거래 변동</h2>
+                  <span className="text-body-1-bold text-[#ef4444]">
+                     +{formatPrice(insights.changeAmount)} ({insights.changeRate}%)
+                  </span>
+               </div>
+
+               <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-body-2-regular">
+                  <Metric label="전일 종가" value={formatPrice(insights.previousClose)} />
+                  <Metric label="최근 거래 체결가" value={formatPrice(insights.recentTrade)} />
+                  <Metric label="금일 하한가" value={formatPrice(insights.dayLow)} valueClassName="text-primary" />
+                  <Metric label="금일 상한가" value={formatPrice(insights.dayHigh)} valueClassName="text-[#ef4444]" />
+               </div>
+
+               <div className="rounded-[16px] border border-border-light bg-white px-3 py-3">
+                  <div className="relative">
+                     <svg viewBox={`0 0 ${chartWidth} ${chartHeight}`} className="h-[136px] w-full" role="img" aria-label={`${zone.name} 리셀 가격 추이`}>
+                        {[0, 1, 2, 3].map((line) => {
+                           const y = 8 + line * 30;
+
+                           return (
+                              <line
+                                 key={line}
+                                 x1="0"
+                                 y1={y}
+                                 x2={chartWidth}
+                                 y2={y}
+                                 stroke="#d9dde3"
+                                 strokeDasharray="4 4"
+                              />
+                           );
+                        })}
+                        <path d={path} fill="none" stroke="#2563eb" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+                        {insights.pricePoints.map((point, index) => {
+                           const x = (index / Math.max(1, insights.pricePoints.length - 1)) * chartWidth;
+                           const y = chartHeight - ((point.price - chartMin) / yRange) * chartHeight;
+
+                           return <circle key={point.time} cx={x} cy={y} r="4" fill="#2563eb" />;
+                        })}
+                     </svg>
+                     <div className="mt-2 flex justify-between text-[11px] font-medium leading-[1.45] text-[#7d8793]">
+                        {insights.pricePoints.map((point) => (
+                           <span key={point.time}>{point.time}</span>
+                        ))}
+                     </div>
+                  </div>
+               </div>
+            </section>
+
+            <section className="space-y-3 rounded-[20px] border border-border-light bg-background p-4">
+               <h3 className="text-heading-3-bold text-foreground">최근 거래 내역</h3>
+               <ul className="space-y-2">
+                  {insights.tradeHistory.map((item) => (
+                     <li key={item.id} className="flex items-center justify-between gap-3 text-body-2-regular">
+                        <div className="min-w-0">
+                           <p className="text-body-2-semibold text-foreground">{formatPrice(item.price)}</p>
+                           <p className="truncate text-muted-foreground">{item.seatLabel}</p>
+                        </div>
+                        <span className="shrink-0 text-caption-1-medium text-[#7d8793]">{item.tradedAt}</span>
+                     </li>
+                  ))}
+               </ul>
+            </section>
+
+            <section className="space-y-3 rounded-[20px] border border-border-light bg-background p-4">
+               <div className="flex items-center gap-2">
+                  <h3 className="text-heading-3-bold text-foreground">리셀 매물</h3>
+                  <span className="text-heading-4-bold text-primary">{insights.listings.length}</span>
+               </div>
+               <ul className="space-y-3">
+                  {insights.listings.map((item) => (
+                     <li key={item.id} className="rounded-[16px] border border-border-light px-4 py-3">
+                        <div className="flex items-center justify-between gap-3">
+                           <div className="min-w-0">
+                              <p className="text-body-2-semibold text-foreground">{item.seatLabel}</p>
+                              <p className="text-caption-1-medium text-muted-foreground">{item.seller}</p>
+                           </div>
+                           <span className="shrink-0 text-body-2-bold text-primary">{formatPrice(item.price)}</span>
+                        </div>
+                     </li>
+                  ))}
+               </ul>
+            </section>
+
+            <section className="space-y-3 rounded-[20px] bg-surface p-4">
+               <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                     <h3 className="text-heading-3-bold text-foreground">선택 좌석</h3>
+                     {selectedSeats.length > 0 ? <span className="text-heading-4-bold text-primary">{selectedSeats.length}</span> : null}
+                  </div>
+                  {selectedSeats.length > 0 ? (
+                     <button
+                        type="button"
+                        onClick={onClearAllSelections}
+                        className="text-body-2-medium text-muted-foreground transition-colors hover:text-foreground"
+                     >
+                        전체 삭제
+                     </button>
+                  ) : null}
+               </div>
+
+               {selectedSeats.length > 0 ? (
+                  <ul className="space-y-3">
+                     {selectedSeats.map((item) => (
+                        <li key={item.seat.id} className="flex items-center justify-between rounded-[16px] border border-border-light bg-background px-4 py-3">
+                           <div>
+                              <p className="text-body-2-semibold text-foreground">{item.zoneName}</p>
+                              <p className="text-body-2-regular text-muted-foreground">
+                                 {item.seat.block}구역 {item.seat.rowLabel} {item.seat.seatNumber}번
+                              </p>
+                           </div>
+                           <div className="flex items-center gap-3">
+                              <span className="text-body-2-semibold text-primary">{formatPrice(item.price)}</span>
+                              <button
+                                 type="button"
+                                 onClick={() => onRemoveSeat(item.zoneId, item.seat.id)}
+                                 className="text-caption-1-medium text-muted-foreground transition-colors hover:text-foreground"
+                              >
+                                 삭제
+                              </button>
+                           </div>
+                        </li>
+                     ))}
+                  </ul>
+               ) : (
+                  <div className="rounded-[16px] border border-dashed border-border-light bg-background px-4 py-6 text-center text-body-2-regular text-muted-foreground">
+                     선택한 좌석이 없습니다.
+                  </div>
+               )}
+
+               <div className="flex items-center justify-between text-body-1-semibold text-foreground">
+                  <span>예상 결제 금액</span>
+                  <span>{formatPrice(selectedPrice)}</span>
+               </div>
+
+               <Button type="button" disabled={selectedSeats.length === 0} className="h-14 w-full rounded-[8px]" onClick={onSubmit}>
+                  예매하기
+               </Button>
+            </section>
+         </div>
+      </aside>
+   );
+}
+
+function Metric({
+   label,
+   value,
+   valueClassName,
+}: {
+   label: string;
+   value: string;
+   valueClassName?: string;
+}) {
+   return (
+      <div className="flex items-center justify-between gap-2">
+         <span className="text-muted-foreground">{label}</span>
+         <span className={valueClassName ?? 'text-foreground'}>{value}</span>
+      </div>
+   );
+}
+
+export default ResellSeatSidebar;

--- a/src/pages/home/ui/FavoriteTeamMatchCard.tsx
+++ b/src/pages/home/ui/FavoriteTeamMatchCard.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/shared/ui/button';
 import { useBookingEntryFlow } from '@/shared/lib/use-booking-entry-flow';
 
 const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
-   const { openBookingEntry, bookingGuideDialog } = useBookingEntryFlow();
+   const { openBookingEntry, openResellEntry, bookingGuideDialog } = useBookingEntryFlow();
    const { data, isPending } = useGameSchedules();
    const match = getClosestMatch(data ?? [], team.id);
 
@@ -90,6 +90,22 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
       });
    };
 
+   const handleResellClick = () => {
+      if (match.resell !== '리셀예매') {
+         return;
+      }
+
+      openResellEntry({
+         homeTeamId: match.homeTeamId,
+         gameId: match.id,
+         stadiumId: match.stadiumId,
+         queueTokenJti: match.queueTokenJti,
+         matchTitle: `${awayTeamName} vs ${homeTeamName}`,
+         venue: match.venue,
+         dateTime: formattedDate,
+      });
+   };
+
    return (
       <div className="bg-white border border-[#e9ebee] rounded-2xl overflow-hidden shadow-[0px_20px_50px_-12px_rgba(0,0,0,0.25)]">
          {Header}
@@ -159,6 +175,8 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
                <Button
                   variant="secondary"
                   className="flex-1 max-w-[300px] h-[46px] text-[14px] font-bold rounded-[10px] tracking-[-0.15px]"
+                  disabled={match.resell !== '리셀예매'}
+                  onClick={handleResellClick}
                >
                   리셀예매
                </Button>
@@ -229,7 +247,12 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
                   >
                      예매하기
                   </Button>
-                  <Button variant="secondary" className="h-12 text-[16px] font-bold rounded-lg">
+                  <Button
+                     variant="secondary"
+                     className="h-12 text-[16px] font-bold rounded-lg"
+                     disabled={match.resell !== '리셀예매'}
+                     onClick={handleResellClick}
+                  >
                      리셀예매
                   </Button>
                </div>

--- a/src/pages/home/ui/game-schedule/ScheduleList.tsx
+++ b/src/pages/home/ui/game-schedule/ScheduleList.tsx
@@ -386,7 +386,7 @@ type ScheduleListProps = {
 };
 
 function ScheduleList({ activeTab, filteredData }: ScheduleListProps) {
-  const { openBookingEntry, bookingGuideDialog } = useBookingEntryFlow();
+  const { openBookingEntry, openResellEntry, bookingGuideDialog } = useBookingEntryFlow();
 
   const openBookingFlow = (game: GameRow) => {
     if (game.ticket !== '예매하기') {
@@ -414,7 +414,20 @@ function ScheduleList({ activeTab, filteredData }: ScheduleListProps) {
       return;
     }
 
-    // 리셀 플로우는 별도 구현 전까지 기존 동작을 유지합니다.
+    const selectedDay = filteredData.find(day =>
+      day.games.some(dayGame => dayGame === game),
+    );
+    const resellDateTime = selectedDay ? `${selectedDay.date} ${game.time}` : game.time;
+
+    openResellEntry({
+      homeTeamId: game.homeTeamId ?? TEAM_IDS[game.home],
+      gameId: game.gameId,
+      stadiumId: game.stadiumId,
+      queueTokenJti: game.queueTokenJti,
+      matchTitle: `${game.away} vs ${game.home}`,
+      venue: game.venue,
+      dateTime: resellDateTime,
+    });
   };
 
   if (filteredData.length === 0) {

--- a/src/pages/tickets/ui/GameCard.tsx
+++ b/src/pages/tickets/ui/GameCard.tsx
@@ -33,7 +33,7 @@ function StatusBadge({ status }: { status: string }) {
 interface GameCardProps {
    game: GameItem;
    activeTab: TabType;
-   onBookingClick: (game: GameItem) => void;
+   onActionClick: (game: GameItem) => void;
 }
 
 /** 탭과 현재 상태에 따라 버튼 텍스트와 활성 여부 결정 */
@@ -49,7 +49,7 @@ function getButtonConfig(status: string, activeTab: TabType): { label: string; i
    }
 }
 
-export function GameCard({ game, activeTab, onBookingClick }: GameCardProps) {
+export function GameCard({ game, activeTab, onActionClick }: GameCardProps) {
    const status = activeTab === '예매' ? game.bookingStatus : game.resellStatus;
    const { label: buttonLabel, isActive } = getButtonConfig(status, activeTab);
    const showPrice = game.minPrice > 0;
@@ -111,7 +111,7 @@ export function GameCard({ game, activeTab, onBookingClick }: GameCardProps) {
             {/* 액션 버튼 */}
             <button
                disabled={!isActive}
-               onClick={activeTab === '예매' && isActive ? () => onBookingClick(game) : undefined}
+               onClick={isActive ? () => onActionClick(game) : undefined}
                className={cn(
                   'px-[14px] py-[6px] rounded-[8px] text-body-2-medium whitespace-nowrap transition-colors w-[77px]',
                   isActive

--- a/src/pages/tickets/ui/TicketsPage.tsx
+++ b/src/pages/tickets/ui/TicketsPage.tsx
@@ -35,7 +35,7 @@ function applyFilters(games: GameItem[], filters: FilterState, activeTab: TabTyp
 }
 
 const TicketsPage = () => {
-   const { openBookingEntry, bookingGuideDialog } = useBookingEntryFlow();
+   const { openBookingEntry, openResellEntry, bookingGuideDialog } = useBookingEntryFlow();
    const scheduleQuery = useGameSchedules();
    const [activeTab, setActiveTab] = useState<TabType>('예매');
    const [isFilterOpen, setIsFilterOpen] = useState(false);
@@ -77,7 +77,20 @@ const TicketsPage = () => {
       setDisplayedGames(allGames);
    };
 
-   const handleBookingClick = (game: GameItem) => {
+   const handleGameActionClick = (game: GameItem) => {
+      if (activeTab === '리셀') {
+         openResellEntry({
+            homeTeamId: game.homeTeamId,
+            gameId: game.id,
+            stadiumId: game.stadiumId,
+            queueTokenJti: game.queueTokenJti,
+            matchTitle: `${game.awayTeam} vs ${game.homeTeam}`,
+            venue: game.venue,
+            dateTime: game.dateTime,
+         });
+         return;
+      }
+
       openBookingEntry({
          homeTeamId: game.homeTeamId,
          gameId: game.id,
@@ -137,7 +150,7 @@ const TicketsPage = () => {
                      </div>
                   ) : gamesToRender.length > 0 ? (
                      gamesToRender.map(game => (
-                        <GameCard key={game.id} game={game} activeTab={activeTab} onBookingClick={handleBookingClick} />
+                        <GameCard key={game.id} game={game} activeTab={activeTab} onActionClick={handleGameActionClick} />
                      ))
                   ) : (
                      <div className="flex items-center justify-center h-full bg-surface rounded-[14px] text-body-1-medium text-muted-foreground">

--- a/src/pages/tickets/ui/payment/ResellPaymentPage.tsx
+++ b/src/pages/tickets/ui/payment/ResellPaymentPage.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import { Button } from '@/shared/ui/button';
 import type { ResaleCheckoutRequest } from '@/pages/tickets/api/paymentApi';
+import type { BotReport } from '@/shared/lib/botDetector';
 import {
    CashReceiptCard,
    DiscountCard,
@@ -47,6 +48,7 @@ type ResellPaymentEntryState = Partial<typeof MOCK_RESALE_ENTRY> & {
    matchTitle?: string;
    venue?: string;
    dateTime?: string;
+   botData?: BotReport;
 };
 
 const resolveUserIdFromAccessToken = (accessToken: string | null) => {
@@ -140,6 +142,7 @@ export default function ResellPaymentPage() {
          ordererPhone: phone,
          ordererEmail: email,
          paymentMethod,
+         botData: resellEntryState?.botData,
          ...(paymentMethod === 'bank' && {
             cashReceiptType,
             cashReceiptNumType,

--- a/src/shared/lib/booking-flow.ts
+++ b/src/shared/lib/booking-flow.ts
@@ -1,0 +1,21 @@
+export type BookingFlowMode = 'standard' | 'resell';
+
+const BOOKING_FLOW_QUERY_KEY = 'mode';
+
+export function getBookingFlowMode(search: string): BookingFlowMode {
+   const params = new URLSearchParams(search);
+
+   return params.get(BOOKING_FLOW_QUERY_KEY) === 'resell' ? 'resell' : 'standard';
+}
+
+export function createBookingFlowSearch(mode: BookingFlowMode): string {
+   if (mode === 'standard') {
+      return '';
+   }
+
+   const params = new URLSearchParams({
+      [BOOKING_FLOW_QUERY_KEY]: mode,
+   });
+
+   return `?${params.toString()}`;
+}

--- a/src/shared/lib/use-booking-entry-flow.tsx
+++ b/src/shared/lib/use-booking-entry-flow.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { createBookingFlowSearch } from '@/shared/lib/booking-flow';
+import { createBookingFlowSearch, type BookingFlowMode } from '@/shared/lib/booking-flow';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import BookingGuideDialog from '@/shared/ui/booking-guide-dialog';
@@ -31,6 +31,11 @@ const createBookingEntryState = (options?: OpenBookingEntryOptions): BookingEntr
   } satisfies BookingEntryState;
 };
 
+type PendingEntry = {
+  entryState: BookingEntryState;
+  mode: BookingFlowMode;
+};
+
 /**
  * 홈 경기 일정의 예매 진입 플로우를 다른 화면에서도 재사용하기 위한 훅입니다.
  */
@@ -39,7 +44,18 @@ export function useBookingEntryFlow() {
   const accessToken = useAuthStore(state => state.accessToken);
   const setBookingEntry = useBookingEntryStore(state => state.setEntry);
   const [isGuideOpen, setIsGuideOpen] = useState(false);
-  const [pendingEntryState, setPendingEntryState] = useState<BookingEntryState | null>(null);
+  const [pendingEntry, setPendingEntry] = useState<PendingEntry | null>(null);
+
+  const openEntryWithGuide = (mode: BookingFlowMode, options?: OpenBookingEntryOptions) => {
+    const nextEntryState = createBookingEntryState(options);
+
+    setBookingEntry(nextEntryState);
+    setPendingEntry({
+      entryState: nextEntryState,
+      mode,
+    });
+    setIsGuideOpen(true);
+  };
 
   const openBookingEntry = (options?: OpenBookingEntryOptions) => {
     if (!accessToken) {
@@ -47,10 +63,7 @@ export function useBookingEntryFlow() {
       return;
     }
 
-    const nextEntryState = createBookingEntryState(options);
-    setBookingEntry(nextEntryState);
-    setPendingEntryState(nextEntryState);
-    setIsGuideOpen(true);
+    openEntryWithGuide('standard', options);
   };
 
   const openResellEntry = (options?: OpenBookingEntryOptions) => {
@@ -59,14 +72,7 @@ export function useBookingEntryFlow() {
       return;
     }
 
-    const nextEntryState = createBookingEntryState(options);
-    setBookingEntry(nextEntryState);
-    navigate({
-      pathname: '/books',
-      search: createBookingFlowSearch('resell'),
-    }, {
-      state: nextEntryState,
-    });
+    openEntryWithGuide('resell', options);
   };
 
   const bookingGuideDialog = (
@@ -75,8 +81,11 @@ export function useBookingEntryFlow() {
       onOpenChange={setIsGuideOpen}
       onConfirm={() => {
         setIsGuideOpen(false);
-        navigate('/books', {
-          state: pendingEntryState ?? { requireCaptcha: true },
+        navigate({
+          pathname: '/books',
+          search: createBookingFlowSearch(pendingEntry?.mode ?? 'standard'),
+        }, {
+          state: pendingEntry?.entryState ?? { requireCaptcha: true },
         });
       }}
     />

--- a/src/shared/lib/use-booking-entry-flow.tsx
+++ b/src/shared/lib/use-booking-entry-flow.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { createBookingFlowSearch } from '@/shared/lib/booking-flow';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import BookingGuideDialog from '@/shared/ui/booking-guide-dialog';
 
-type OpenBookingEntryOptions = {
+export type OpenBookingEntryOptions = {
   homeTeamId?: string;
   gameId?: string;
   stadiumId?: string;
@@ -14,6 +15,20 @@ type OpenBookingEntryOptions = {
   matchTitle?: string;
   venue?: string;
   dateTime?: string;
+};
+
+const createBookingEntryState = (options?: OpenBookingEntryOptions): BookingEntryState => {
+  return {
+    requireCaptcha: true,
+    homeTeamId: options?.homeTeamId,
+    gameId: options?.gameId,
+    stadiumId: options?.stadiumId,
+    queueTokenJti: options?.queueTokenJti,
+    userId: options?.userId,
+    matchTitle: options?.matchTitle,
+    venue: options?.venue,
+    dateTime: options?.dateTime,
+  } satisfies BookingEntryState;
 };
 
 /**
@@ -32,21 +47,26 @@ export function useBookingEntryFlow() {
       return;
     }
 
-    const nextEntryState = {
-      requireCaptcha: true,
-      homeTeamId: options?.homeTeamId,
-      gameId: options?.gameId,
-      stadiumId: options?.stadiumId,
-      queueTokenJti: options?.queueTokenJti,
-      userId: options?.userId,
-      matchTitle: options?.matchTitle,
-      venue: options?.venue,
-      dateTime: options?.dateTime,
-    } satisfies BookingEntryState;
-
+    const nextEntryState = createBookingEntryState(options);
     setBookingEntry(nextEntryState);
     setPendingEntryState(nextEntryState);
     setIsGuideOpen(true);
+  };
+
+  const openResellEntry = (options?: OpenBookingEntryOptions) => {
+    if (!accessToken) {
+      navigate('/auth/login');
+      return;
+    }
+
+    const nextEntryState = createBookingEntryState(options);
+    setBookingEntry(nextEntryState);
+    navigate({
+      pathname: '/books',
+      search: createBookingFlowSearch('resell'),
+    }, {
+      state: nextEntryState,
+    });
   };
 
   const bookingGuideDialog = (
@@ -64,6 +84,7 @@ export function useBookingEntryFlow() {
 
   return {
     openBookingEntry,
+    openResellEntry,
     bookingGuideDialog,
   };
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #101

<br/>

## 🔎 개요
리셀 예매 UI 구현

<br/>

## 📋 작업 내용
- 예매 플로우에 mode 값 추가하여 리셀/일반 티켓 예매 플로우 구분
- 리셀 예매를 위한 가격대 그래프 구현
- 리셀 예매 아이템 리스트 구현(seleceted시 디자인 부분 미적용)

<br/>
