### PR TITLE
 [refactor] 경기 일정/예매 API 최신 스펙 반영 및 팀 매핑 개선

### DIFF
--- a/src/entities/game/api/scheduleApi.ts
+++ b/src/entities/game/api/scheduleApi.ts
@@ -30,6 +30,17 @@ export type GameScheduleResponse = {
   stadiumName?: string;
 };
 
+export type BaseballTeamDetailResponse = {
+  id: string;
+  teamCode: string;
+  teamName: string;
+  teamNameEn?: string;
+  homeGround?: string;
+};
+
+const baseballTeamCache = new Map<string, BaseballTeamDetailResponse>();
+const baseballTeamRequestCache = new Map<string, Promise<BaseballTeamDetailResponse>>();
+
 export const fetchGameSchedules = async (params: FetchGameSchedulesParams = {}) => {
   const response = await apiClient.get<ApiEnvelope<GameScheduleResponse[]>>('/api/v1/games/schedules', {
     params: {
@@ -42,4 +53,48 @@ export const fetchGameSchedules = async (params: FetchGameSchedulesParams = {}) 
   });
 
   return response.data.data;
+};
+
+export const fetchBaseballTeamDetail = async (teamId: string) => {
+  const cached = baseballTeamCache.get(teamId);
+
+  if (cached) {
+    return cached;
+  }
+
+  const pending = baseballTeamRequestCache.get(teamId);
+
+  if (pending) {
+    return pending;
+  }
+
+  const request = apiClient
+    .get<ApiEnvelope<BaseballTeamDetailResponse>>(`/api/v1/baseball-teams/${teamId}`)
+    .then((response) => {
+      const detail = response.data.data;
+      baseballTeamCache.set(teamId, detail);
+      baseballTeamRequestCache.delete(teamId);
+      return detail;
+    })
+    .catch((error) => {
+      baseballTeamRequestCache.delete(teamId);
+      throw error;
+    });
+
+  baseballTeamRequestCache.set(teamId, request);
+  return request;
+};
+
+export const fetchBaseballTeamDetails = async (teamIds: string[]) => {
+  const uniqueTeamIds = [...new Set(teamIds.filter(Boolean))];
+
+  if (uniqueTeamIds.length === 0) {
+    return new Map<string, BaseballTeamDetailResponse>();
+  }
+
+  const details = await Promise.all(
+    uniqueTeamIds.map(async (teamId) => [teamId, await fetchBaseballTeamDetail(teamId)] as const),
+  );
+
+  return new Map<string, BaseballTeamDetailResponse>(details);
 };

--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -1,7 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { buildMockQueueTokenJti } from '@/shared/config/booking';
-import { fetchGameSchedules, type FetchGameSchedulesParams, type GameScheduleResponse } from '@/entities/game/api/scheduleApi';
+import {
+  fetchBaseballTeamDetails,
+  fetchGameSchedules,
+  type FetchGameSchedulesParams,
+  type GameScheduleResponse,
+} from '@/entities/game/api/scheduleApi';
+import { teams } from '@/entities/team/model/teams';
 import type { DaySchedule, GameRow, GameStatus, ReselStatus, TicketStatus } from '@/pages/home/ui/game-schedule/types';
 
 export type NormalizedScheduleGame = {
@@ -32,24 +38,49 @@ export type NormalizedScheduleGame = {
 
 type TeamReference = {
   frontendId: string;
+  serverTeamId?: string;
   teamCode: string;
   shortName: string;
   fullName: string;
   aliases: string[];
 };
 
-const TEAM_REFERENCES: TeamReference[] = [
-  { frontendId: 'kia', teamCode: 'KIA', shortName: 'KIA', fullName: 'KIA 타이거즈', aliases: ['kia', 'teamkia', 'kiatigers', '기아', '기아타이거즈'] },
-  { frontendId: 'samsung', teamCode: 'SS', shortName: '삼성', fullName: '삼성 라이온즈', aliases: ['samsung', 'teamsamsung', '삼성', '삼성라이온즈', 'ss', 'samsunglions'] },
-  { frontendId: 'lg', teamCode: 'LG', shortName: 'LG', fullName: 'LG 트윈스', aliases: ['lg', 'teamlg', 'lgtwins', '엘지', '엘지트윈스', 'lg트윈스'] },
-  { frontendId: 'hanwha', teamCode: 'HH', shortName: '한화', fullName: '한화 이글스', aliases: ['hanwha', 'teamhanwha', '한화', '한화이글스', 'hh', 'hanwhaeagles'] },
-  { frontendId: 'ssg', teamCode: 'SSG', shortName: 'SSG', fullName: 'SSG 랜더스', aliases: ['ssg', 'teamssg', 'ssglanders', '랜더스', 'ssg랜더스'] },
-  { frontendId: 'nc', teamCode: 'NC', shortName: 'NC', fullName: 'NC 다이노스', aliases: ['nc', 'teamnc', 'ncdinos', 'nc다이노스'] },
-  { frontendId: 'kt', teamCode: 'KT', shortName: 'KT', fullName: 'KT wiz', aliases: ['kt', 'teamkt', 'ktwiz', '케이티', '케이티위즈'] },
-  { frontendId: 'lotte', teamCode: 'LOT', shortName: '롯데', fullName: '롯데 자이언츠', aliases: ['lotte', 'teamlotte', '롯데', '롯데자이언츠', 'lot', 'lottegiants'] },
-  { frontendId: 'doosan', teamCode: 'DO', shortName: '두산', fullName: '두산 베어스', aliases: ['doosan', 'teamdoosan', '두산', '두산베어스', 'do', 'doosanbears'] },
-  { frontendId: 'kiwoom', teamCode: 'KIW', shortName: '키움', fullName: '키움 히어로즈', aliases: ['kiwoom', 'teamkiwoom', '키움', '키움히어로즈', 'kiw', 'kiwoomheroes'] },
-];
+const TEAM_ALIASES_BY_ID: Partial<Record<string, string[]>> = {
+  kia: ['teamkia', 'kiatigers', '기아', '기아타이거즈'],
+  samsung: ['teamsamsung', '삼성', '삼성라이온즈', 'ss', 'samsunglions'],
+  lg: ['teamlg', 'lgtwins', '엘지', '엘지트윈스', 'lg트윈스'],
+  hanwha: ['teamhanwha', '한화', '한화이글스', 'hh', 'hanwhaeagles'],
+  ssg: ['teamssg', 'ssglanders', '랜더스', 'ssg랜더스'],
+  nc: ['teamnc', 'ncdinos', 'nc다이노스'],
+  kt: ['teamkt', 'ktwiz', '케이티', '케이티위즈'],
+  lotte: ['teamlotte', '롯데', '롯데자이언츠', 'lot', 'lottegiants'],
+  doosan: ['teamdoosan', '두산', '두산베어스', 'do', 'doosanbears'],
+  kiwoom: ['teamkiwoom', '키움', '키움히어로즈', 'kiw', 'kiwoomheroes'],
+};
+
+const TEAM_SHORT_NAME_BY_ID: Partial<Record<string, string>> = {
+  kia: 'KIA',
+  samsung: '삼성',
+  lg: 'LG',
+  hanwha: '한화',
+  ssg: 'SSG',
+  nc: 'NC',
+  kt: 'KT',
+  lotte: '롯데',
+  doosan: '두산',
+  kiwoom: '키움',
+};
+
+const TEAM_REFERENCES: TeamReference[] = teams
+  .filter((team): team is typeof team & { teamCode: string } => Boolean(team.teamCode))
+  .map((team) => ({
+    frontendId: team.id,
+    serverTeamId: team.serverTeamId,
+    teamCode: team.teamCode,
+    shortName: TEAM_SHORT_NAME_BY_ID[team.id] ?? team.name,
+    fullName: team.name,
+    aliases: [team.id, team.name, team.teamCode, ...(TEAM_ALIASES_BY_ID[team.id] ?? [])],
+  }));
 
 type StadiumReference = {
   displayName: string;
@@ -109,11 +140,68 @@ const findTeamReference = (...candidates: Array<string | undefined>) => {
   }
 
   return TEAM_REFERENCES.find((reference) => {
-    const referenceCandidates = [reference.frontendId, reference.teamCode, reference.shortName, reference.fullName, ...reference.aliases]
+    const referenceCandidates = [
+      reference.frontendId,
+      reference.serverTeamId,
+      reference.teamCode,
+      reference.shortName,
+      reference.fullName,
+      ...reference.aliases,
+    ]
       .map(normalizeLookupValue);
 
     return normalizedCandidates.some((candidate) => referenceCandidates.includes(candidate));
   });
+};
+
+const needsTeamLookup = (
+  teamId: string | undefined,
+  teamCode: string | undefined,
+  teamName: string | undefined,
+) => {
+  if (!teamId) {
+    return false;
+  }
+
+  if (findTeamReference(teamCode, teamName, teamId)) {
+    return false;
+  }
+
+  return !teamCode || !teamName;
+};
+
+const collectLookupTeamIds = (games: GameScheduleResponse[]) => {
+  const ids = new Set<string>();
+
+  games.forEach((game) => {
+    if (needsTeamLookup(game.homeTeamId, game.homeTeamCode, game.homeTeamName)) {
+      ids.add(game.homeTeamId);
+    }
+
+    if (needsTeamLookup(game.awayTeamId, game.awayTeamCode, game.awayTeamName)) {
+      ids.add(game.awayTeamId);
+    }
+  });
+
+  return [...ids];
+};
+
+const mergeScheduleWithTeamDetails = (game: GameScheduleResponse, teamDetails: Map<string, {
+  teamCode: string;
+  teamName: string;
+  homeGround?: string;
+}>) => {
+  const homeTeamDetail = teamDetails.get(game.homeTeamId);
+  const awayTeamDetail = teamDetails.get(game.awayTeamId);
+
+  return {
+    ...game,
+    homeTeamCode: game.homeTeamCode ?? homeTeamDetail?.teamCode,
+    awayTeamCode: game.awayTeamCode ?? awayTeamDetail?.teamCode,
+    homeTeamName: game.homeTeamName ?? homeTeamDetail?.teamName,
+    awayTeamName: game.awayTeamName ?? awayTeamDetail?.teamName,
+    stadiumName: game.stadiumName ?? homeTeamDetail?.homeGround,
+  } satisfies GameScheduleResponse;
 };
 
 const parseApiDateTime = (value: string) => {
@@ -363,7 +451,13 @@ export const useGameSchedules = (params: FetchGameSchedulesParams = {}) => {
     queryKey: ['game-schedules', params.teamId ?? null, params.year ?? null, params.month ?? null, params.week ?? null, params.today ?? null],
     queryFn: async () => {
       const schedules = await fetchGameSchedules(params);
-      return schedules.map(normalizeScheduleGame).sort(sortByStartAt);
+      const lookupTeamIds = collectLookupTeamIds(schedules);
+      const teamDetails = await fetchBaseballTeamDetails(lookupTeamIds);
+
+      return schedules
+        .map((game) => mergeScheduleWithTeamDetails(game, teamDetails))
+        .map(normalizeScheduleGame)
+        .sort(sortByStartAt);
     },
   });
 };

--- a/src/entities/team/model/teams.ts
+++ b/src/entities/team/model/teams.ts
@@ -11,6 +11,7 @@ export const teams: Team[] = [
     logoSrc: "/baseball/logos/samsung.png",
     logoAspectClassName: "aspect-[1280/962]",
     isEnabled: true,
+    serverTeamId: "412cfc77-2c5d-4583-8e79-968339223864",
     teamCode: "SS",
     stadiumName: "대구",
     stadiumGuide: {
@@ -56,6 +57,7 @@ export const teams: Team[] = [
     logoSrc: "/baseball/logos/kia.png",
     logoAspectClassName: "aspect-[1280/954]",
     isEnabled: true,
+    serverTeamId: "e5f58f8c-fcde-4017-8033-d8deb34fd4a2",
     teamCode: "KIA",
     stadiumName: "광주",
     stadiumGuide: {
@@ -101,6 +103,8 @@ export const teams: Team[] = [
     logoSrc: "/baseball/logos/lg.png",
     logoAspectClassName: "aspect-[1280/1023]",
     isEnabled: false,
+    serverTeamId: "f44d1e89-e2fe-40e7-a587-1157d7a9c80a",
+    teamCode: "LG",
   },
   {
     id: "hanwha",
@@ -108,6 +112,8 @@ export const teams: Team[] = [
     logoSrc: "/baseball/logos/hanwha.png",
     logoAspectClassName: "aspect-[1280/1065]",
     isEnabled: false,
+    serverTeamId: "34159d27-2497-44d4-a4a2-c461dc3585c8",
+    teamCode: "HH",
   },
   {
     id: "ssg",
@@ -115,6 +121,8 @@ export const teams: Team[] = [
     logoSrc: "/baseball/logos/ssg.png",
     logoAspectClassName: "aspect-[1280/754]",
     isEnabled: false,
+    serverTeamId: "c33af471-d869-4af1-9b68-d085472e4408",
+    teamCode: "SSG",
   },
   {
     id: "nc",
@@ -122,6 +130,8 @@ export const teams: Team[] = [
     logoSrc: "/baseball/logos/nc.png",
     logoAspectClassName: "aspect-[1280/862]",
     isEnabled: false,
+    serverTeamId: "72c57b65-9f68-4b6e-b9e3-2ec9074861f6",
+    teamCode: "NC",
   },
   {
     id: "kt",
@@ -129,6 +139,8 @@ export const teams: Team[] = [
     logoSrc: "/baseball/logos/kt.png",
     logoAspectClassName: "aspect-[1280/1158]",
     isEnabled: false,
+    serverTeamId: "1e4022c6-3887-44f6-b510-d98aad5a4192",
+    teamCode: "KT",
   },
   {
     id: "lotte",
@@ -136,6 +148,8 @@ export const teams: Team[] = [
     logoSrc: "/baseball/logos/lotte.png",
     logoAspectClassName: "aspect-[1280/961]",
     isEnabled: false,
+    serverTeamId: "d7b12b0f-c69d-4a7f-badc-04226daabb5f",
+    teamCode: "LOT",
   },
   {
     id: "doosan",
@@ -143,6 +157,8 @@ export const teams: Team[] = [
     logoSrc: "/baseball/logos/doosan.png",
     logoAspectClassName: "aspect-[1280/1280]",
     isEnabled: false,
+    serverTeamId: "d64b4220-6479-4e77-986a-f52447a433a6",
+    teamCode: "DO",
   },
   {
     id: "kiwoom",
@@ -150,6 +166,7 @@ export const teams: Team[] = [
     logoSrc: "/baseball/logos/kiwoom.png",
     logoAspectClassName: "aspect-[1280/940]",
     isEnabled: false,
+    serverTeamId: "520af775-e84b-4112-aa02-18ed1a6c8458",
+    teamCode: "KIW",
   },
 ];
-

--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -117,14 +117,16 @@ const sortRowNames = (left: string, right: string) =>
       sensitivity: 'base',
    });
 
-export const fetchSeatGrades = async (stadiumId: string) => {
-   const response = await apiClient.get<ApiEnvelope<SeatGradeResponse[]>>(`/api/v1/stadiums/${stadiumId}/seat-grades`);
+export const fetchSeatGrades = async (gameId: string, stadiumId: string) => {
+   const response = await apiClient.get<ApiEnvelope<SeatGradeResponse[]>>(
+      `/api/v1/stadium-seats/stadiums/${stadiumId}/games/${gameId}/seat-grades`,
+   );
 
    return response.data.data;
 };
 
 export const fetchSeatSections = async (stadiumId: string) => {
-   const response = await apiClient.get<ApiEnvelope<SeatSectionResponse[]>>(`/api/v1/stadiums/${stadiumId}/seat-sections`);
+   const response = await apiClient.get<ApiEnvelope<SeatSectionResponse[]>>(`/api/v1/stadium-seats/stadiums/${stadiumId}/seat-sections`);
 
    return response.data.data;
 };

--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -44,7 +44,7 @@ const BooksPage = () => {
       enabled: Boolean(bookingEntryState?.stadiumId),
       queryFn: async () => {
          const [grades, sections] = await Promise.all([
-            fetchSeatGrades(bookingEntryState!.stadiumId!),
+            fetchSeatGrades(bookingEntryState!.gameId!, bookingEntryState!.stadiumId!),
             fetchSeatSections(bookingEntryState!.stadiumId!),
          ]);
 

--- a/src/pages/teams/api/gameApi.ts
+++ b/src/pages/teams/api/gameApi.ts
@@ -14,15 +14,14 @@ export const gameApi = {
       return response.data.data ?? [];
    },
 
-   // 좌석 등급 조회 (GET /api/v1/stadiums/{stadiumId}/seat-grades)
-   getSeatGrades: async (stadiumId: string): Promise<SeatGradeResponse[]> => {
-      const response = await apiClient.get(`/api/v1/stadiums/${stadiumId}/seat-grades`);
-      return response.data.data ?? [];
+   // 좌석 등급 조회는 최신 스펙상 gameId가 필요하므로 팀 상세 탭에서는 실데이터 조회를 보류한다.
+   getSeatGrades: async (_stadiumId: string): Promise<SeatGradeResponse[]> => {
+      return [];
    },
 
-   // 좌석 구역 조회 (GET /api/v1/stadiums/{stadiumId}/seat-sections)
+   // 좌석 구역 조회 (GET /api/v1/stadium-seats/stadiums/{stadiumId}/seat-sections)
    getSeatSections: async (stadiumId: string): Promise<SeatSectionResponse[]> => {
-      const response = await apiClient.get(`/api/v1/stadiums/${stadiumId}/seat-sections`);
+      const response = await apiClient.get(`/api/v1/stadium-seats/stadiums/${stadiumId}/seat-sections`);
       return response.data.data ?? [];
    },
 };

--- a/src/pages/teams/ui/TeamScheduleTab.tsx
+++ b/src/pages/teams/ui/TeamScheduleTab.tsx
@@ -2,13 +2,13 @@
 import { useMemo, useRef, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
+import { mapGamesToDaySchedules, useGameSchedules } from '@/entities/game/model/schedule';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
 import ScheduleList from '@/pages/home/ui/game-schedule/ScheduleList';
 import { YearMonthPicker } from '@/pages/home/ui/game-schedule/YearMonthPicker';
 import { WEEK_OPTIONS, TAB_WEEK } from '@/pages/home/ui/game-schedule/constants';
 import { filterScheduleData } from '@/pages/home/ui/game-schedule/utils';
-import { useGameSchedules } from '../api/useGameSchedules';
 import { BookingGuide } from './BookingGuide';
 
 function getCurrentWeek(): number {
@@ -26,12 +26,17 @@ export function TeamScheduleTab({ serverTeamId }: Props) {
    const [selectedWeek, setSelectedWeek] = useState(getCurrentWeek());
    const [showPicker, setShowPicker] = useState(false);
    const pickerContainerRef = useRef<HTMLDivElement>(null);
-   const { schedules, loading, error } = useGameSchedules({
-      serverTeamId,
+   const scheduleQuery = useGameSchedules({
+      teamId: serverTeamId,
       year: weekYear,
       month: weekMonth,
       week: selectedWeek,
+      today: false,
    });
+   const schedules = useMemo(
+      () => mapGamesToDaySchedules(scheduleQuery.data ?? []),
+      [scheduleQuery.data],
+   );
 
    const filteredData = useMemo(() => {
       return filterScheduleData(schedules, {
@@ -137,11 +142,11 @@ export function TeamScheduleTab({ serverTeamId }: Props) {
          <div className="flex flex-col gap-30 items-start w-full">
             {/* 경기 일정 리스트 */}
             <div className="flex flex-col gap-6.25 items-start w-full">
-               {loading ? (
+               {scheduleQuery.isPending ? (
                   <div className="flex h-100 items-center justify-center rounded-[10px] border-border bg-surface w-full">
                      <p className="text-[18px] text-[#acb4bb]">일정을 불러오는 중...</p>
                   </div>
-               ) : error ? (
+               ) : scheduleQuery.error ? (
                   <div className="rounded-[10px] border border-border bg-surface px-5 py-10 text-center text-body-1-medium text-muted-foreground w-full">
                      경기 일정을 불러오지 못했습니다.
                   </div>

--- a/src/shared/api/mocks/handlers/game.ts
+++ b/src/shared/api/mocks/handlers/game.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from 'msw';
+import { teams } from '@/entities/team/model/teams';
 
 type MockGameSchedule = {
   gameId: string;
@@ -38,8 +39,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameId: 'game-kia-home-yesterday',
     startAt: formatLocalDateTime(-1, 18, 30),
     leagueType: 'REGULAR',
-    homeTeamId: 'team-kia',
-    awayTeamId: 'team-lg',
+    homeTeamId: 'e5f58f8c-fcde-4017-8033-d8deb34fd4a2',
+    awayTeamId: 'f44d1e89-e2fe-40e7-a587-1157d7a9c80a',
     stadiumId: 'stadium-kia-champions-field',
     gameStatus: 'FINISHED',
     homeTeamScore: 6,
@@ -52,8 +53,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameId: 'game-samsung-home-today',
     startAt: formatLocalDateTime(0, 18, 30),
     leagueType: 'REGULAR',
-    homeTeamId: 'team-samsung',
-    awayTeamId: 'team-doosan',
+    homeTeamId: '412cfc77-2c5d-4583-8e79-968339223864',
+    awayTeamId: 'd64b4220-6479-4e77-986a-f52447a433a6',
     stadiumId: 'stadium-samsung-lions-park',
     gameStatus: 'SCHEDULED',
     homeTeamScore: 0,
@@ -66,8 +67,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameId: 'game-kia-home-tomorrow',
     startAt: formatLocalDateTime(1, 18, 30),
     leagueType: 'REGULAR',
-    homeTeamId: 'team-kia',
-    awayTeamId: 'team-kiwoom',
+    homeTeamId: 'e5f58f8c-fcde-4017-8033-d8deb34fd4a2',
+    awayTeamId: '520af775-e84b-4112-aa02-18ed1a6c8458',
     stadiumId: 'stadium-kia-champions-field',
     gameStatus: 'SCHEDULED',
     homeTeamScore: 0,
@@ -80,8 +81,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameId: 'game-samsung-home-this-weekend',
     startAt: formatLocalDateTime(3, 14, 0),
     leagueType: 'REGULAR',
-    homeTeamId: 'team-samsung',
-    awayTeamId: 'team-kt',
+    homeTeamId: '412cfc77-2c5d-4583-8e79-968339223864',
+    awayTeamId: '1e4022c6-3887-44f6-b510-d98aad5a4192',
     stadiumId: 'stadium-samsung-lions-park',
     gameStatus: 'SCHEDULED',
     homeTeamScore: 0,
@@ -94,8 +95,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameId: 'game-kia-home-next-week',
     startAt: formatLocalDateTime(8, 18, 30),
     leagueType: 'REGULAR',
-    homeTeamId: 'team-kia',
-    awayTeamId: 'team-doosan',
+    homeTeamId: 'e5f58f8c-fcde-4017-8033-d8deb34fd4a2',
+    awayTeamId: 'd64b4220-6479-4e77-986a-f52447a433a6',
     stadiumId: 'stadium-kia-champions-field',
     gameStatus: 'SCHEDULED',
     homeTeamScore: 0,
@@ -108,8 +109,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameId: 'game-samsung-home-next-weekend',
     startAt: formatLocalDateTime(9, 17, 0),
     leagueType: 'REGULAR',
-    homeTeamId: 'team-samsung',
-    awayTeamId: 'team-lg',
+    homeTeamId: '412cfc77-2c5d-4583-8e79-968339223864',
+    awayTeamId: 'f44d1e89-e2fe-40e7-a587-1157d7a9c80a',
     stadiumId: 'stadium-samsung-lions-park',
     gameStatus: 'SCHEDULED',
     homeTeamScore: 0,
@@ -122,8 +123,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameId: 'game-kia-home-two-weeks',
     startAt: formatLocalDateTime(14, 18, 30),
     leagueType: 'REGULAR',
-    homeTeamId: 'team-kia',
-    awayTeamId: 'team-hanwha',
+    homeTeamId: 'e5f58f8c-fcde-4017-8033-d8deb34fd4a2',
+    awayTeamId: '34159d27-2497-44d4-a4a2-c461dc3585c8',
     stadiumId: 'stadium-kia-champions-field',
     gameStatus: 'SCHEDULED',
     homeTeamScore: 0,
@@ -172,6 +173,32 @@ export const gameHandlers = [
       code: 'SUCCESS',
       message: 'ok',
       data: filteredGames,
+    });
+  }),
+
+  http.get('/api/v1/baseball-teams/:teamId', async ({ params }) => {
+    const team = teams.find((item) => item.serverTeamId === String(params.teamId));
+
+    if (!team?.serverTeamId || !team.teamCode) {
+      return HttpResponse.json(
+        {
+          code: 'NOT_FOUND',
+          message: 'team not found',
+          data: null,
+        },
+        { status: 404 },
+      );
+    }
+
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: {
+        id: team.serverTeamId,
+        teamCode: team.teamCode,
+        teamName: team.name,
+        homeGround: team.stadiumName,
+      },
     });
   }),
 ];

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -364,7 +364,7 @@ const buildPageResponse = <T>(content: T[], page = 0, size = content.length || 1
 };
 
 export const paymentHandlers = [
-   http.get('/api/v1/stadiums/:stadiumId/seat-grades', async ({ params }) => {
+   http.get('/api/v1/stadium-seats/stadiums/:stadiumId/games/:gameId/seat-grades', async ({ params }) => {
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
@@ -372,7 +372,7 @@ export const paymentHandlers = [
       });
    }),
 
-   http.get('/api/v1/stadiums/:stadiumId/seat-sections', async ({ params }) => {
+   http.get('/api/v1/stadium-seats/stadiums/:stadiumId/seat-sections', async ({ params }) => {
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',

--- a/src/shared/types/game.ts
+++ b/src/shared/types/game.ts
@@ -44,7 +44,7 @@ export interface GetGameSchedulesParams {
    today?: boolean;
 }
 
-// GET /api/v1/stadiums/{stadiumId}/seat-grades 응답 타입
+// GET /api/v1/stadium-seats/stadiums/{stadiumId}/games/{gameId}/seat-grades 응답 타입
 export interface SeatGradeResponse {
    seatGradeId: string;
    stadiumId: string;
@@ -52,7 +52,7 @@ export interface SeatGradeResponse {
    displayColorHex: string;
 }
 
-// GET /api/v1/stadiums/{stadiumId}/seat-sections 응답 타입
+// GET /api/v1/stadium-seats/stadiums/{stadiumId}/seat-sections 응답 타입
 export interface SeatSectionResponse {
    sectionId: string;
    gradeId: string;


### PR DESCRIPTION
## #️⃣ 관련 이슈
 - #118

  <br/>
## 🔎 개요
경기 일정 및 예매 관련 API를 최신 ticketing 스펙에 맞게 정리하고, 경기 일정 응답의 팀 정보 누락 시 팀 상세 조회와 캐싱을 통해 팀명/팀 코드 매핑이 안정적으로 동작하도록 수정했습니다. 추가로 좌석 등급/구역 조회 경로를 최신 공개 API 기준으로 반영하고, 팀 상세 화면의 일정 조회도 공통 경기 일정 모델을 사용하도록 맞췄습니다.

  <br/>

  ## 📋 작업 내용
 - `GET /api/v1/games/schedules` 응답에서 팀명 또는 팀 코드가 비어 있는 경우를 대비해 팀 상세 조회 로직을 추가했습니다.
- 팀 상세 조회 결과를 메모리 캐시와 요청 캐시로 관리해 중복 요청을 줄이고, 경기 일정 정규화 로직에서 팀명/팀 코드/구장명을 안정적으로 보완하도록 수정했습니다.
- `teams` 메타데이터에 `serverTeamId`, `teamCode`를 반영해 프론트 팀 정보와 서버 팀 정보를 일관되게 매핑하도록 정리했습니다.
- 예매 페이지 좌석 등급 조회 API를 최신 스펙인 `/api/v1/stadium-seats/stadiums/{stadiumId}/games/{gameId}/seat-grades`기준으로 변경했습니다.
- 좌석 구역 조회 API도 `/api/v1/stadium-seats/stadiums/{stadiumId}/seat-sections` 경로로 맞췄습니다.
- 팀 상세 화면의 경기 일정 탭이 기존 전용 훅 대신 공통`useGameSchedules` 및 일정 매핑 로직을 사용하도록 변경했습니다.
- 최신 스펙상 좌석 등급 조회에 `gameId`가 필요한 점을 반영해,팀 상세 탭에서는 실데이터 좌석 등급 조회를 보류하도록 처리했습니다.
- MSW mock handler도 실제 스펙에 맞춰 팀 ID, 팀 상세 조회, 좌석 등급/구역 경로를 함께 수정했습니다.

  <br/>