### PR TITLE
[design] 리셀 예매 모바일 UI 및 일부 디자인 세부 사항 수정

### DIFF
--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -7,11 +7,10 @@ import { getBookingTeamConfig, getZoneDisplayOrder, getBookingZones } from '@/pa
 import type { ZoneItem } from '@/pages/books/model/types';
 import { getBookingFlowMode } from '@/shared/lib/booking-flow';
 import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
-import { Drawer, DrawerContent, DrawerTrigger } from '@/shared/ui/drawer';
 
 import BookingCaptchaGate from './components/BookingCaptchaGate';
-import BookingZoneList from './components/BookingZoneList';
-import BookingZoneMap from './components/BookingZoneMap';
+import BookingZoneDesktopLayout from './components/BookingZoneDesktopLayout';
+import BookingZoneMobileLayout from './components/BookingZoneMobileLayout';
 
 const CAPTCHA_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
 
@@ -203,67 +202,24 @@ const BooksPage = () => {
             onRefresh={refreshCaptcha}
             onSubmit={submitCaptcha}
          />
-         <section className="relative min-h-[calc(100vh-140px)] bg-[#f1f2f4] lg:hidden">
-            <BookingZoneMap
-               zones={zones}
-               selectedZoneId={selectedZoneId}
-               onSelectZone={handleSelectZone}
-               mobileExpanded={!isCaptchaOpen && !isZoneDrawerOpen}
-               stadiumImage={bookingTeamConfig.stadiumImage}
-               stadiumImageAlt={bookingTeamConfig.stadiumImageAlt}
-            />
-            {!isCaptchaOpen ? (
-               <Drawer open={isZoneDrawerOpen} onOpenChange={setIsZoneDrawerOpen} modal={false}>
-                  {!isZoneDrawerOpen ? (
-                     <div className="absolute inset-x-0 bottom-0 z-10">
-                        <DrawerTrigger asChild>
-                           <button
-                              type="button"
-                              className="w-full rounded-t-[16px] bg-elevated px-5 py-4 text-left shadow-[0_-6px_24px_rgba(0,0,0,0.16)]"
-                           >
-                              <div className="mb-3 flex justify-center" aria-hidden="true">
-                                 <div className="h-1 w-9 rounded-full bg-border-light" />
-                              </div>
-                              <div className="flex items-center justify-between gap-3">
-                                 <span className="text-heading-3-bold text-foreground">
-                                    {bookingFlowMode === 'resell' ? '리셀 좌석 구역' : '좌석 등급/잔여석'}
-                                 </span>
-                                 <span className="text-body-1-medium text-tertiary">{zones.length}개 구역</span>
-                              </div>
-                           </button>
-                        </DrawerTrigger>
-                     </div>
-                  ) : null}
-                  <DrawerContent
-                     showOverlay={false}
-                     resizable
-                     defaultHeight={360}
-                     minHeight={232}
-                     maxHeight={488}
-                     className="overflow-hidden border-none p-0"
-                  >
-                     <div className="h-full overflow-y-auto">
-                        <BookingZoneList
-                           variant="drawer"
-                           zones={zones}
-                           selectedZoneId={selectedZoneId}
-                           onSelectZone={handleSelectZone}
-                        />
-                     </div>
-                  </DrawerContent>
-               </Drawer>
-            ) : null}
-         </section>
-         <main className="hidden min-h-[calc(100vh-140px)] lg:grid lg:h-[calc(100vh-140px)] lg:grid-cols-[minmax(0,1fr)_420px]">
-            <BookingZoneMap
-               zones={zones}
-               selectedZoneId={selectedZoneId}
-               onSelectZone={handleSelectZone}
-               stadiumImage={bookingTeamConfig.stadiumImage}
-               stadiumImageAlt={bookingTeamConfig.stadiumImageAlt}
-            />
-            <BookingZoneList zones={zones} selectedZoneId={selectedZoneId} onSelectZone={handleSelectZone} />
-         </main>
+         <BookingZoneMobileLayout
+            bookingFlowMode={bookingFlowMode}
+            zones={zones}
+            selectedZoneId={selectedZoneId}
+            isCaptchaOpen={isCaptchaOpen}
+            isZoneDrawerOpen={isZoneDrawerOpen}
+            onOpenChange={setIsZoneDrawerOpen}
+            onSelectZone={handleSelectZone}
+            stadiumImage={bookingTeamConfig.stadiumImage}
+            stadiumImageAlt={bookingTeamConfig.stadiumImageAlt}
+         />
+         <BookingZoneDesktopLayout
+            zones={zones}
+            selectedZoneId={selectedZoneId}
+            onSelectZone={handleSelectZone}
+            stadiumImage={bookingTeamConfig.stadiumImage}
+            stadiumImageAlt={bookingTeamConfig.stadiumImageAlt}
+         />
       </div>
    );
 };

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -532,12 +532,17 @@ function SeatsPage() {
                                           type="button"
                                           onClick={() => handleSelectResellListing(listing)}
                                           className={[
-                                             'flex w-full items-start justify-between gap-4 rounded-[12px] border px-4 py-4 text-left transition-colors',
-                                             isSelected ? 'border-primary bg-primary/5' : 'border-border-light bg-background',
+                                             'flex w-full items-start justify-between gap-4 rounded-[12px] bg-background px-4 py-4 text-left transition-colors',
+                                             isSelected ? 'border-2 border-primary' : 'border border-border-light',
                                           ].join(' ')}
                                        >
                                           <span className="text-body-1-semibold text-secondary">{listing.seatLabel}</span>
-                                          <span className="shrink-0 text-body-1-bold text-secondary">
+                                          <span
+                                             className={[
+                                                'shrink-0 text-body-1-bold',
+                                                isSelected ? 'text-primary' : 'text-secondary',
+                                             ].join(' ')}
+                                          >
                                              {formatPrice(listing.listingPrice)}
                                           </span>
                                        </button>

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -13,6 +13,7 @@ import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBo
 import { Drawer, DrawerContent, DrawerTrigger } from '@/shared/ui/drawer';
 import SeatMapStage from './components/SeatMapStage';
 import ResellSeatSidebar from './components/ResellSeatSidebar';
+import ResellZonePreviewSheet from './components/ResellZonePreviewSheet';
 import SelectedSeatSummaryList, { type SelectedSeatSummaryItem } from './components/SelectedSeatSummaryList';
 import { useBotDetector } from '@/shared/lib/useBotDetector';
 
@@ -507,69 +508,22 @@ function SeatsPage() {
                   <DrawerContent
                      showOverlay={false}
                      resizable
-                     defaultHeight={280}
-                     minHeight={152}
+                     defaultHeight={isResellMode ? 488 : 280}
+                     minHeight={isResellMode ? 280 : 152}
                      maxHeight={560}
                      className="overflow-hidden border-none p-0 xl:hidden"
                   >
                      <div className="h-full overflow-y-auto">
-                        {isResellMode ? (
-                           <>
-                              <div className="px-5 py-4">
-                                 <div className="flex items-center gap-1 text-heading-3-bold text-foreground">
-                                    <h2>판매 중인 좌석</h2>
-                                    <span className="text-primary">{resellInsights?.listings.length ?? 0}</span>
-                                 </div>
-                              </div>
-
-                              <div className="space-y-3 px-5 pb-4">
-                                 {resellInsights?.listings.map((listing) => {
-                                    const isSelected = selectedResellListing?.listingId === listing.listingId;
-
-                                    return (
-                                       <button
-                                          key={listing.listingId}
-                                          type="button"
-                                          onClick={() => handleSelectResellListing(listing)}
-                                          className={[
-                                             'flex w-full items-start justify-between gap-4 rounded-[12px] bg-background px-4 py-4 text-left transition-colors',
-                                             isSelected ? 'border-2 border-primary' : 'border border-border-light',
-                                          ].join(' ')}
-                                       >
-                                          <span className="text-body-1-semibold text-secondary">{listing.seatLabel}</span>
-                                          <span
-                                             className={[
-                                                'shrink-0 text-body-1-bold',
-                                                isSelected ? 'text-primary' : 'text-secondary',
-                                             ].join(' ')}
-                                          >
-                                             {formatPrice(listing.listingPrice)}
-                                          </span>
-                                       </button>
-                                    );
-                                 })}
-                              </div>
-
-                              <div className="px-5 pb-5">
-                                 <div className="flex items-center justify-between gap-3 px-1 pb-5 text-heading-4-medium text-secondary">
-                                    <span>총 결제 금액</span>
-                                    <span className="text-heading-4-bold text-primary">{formatPrice(summaryPrice)}</span>
-                                 </div>
-                                 <button
-                                    type="button"
-                                    disabled={!selectedResellListing}
-                                    onClick={handleProceedToPayment}
-                                    className={[
-                                       'h-12 w-full rounded-[8px] text-label-1-bold transition-colors',
-                                       !selectedResellListing
-                                          ? 'bg-fill-disabled text-disabled-foreground'
-                                          : 'bg-primary text-white hover:bg-primary-strong',
-                                    ].join(' ')}
-                                 >
-                                    {bookingButtonLabel}
-                                 </button>
-                              </div>
-                           </>
+                        {isResellMode && resellInsights ? (
+                           <ResellZonePreviewSheet
+                              insights={resellInsights}
+                              zone={zone}
+                              selectedListingId={selectedResellListing?.listingId}
+                              onSelectListing={handleSelectResellListing}
+                              submitLabel={bookingButtonLabel}
+                              submitDisabled={!selectedResellListing}
+                              onSubmit={handleProceedToPayment}
+                           />
                         ) : (
                            <>
                               <div className="flex items-center justify-between gap-3 px-5 py-4">

--- a/src/pages/books/ui/components/BookingZoneDesktopLayout.tsx
+++ b/src/pages/books/ui/components/BookingZoneDesktopLayout.tsx
@@ -1,0 +1,35 @@
+import type { ZoneItem } from '@/pages/books/model/types';
+
+import BookingZoneList from './BookingZoneList';
+import BookingZoneMap from './BookingZoneMap';
+
+type BookingZoneDesktopLayoutProps = {
+   zones: ZoneItem[];
+   selectedZoneId: string;
+   onSelectZone: (zoneId: string) => void;
+   stadiumImage: string;
+   stadiumImageAlt: string;
+};
+
+function BookingZoneDesktopLayout({
+   zones,
+   selectedZoneId,
+   onSelectZone,
+   stadiumImage,
+   stadiumImageAlt,
+}: BookingZoneDesktopLayoutProps) {
+   return (
+      <main className="hidden min-h-[calc(100vh-140px)] lg:grid lg:h-[calc(100vh-140px)] lg:grid-cols-[minmax(0,1fr)_420px]">
+         <BookingZoneMap
+            zones={zones}
+            selectedZoneId={selectedZoneId}
+            onSelectZone={onSelectZone}
+            stadiumImage={stadiumImage}
+            stadiumImageAlt={stadiumImageAlt}
+         />
+         <BookingZoneList zones={zones} selectedZoneId={selectedZoneId} onSelectZone={onSelectZone} />
+      </main>
+   );
+}
+
+export default BookingZoneDesktopLayout;

--- a/src/pages/books/ui/components/BookingZoneMobileLayout.tsx
+++ b/src/pages/books/ui/components/BookingZoneMobileLayout.tsx
@@ -43,7 +43,7 @@ function BookingZoneMobileLayout({
                {!isZoneDrawerOpen ? (
                   <div className="absolute inset-x-0 bottom-0 z-10">
                      <DrawerTrigger asChild>
-                        <button
+                       <button
                            type="button"
                            className="w-full rounded-t-[16px] bg-elevated px-5 py-4 text-left shadow-[0_-6px_24px_rgba(0,0,0,0.16)]"
                         >

--- a/src/pages/books/ui/components/BookingZoneMobileLayout.tsx
+++ b/src/pages/books/ui/components/BookingZoneMobileLayout.tsx
@@ -1,0 +1,86 @@
+import type { BookingFlowMode } from '@/shared/lib/booking-flow';
+import { Drawer, DrawerContent, DrawerTrigger } from '@/shared/ui/drawer';
+import type { ZoneItem } from '@/pages/books/model/types';
+
+import BookingZoneList from './BookingZoneList';
+import BookingZoneMap from './BookingZoneMap';
+
+type BookingZoneMobileLayoutProps = {
+   bookingFlowMode: BookingFlowMode;
+   zones: ZoneItem[];
+   selectedZoneId: string;
+   isCaptchaOpen: boolean;
+   isZoneDrawerOpen: boolean;
+   onOpenChange: (open: boolean) => void;
+   onSelectZone: (zoneId: string) => void;
+   stadiumImage: string;
+   stadiumImageAlt: string;
+};
+
+function BookingZoneMobileLayout({
+   bookingFlowMode,
+   zones,
+   selectedZoneId,
+   isCaptchaOpen,
+   isZoneDrawerOpen,
+   onOpenChange,
+   onSelectZone,
+   stadiumImage,
+   stadiumImageAlt,
+}: BookingZoneMobileLayoutProps) {
+   return (
+      <section className="relative min-h-[calc(100vh-140px)] bg-[#f1f2f4] lg:hidden">
+         <BookingZoneMap
+            zones={zones}
+            selectedZoneId={selectedZoneId}
+            onSelectZone={onSelectZone}
+            mobileExpanded={!isCaptchaOpen && !isZoneDrawerOpen}
+            stadiumImage={stadiumImage}
+            stadiumImageAlt={stadiumImageAlt}
+         />
+         {!isCaptchaOpen ? (
+            <Drawer open={isZoneDrawerOpen} onOpenChange={onOpenChange} modal={false}>
+               {!isZoneDrawerOpen ? (
+                  <div className="absolute inset-x-0 bottom-0 z-10">
+                     <DrawerTrigger asChild>
+                        <button
+                           type="button"
+                           className="w-full rounded-t-[16px] bg-elevated px-5 py-4 text-left shadow-[0_-6px_24px_rgba(0,0,0,0.16)]"
+                        >
+                           <div className="mb-3 flex justify-center" aria-hidden="true">
+                              <div className="h-1 w-9 rounded-full bg-border-light" />
+                           </div>
+                           <div className="flex items-center justify-between gap-3">
+                              <span className="text-heading-3-bold text-foreground">
+                                 {bookingFlowMode === 'resell' ? '리셀 좌석 구역' : '좌석 등급/잔여석'}
+                              </span>
+                              <span className="text-body-1-medium text-tertiary">{zones.length}개 구역</span>
+                           </div>
+                        </button>
+                     </DrawerTrigger>
+                  </div>
+               ) : null}
+               <DrawerContent
+                  showOverlay={false}
+                  resizable
+                  defaultHeight={360}
+                  minHeight={232}
+                  maxHeight={488}
+                  className="overflow-hidden border-none p-0"
+               >
+                  <div className="h-full overflow-y-auto">
+                     <BookingZoneList
+                        variant="drawer"
+                        zones={zones}
+                        selectedZoneId={selectedZoneId}
+                        onSelectZone={onSelectZone}
+                     />
+                  </div>
+               </DrawerContent>
+            </Drawer>
+         ) : null}
+      </section>
+   );
+}
+
+export default BookingZoneMobileLayout;

--- a/src/pages/books/ui/components/ResellSeatSidebar.tsx
+++ b/src/pages/books/ui/components/ResellSeatSidebar.tsx
@@ -307,13 +307,15 @@ function ResellSeatSidebar({
                               type="button"
                               onClick={() => onSelectListing(item)}
                               className={cn(
-                                 'flex w-full items-start gap-6 rounded-[12px] border px-4 py-4 text-left transition-colors',
-                                 isSelected ? 'border-primary bg-primary/5' : 'border-border-light bg-background hover:border-primary/40',
+                                 'flex w-full items-start gap-6 rounded-[12px] bg-background px-4 py-4 text-left transition-colors',
+                                 isSelected ? 'border-2 border-primary' : 'border border-border-light hover:border-primary/40',
                               )}
                               aria-pressed={isSelected}
                            >
                               <span className="flex-1 text-body-1-semibold text-secondary">{item.seatLabel}</span>
-                              <span className="shrink-0 text-body-1-bold text-secondary">{formatPrice(item.listingPrice)}</span>
+                              <span className={cn('shrink-0 text-body-1-bold', isSelected ? 'text-primary' : 'text-secondary')}>
+                                 {formatPrice(item.listingPrice)}
+                              </span>
                            </button>
                         </li>
                      );

--- a/src/pages/books/ui/components/ResellZonePreviewSheet.tsx
+++ b/src/pages/books/ui/components/ResellZonePreviewSheet.tsx
@@ -2,20 +2,20 @@ import type { ApexOptions } from 'apexcharts';
 import { useMemo, useState } from 'react';
 import Chart from 'react-apexcharts';
 
-import { Button } from '@/shared/ui/button';
 import { formatPrice } from '@/pages/books/model/zoneData';
-import type { ZoneItem } from '@/pages/books/model/types';
 import type { ResellListingItem, ResellTradeRange, ResellZoneInsights } from '@/pages/books/model/resellData';
+import type { ZoneItem } from '@/pages/books/model/types';
+import { Button } from '@/shared/ui/button';
 import { cn } from '@/shared/lib/utils';
 
-type ResellSeatSidebarProps = {
+type ResellZonePreviewSheetProps = {
    insights: ResellZoneInsights;
-   selectedListingId?: string;
    zone: ZoneItem;
-   zoneOverviewImage: string;
-   stadiumName: string;
-   onSelectListing: (listing: ResellListingItem) => void;
-   onSubmit: () => void;
+   selectedListingId?: string;
+   onSelectListing?: (listing: ResellListingItem) => void;
+   submitLabel?: string;
+   submitDisabled?: boolean;
+   onSubmit?: () => void;
 };
 
 const tooltipWeekdayFormatter = new Intl.DateTimeFormat('ko-KR', {
@@ -49,15 +49,15 @@ const formatTooltipChangeRate = (price: number, previousClose: number) => {
    return `${changeRate >= 0 ? '+' : ''}${changeRate.toFixed(2)}%`;
 };
 
-function ResellSeatSidebar({
+function ResellZonePreviewSheet({
    insights,
-   selectedListingId,
    zone,
-   zoneOverviewImage,
-   stadiumName,
+   selectedListingId,
    onSelectListing,
+   submitLabel,
+   submitDisabled,
    onSubmit,
-}: ResellSeatSidebarProps) {
+}: ResellZonePreviewSheetProps) {
    const [chartRange, setChartRange] = useState<ResellTradeRange>('minute');
    const pricePoints = insights.pricePointsByRange[chartRange];
    const priceValues = useMemo(() => pricePoints.map((point) => point.price), [pricePoints]);
@@ -69,9 +69,7 @@ function ResellSeatSidebar({
 
       return Math.max(1000, Math.ceil(roughStep / 1000) * 1000);
    }, [chartMax, chartMin]);
-   const yAxisMin = useMemo(() => {
-      return Math.max(0, Math.floor(chartMin / yAxisStep) * yAxisStep);
-   }, [chartMin, yAxisStep]);
+   const yAxisMin = useMemo(() => Math.max(0, Math.floor(chartMin / yAxisStep) * yAxisStep), [chartMin, yAxisStep]);
    const yAxisMax = useMemo(() => {
       const nextMax = Math.ceil(chartMax / yAxisStep) * yAxisStep;
 
@@ -81,7 +79,7 @@ function ResellSeatSidebar({
       () => ({
          chart: {
             type: 'area',
-            height: 200,
+            height: 179,
             toolbar: { show: false },
             zoom: { enabled: false },
             sparkline: { enabled: false },
@@ -106,12 +104,10 @@ function ResellSeatSidebar({
                opacityFrom: 0.2,
                opacityTo: 0,
                stops: [0, 100],
-               colorStops: [
-                  [
-                     { offset: 0, color: '#2563eb', opacity: 0.2 },
-                     { offset: 100, color: '#2563eb', opacity: 0 },
-                  ],
-               ],
+               colorStops: [[
+                  { offset: 0, color: '#2563eb', opacity: 0.2 },
+                  { offset: 100, color: '#2563eb', opacity: 0 },
+               ]],
             },
          },
          stroke: {
@@ -149,13 +145,13 @@ function ResellSeatSidebar({
             },
          },
          legend: { show: false },
-        grid: {
+         grid: {
             borderColor: '#d9dde3',
             strokeDashArray: 4,
             padding: {
                top: 8,
                right: 18,
-               bottom: 0,
+               bottom: -2,
                left: 12,
             },
             xaxis: { lines: { show: false } },
@@ -170,23 +166,15 @@ function ResellSeatSidebar({
             labels: {
                offsetX: 4,
                style: {
-                  colors: Array.from({ length: pricePoints.length }, () => '#8a94a6'),
+                  colors: Array.from({ length: pricePoints.length }, () => '#646f7c'),
                   fontSize: '12px',
                   fontWeight: 400,
                },
             },
          },
          states: {
-            hover: {
-               filter: {
-                  type: 'none',
-               },
-            },
-            active: {
-               filter: {
-                  type: 'none',
-               },
-            },
+            hover: { filter: { type: 'none' } },
+            active: { filter: { type: 'none' } },
          },
          yaxis: {
             show: true,
@@ -199,12 +187,12 @@ function ResellSeatSidebar({
             forceNiceScale: false,
             labels: {
                show: true,
-               minWidth: 44,
-               maxWidth: 44,
+               minWidth: 52,
+               maxWidth: 52,
                align: 'left',
                offsetX: 6,
                style: {
-                  colors: ['#8a94a6'],
+                  colors: ['#646f7c'],
                   fontSize: '12px',
                   fontWeight: 400,
                },
@@ -216,126 +204,123 @@ function ResellSeatSidebar({
    );
 
    return (
-      <aside className="hidden w-full shrink-0 flex-col border-l border-border-light bg-background xl:flex xl:w-[420px]">
-         <div className="relative h-[220px] overflow-hidden border-b border-border-light bg-[#e9ebee] px-5 py-2.5">
-            <div className="relative mx-auto h-[200px] w-[200px] shrink-0">
-               <img
-                  src={zoneOverviewImage}
-                  alt={`${stadiumName} ${zone.name} 구역 좌석도`}
-                  className="h-full w-full object-contain opacity-70"
-                  draggable={false}
-               />
+      <div className="flex h-full flex-col overflow-y-auto pb-8">
+         <section className="space-y-5">
+            <div className="flex items-center gap-1 px-5 pt-5">
+               <h2 className="text-heading-3-bold text-foreground">거래 변동</h2>
+               <span className={cn('text-label-1-semibold', insights.changeAmount >= 0 ? 'text-destructive' : 'text-primary')}>
+                  {insights.changeAmount >= 0 ? '+' : ''}
+                  {formatPrice(insights.changeAmount)} ({insights.changeRate}%)
+               </span>
             </div>
-         </div>
 
-         <div className="flex flex-1 flex-col gap-12 overflow-y-auto pb-5">
-            <section className="space-y-6">
-               <div className="flex items-center gap-1 px-5 pt-5">
-                  <h2 className="text-heading-3-bold text-foreground">거래 변동</h2>
-                  <span className={cn('text-label-2-semibold', insights.changeAmount >= 0 ? 'text-destructive' : 'text-primary')}>
-                     {insights.changeAmount >= 0 ? '+' : ''}
-                     {formatPrice(insights.changeAmount)} ({insights.changeRate}%)
-                  </span>
+            <div className="grid grid-cols-2 gap-x-8 gap-y-1 px-5 text-caption-1-medium text-tertiary">
+               <Metric label="전일 종가" value={formatPrice(insights.previousClose)} />
+               <Metric label="최근 거래 체결가" value={formatPrice(insights.recentTrade)} />
+               <Metric label="금일 하한가" value={formatPrice(insights.dayLow)} valueClassName="text-primary" />
+               <Metric label="금일 상한가" value={formatPrice(insights.dayHigh)} valueClassName="text-destructive" />
+            </div>
+
+            <div className="px-5">
+               <div className="flex rounded-[12px] bg-[#f1f2f4] p-1">
+                  {([
+                     { key: 'minute', label: '1분' },
+                     { key: 'day', label: '1일' },
+                  ] as const).map((item) => (
+                     <button
+                        key={item.key}
+                        type="button"
+                        onClick={() => setChartRange(item.key)}
+                        className={cn(
+                           'flex-1 rounded-[8px] px-2.5 py-2 text-body-2-bold transition-colors',
+                           chartRange === item.key ? 'bg-background text-secondary' : 'text-disabled-foreground',
+                        )}
+                     >
+                        {item.label}
+                     </button>
+                  ))}
                </div>
+            </div>
 
-               <div className="grid grid-cols-2 gap-x-8 gap-y-1 px-5 text-caption-1-medium text-tertiary">
-                  <Metric label="전일 종가" value={formatPrice(insights.previousClose)} />
-                  <Metric label="최근 거래 체결가" value={formatPrice(insights.recentTrade)} />
-                  <Metric label="금일 하한가" value={formatPrice(insights.dayLow)} valueClassName="text-primary" />
-                  <Metric label="금일 상한가" value={formatPrice(insights.dayHigh)} valueClassName="text-destructive" />
-               </div>
-
-               <div className="px-5">
-                  <div className="flex rounded-[12px] bg-[#f1f2f4] p-1">
-                     {([
-                        { key: 'minute', label: '1분' },
-                        { key: 'day', label: '1일' },
-                     ] as const).map((item) => (
-                        <button
-                           key={item.key}
-                           type="button"
-                           onClick={() => setChartRange(item.key)}
-                           className={cn(
-                              'flex-1 rounded-[8px] px-2.5 py-2 text-body-2-bold transition-colors',
-                              chartRange === item.key ? 'bg-background text-secondary' : 'text-disabled-foreground',
-                           )}
-                        >
-                           {item.label}
-                        </button>
-                     ))}
-                  </div>
-               </div>
-
-               <div className="px-5">
-                  <div className="bg-background py-3">
-                     <div role="img" aria-label={`${zone.name} 리셀 가격 추이`}>
-                        <div>
-                           <Chart options={chartOptions} series={chartOptions.series ?? []} type="area" height={200} />
-                        </div>
+            <div className="px-5">
+               <div className="rounded-[8px] bg-background py-2">
+                  <div role="img" aria-label={`${zone.name} 리셀 가격 추이`}>
+                     <div className="pr-1">
+                        <Chart options={chartOptions} series={chartOptions.series ?? []} type="area" height={179} />
                      </div>
                   </div>
                </div>
-            </section>
+            </div>
+         </section>
 
-            <section className="space-y-4">
-               <div className="px-5">
-                  <h3 className="text-heading-3-bold text-foreground">최근 거래 내역</h3>
-               </div>
-               <ul className="space-y-1 px-5">
-                  {insights.tradeHistory.map((item) => (
-                     <li key={item.id} className="grid grid-cols-[max-content_minmax(0,1fr)_88px] items-center gap-x-3 text-body-2-regular text-secondary">
-                        <span className="whitespace-nowrap text-body-2-semibold">{formatPrice(item.price)}</span>
-                        <span className="min-w-0 truncate text-right">{item.seatLabel}</span>
-                        <span className="whitespace-nowrap text-right text-caption-1-regular text-tertiary">{item.tradedAt}</span>
-                     </li>
-                  ))}
-               </ul>
-            </section>
+         <section className="space-y-4 pt-12">
+            <div className="px-5">
+               <h3 className="text-heading-3-bold text-foreground">최근 거래 내역</h3>
+            </div>
+            <ul className="space-y-1 px-5">
+               {insights.tradeHistory.map((item) => (
+                  <li key={item.id} className="grid grid-cols-[max-content_minmax(0,1fr)_66px] items-center gap-x-3 text-body-2-regular text-secondary">
+                     <span className="whitespace-nowrap text-body-1-semibold">{formatPrice(item.price)}</span>
+                     <span className="min-w-0 truncate text-right">{item.seatLabel}</span>
+                     <span className="whitespace-nowrap text-right text-caption-1-regular text-tertiary">{item.tradedAt}</span>
+                  </li>
+               ))}
+            </ul>
+         </section>
 
-            <section className="space-y-3">
-               <div className="flex items-center gap-1 px-5">
-                  <h3 className="text-heading-3-bold text-foreground">판매 중인 좌석</h3>
-                  <span className="text-heading-3-bold text-primary">{insights.listings.length}</span>
-               </div>
+         <section className="space-y-3 pt-12">
+            <div className="flex items-center gap-1 px-5">
+               <h3 className="text-heading-3-bold text-foreground">판매 중인 좌석</h3>
+               <span className="text-heading-3-bold text-primary">{insights.listings.length}</span>
+            </div>
 
-               <ul className="space-y-3 px-5">
-                  {insights.listings.map((item) => {
-                     const isSelected = item.listingId === selectedListingId;
+            <ul className="space-y-3 px-5">
+               {insights.listings.map((item) => {
+                  const isSelected = item.listingId === selectedListingId;
 
+                  if (onSelectListing) {
                      return (
                         <li key={item.listingId}>
                            <button
                               type="button"
                               onClick={() => onSelectListing(item)}
                               className={cn(
-                                 'flex w-full items-start gap-6 rounded-[12px] bg-background px-4 py-4 text-left transition-colors',
-                                 isSelected ? 'border-2 border-primary' : 'border border-border-light hover:border-primary/40',
+                                 'flex w-full items-start justify-between gap-4 rounded-[12px] bg-background px-4 py-4 text-left transition-colors',
+                                 isSelected ? 'border-2 border-primary' : 'border border-border-light',
                               )}
-                              aria-pressed={isSelected}
                            >
-                              <span className="flex-1 text-body-1-semibold text-secondary">{item.seatLabel}</span>
+                              <span className="text-body-1-semibold text-secondary">{item.seatLabel}</span>
                               <span className={cn('shrink-0 text-body-1-bold', isSelected ? 'text-primary' : 'text-secondary')}>
                                  {formatPrice(item.listingPrice)}
                               </span>
                            </button>
                         </li>
                      );
-                  })}
-               </ul>
-            </section>
-         </div>
+                  }
 
-         <div className="px-5 pb-5">
-            <Button
-               type="button"
-               disabled={!selectedListingId}
-               className="h-12 w-full rounded-[8px]"
-               onClick={onSubmit}
-            >
-               예매하기
-            </Button>
-         </div>
-      </aside>
+                  return (
+                     <li key={item.listingId} className="flex w-full items-start gap-6 rounded-[12px] border border-border-light bg-background px-4 py-4">
+                        <span className="flex-1 text-body-1-semibold text-secondary">{item.seatLabel}</span>
+                        <span className="shrink-0 text-body-1-bold text-secondary">{formatPrice(item.listingPrice)}</span>
+                     </li>
+                  );
+               })}
+            </ul>
+         </section>
+
+         {submitLabel && onSubmit ? (
+            <div className="px-5 pt-5">
+               <Button
+                  type="button"
+                  disabled={submitDisabled}
+                  className="h-12 w-full rounded-[8px]"
+                  onClick={onSubmit}
+               >
+                  {submitLabel}
+               </Button>
+            </div>
+         ) : null}
+      </div>
    );
 }
 
@@ -356,4 +341,4 @@ function Metric({
    );
 }
 
-export default ResellSeatSidebar;
+export default ResellZonePreviewSheet;


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #101

<br/>

## 🔎 개요
리셀 예매 페이지의 모바일 UI 구현 및 그래프와 리셀 판매 티켓 아이템 UI 세부 사항 수정

<br/>

## 📋 작업 내용
- 모바일 UI에서 리셀 그래프가 나오도록 변경
- 리셀 그래프에서 가격 및 시간대 표시가 일부 외곽에서 잘리는 문제 해결
- 리셀 판매 티켓 아이템이 selected되었을 때 임시 Ui가 아닌 figma 정식 ui대로 변하도록 변경(border 굵기 변경 및 파랗게 색상 변경, 가격 파란 글씨 표시)

<br/>
