### PR TITLE
[bug] 인증 응답 html 파싱 실패 및 새로고침 시 로그인 유지 버그 수정

### DIFF
--- a/src/app/providers/router/ui/AuthSessionController.tsx
+++ b/src/app/providers/router/ui/AuthSessionController.tsx
@@ -1,11 +1,22 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useAuthStore } from '@/entities/auth/model/authStore';
+import { reissueAccessToken } from '@/features/auth/api/authApi';
+
+const shouldKeepSessionAlivePath = (pathname: string) =>
+   pathname.startsWith('/books') || pathname.startsWith('/tickets');
 
 const AuthSessionController = () => {
+   const { pathname } = useLocation();
+   const isReissuingRef = useRef(false);
+   const accessToken = useAuthStore(state => state.accessToken);
    const authExpiresAt = useAuthStore(state => state.authExpiresAt);
+   const sessionRemainingSeconds = useAuthStore(state => state.sessionRemainingSeconds);
    const startAuthSessionTimer = useAuthStore(state => state.startAuthSessionTimer);
    const stopAuthSessionTimer = useAuthStore(state => state.stopAuthSessionTimer);
    const syncAuthSession = useAuthStore(state => state.syncAuthSession);
+   const setAccessToken = useAuthStore(state => state.setAccessToken);
+   const clearAuth = useAuthStore(state => state.clearAuth);
 
    useEffect(() => {
       syncAuthSession();
@@ -23,6 +34,50 @@ const AuthSessionController = () => {
          stopAuthSessionTimer();
       };
    }, [authExpiresAt, startAuthSessionTimer, stopAuthSessionTimer]);
+
+   useEffect(() => {
+      if (!accessToken) {
+         return;
+      }
+
+      if (!shouldKeepSessionAlivePath(pathname)) {
+         return;
+      }
+
+      if (sessionRemainingSeconds <= 0 || sessionRemainingSeconds > 60) {
+         return;
+      }
+
+      if (isReissuingRef.current) {
+         return;
+      }
+
+      let cancelled = false;
+      isReissuingRef.current = true;
+
+      reissueAccessToken()
+         .then((response) => {
+            if (cancelled) {
+               return;
+            }
+
+            setAccessToken(response.accessToken);
+         })
+         .catch(() => {
+            if (cancelled) {
+               return;
+            }
+
+            clearAuth('expired');
+         })
+         .finally(() => {
+            isReissuingRef.current = false;
+         });
+
+      return () => {
+         cancelled = true;
+      };
+   }, [accessToken, clearAuth, pathname, sessionRemainingSeconds, setAccessToken]);
 
    return null;
 };

--- a/src/app/providers/router/ui/AuthSessionController.tsx
+++ b/src/app/providers/router/ui/AuthSessionController.tsx
@@ -9,6 +9,8 @@ const shouldKeepSessionAlivePath = (pathname: string) =>
 const AuthSessionController = () => {
    const { pathname } = useLocation();
    const isReissuingRef = useRef(false);
+   const hasHydrated = useAuthStore(state => state.hasHydrated);
+   const hasResolvedSession = useAuthStore(state => state.hasResolvedSession);
    const accessToken = useAuthStore(state => state.accessToken);
    const authExpiresAt = useAuthStore(state => state.authExpiresAt);
    const sessionRemainingSeconds = useAuthStore(state => state.sessionRemainingSeconds);
@@ -16,13 +18,66 @@ const AuthSessionController = () => {
    const stopAuthSessionTimer = useAuthStore(state => state.stopAuthSessionTimer);
    const syncAuthSession = useAuthStore(state => state.syncAuthSession);
    const setAccessToken = useAuthStore(state => state.setAccessToken);
+   const setHasResolvedSession = useAuthStore(state => state.setHasResolvedSession);
    const clearAuth = useAuthStore(state => state.clearAuth);
 
    useEffect(() => {
-      syncAuthSession();
-   }, [syncAuthSession]);
+      if (!hasHydrated) {
+         return;
+      }
+
+      if (hasResolvedSession) {
+         return;
+      }
+
+      if (accessToken) {
+         setHasResolvedSession(true);
+         return;
+      }
+
+      let cancelled = false;
+
+      reissueAccessToken()
+         .then((response) => {
+            if (cancelled) {
+               return;
+            }
+
+            setAccessToken(response.accessToken);
+         })
+         .catch(() => {
+            if (cancelled) {
+               return;
+            }
+
+            clearAuth('manual');
+         })
+         .finally(() => {
+            if (cancelled) {
+               return;
+            }
+
+            setHasResolvedSession(true);
+         });
+
+      return () => {
+         cancelled = true;
+      };
+   }, [accessToken, clearAuth, hasHydrated, hasResolvedSession, setAccessToken, setHasResolvedSession]);
 
    useEffect(() => {
+      if (!hasHydrated || !hasResolvedSession) {
+         return;
+      }
+
+      syncAuthSession();
+   }, [hasHydrated, hasResolvedSession, syncAuthSession]);
+
+   useEffect(() => {
+      if (!hasHydrated || !hasResolvedSession) {
+         return;
+      }
+
       if (authExpiresAt === null) {
          stopAuthSessionTimer();
          return;
@@ -33,9 +88,13 @@ const AuthSessionController = () => {
       return () => {
          stopAuthSessionTimer();
       };
-   }, [authExpiresAt, startAuthSessionTimer, stopAuthSessionTimer]);
+   }, [authExpiresAt, hasHydrated, hasResolvedSession, startAuthSessionTimer, stopAuthSessionTimer]);
 
    useEffect(() => {
+      if (!hasHydrated || !hasResolvedSession) {
+         return;
+      }
+
       if (!accessToken) {
          return;
       }
@@ -77,7 +136,7 @@ const AuthSessionController = () => {
       return () => {
          cancelled = true;
       };
-   }, [accessToken, clearAuth, pathname, sessionRemainingSeconds, setAccessToken]);
+   }, [accessToken, clearAuth, hasHydrated, hasResolvedSession, pathname, sessionRemainingSeconds, setAccessToken]);
 
    return null;
 };

--- a/src/entities/auth/model/authStore.ts
+++ b/src/entities/auth/model/authStore.ts
@@ -12,6 +12,7 @@ export type SocialProvider = "kakao" | "naver" | "google";
 export type LogoutReason = "manual" | "expired";
 
 const AUTH_SESSION_DURATION_MS = 60 * 60 * 1000;
+const AUTH_STORAGE_KEY = "auth-store";
 
 const getRemainingSeconds = (authExpiresAt: number | null) => {
   if (!authExpiresAt) {
@@ -22,6 +23,8 @@ const getRemainingSeconds = (authExpiresAt: number | null) => {
 };
 
 export type AuthState = {
+  hasHydrated: boolean;
+  hasResolvedSession: boolean;
   accessToken: string | null;
   authExpiresAt: number | null;
   sessionRemainingSeconds: number;
@@ -32,6 +35,8 @@ export type AuthState = {
   loginPopupTimerId: number | null;
   loginTimedOut: boolean;
   loginAlert: LoginAlert | null;
+  setHasHydrated: (hasHydrated: boolean) => void;
+  setHasResolvedSession: (hasResolvedSession: boolean) => void;
   // 인증 단계 응답 처리 시 setAuthTokens 사용(일관된 일괄 업데이트).
   // 토큰 갱신 등 일부 값만 바꿀 때는 setAccessToken 사용.
   setAccessToken: (accessToken: string | null) => void;
@@ -55,6 +60,8 @@ export type AuthState = {
 export const useAuthStore = create<AuthState>()(
   persist(
     (set, get) => ({
+      hasHydrated: false,
+      hasResolvedSession: false,
       accessToken: null,
       authExpiresAt: null,
       sessionRemainingSeconds: 0,
@@ -65,6 +72,8 @@ export const useAuthStore = create<AuthState>()(
       loginPopupTimerId: null,
       loginTimedOut: false,
       loginAlert: null,
+      setHasHydrated: (hasHydrated) => set({ hasHydrated }),
+      setHasResolvedSession: (hasResolvedSession) => set({ hasResolvedSession }),
       setAccessToken: (accessToken) => {
         const previousState = get();
         const nextAuthExpiresAt =
@@ -80,6 +89,7 @@ export const useAuthStore = create<AuthState>()(
           accessToken,
           authExpiresAt: nextAuthExpiresAt,
           sessionRemainingSeconds: getRemainingSeconds(nextAuthExpiresAt),
+          hasResolvedSession: true,
           logoutReason: null,
         });
       },
@@ -102,6 +112,7 @@ export const useAuthStore = create<AuthState>()(
           authExpiresAt: nextAuthExpiresAt,
           sessionRemainingSeconds: getRemainingSeconds(nextAuthExpiresAt),
           socialVerifyToken,
+          hasResolvedSession: true,
           logoutReason: null,
         });
       },
@@ -117,6 +128,7 @@ export const useAuthStore = create<AuthState>()(
           authExpiresAt: null,
           sessionRemainingSeconds: 0,
           socialVerifyToken: null,
+          hasResolvedSession: true,
           logoutReason: reason,
           sessionTimerId: null,
         });
@@ -199,23 +211,36 @@ export const useAuthStore = create<AuthState>()(
     {
       name: "auth-store",
       storage: createJSONStorage(() => localStorage),
+      version: 2,
       onRehydrateStorage: () => (state) => {
-        if (!state?.accessToken || !state.authExpiresAt) {
-          state?.stopAuthSessionTimer();
-          return;
-        }
+        state?.setHasHydrated(true);
+        state?.setHasResolvedSession(false);
+        const recentLoginProvider = state?.recentLoginProvider ?? null;
 
-        if (state.authExpiresAt <= Date.now()) {
-          state.clearAuth("expired");
-          return;
-        }
+        state?.stopAuthSessionTimer();
 
-        state.syncAuthSession();
-        state.startAuthSessionTimer();
+        if (typeof window !== "undefined") {
+          window.localStorage.setItem(
+            AUTH_STORAGE_KEY,
+            JSON.stringify({
+              state: {
+                recentLoginProvider,
+              },
+              version: 2,
+            }),
+          );
+        }
+      },
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<AuthState> | undefined;
+
+        return {
+          ...currentState,
+          recentLoginProvider:
+            persisted?.recentLoginProvider ?? currentState.recentLoginProvider,
+        };
       },
       partialize: (state) => ({
-        accessToken: state.accessToken,
-        authExpiresAt: state.authExpiresAt,
         recentLoginProvider: state.recentLoginProvider,
       }),
     },

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -31,12 +31,19 @@ export type SendSignupSmsParams = {
   mobile: string;
 };
 
+export type ReissueAccessTokenResponse = {
+  accessToken: string;
+};
+
 export const loginWithSocialVerifyToken = async (payload: {
   socialVerifyToken: string;
 }): Promise<AuthTokenResponse> => {
   const response = await apiClient.post<ApiEnvelope<AuthTokenResponse>>(
     "/api/v1/auth/login",
     payload,
+    {
+      withCredentials: true,
+    },
   );
 
   return unwrapApiData<AuthTokenResponse>(response.data);
@@ -48,6 +55,9 @@ export const signupWithSocialVerifyToken = async (
   const response = await apiClient.post<ApiEnvelope<AuthTokenResponse>>(
     "/api/v1/auth/signup",
     payload,
+    {
+      withCredentials: true,
+    },
   );
 
   const data = unwrapApiData<AuthTokenResponse>(response.data);
@@ -68,4 +78,16 @@ export const sendSignupSmsCode = async (
   );
 
   return unwrapApiData<unknown>(response.data);
+};
+
+export const reissueAccessToken = async (): Promise<ReissueAccessTokenResponse> => {
+  const response = await apiClient.post<ApiEnvelope<ReissueAccessTokenResponse>>(
+    "/api/v1/auth/reissue",
+    undefined,
+    {
+      withCredentials: true,
+    },
+  );
+
+  return unwrapApiData<ReissueAccessTokenResponse>(response.data);
 };

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -1,4 +1,4 @@
-import apiClient from "@/shared/api/client";
+import apiClient, { unwrapApiData } from "@/shared/api/client";
 import type { ApiEnvelope } from "./types";
 
 // 로그인 성공 후 서버에서 반환하는 계정 상태
@@ -15,7 +15,7 @@ export type AuthTokenResponse = {
   failCount?: number; // failed_under_5 / failed_over_5 일 때 실패 횟수
 };
 
-export type SignupGender = "MALE" | "FEMALE";
+export type SignupGender = "MALE" | "FEMALE" | "UNKNOWN";
 
 export type SocialSignupParams = {
   socialVerifyToken: string;
@@ -39,33 +39,33 @@ export const loginWithSocialVerifyToken = async (payload: {
     payload,
   );
 
-  return response.data.data;
+  return unwrapApiData<AuthTokenResponse>(response.data);
 };
 
 export const signupWithSocialVerifyToken = async (
   payload: SocialSignupParams,
 ): Promise<AuthTokenResponse> => {
-  // 회원가입 상세 스펙은 doc/auth-api.md에 아직 비어 있으므로,
-  // 현재 서버와 맞춰진 프론트 payload를 유지하되 응답 형식은 엄격히 검증한다.
   const response = await apiClient.post<ApiEnvelope<AuthTokenResponse>>(
     "/api/v1/auth/signup",
     payload,
   );
 
-  if (!response.data.data?.accessToken) {
-    throw new Error("회원가입 응답에 accessToken이 없습니다. auth signup 스펙 확인이 필요합니다.");
+  const data = unwrapApiData<AuthTokenResponse>(response.data);
+
+  if (!data?.accessToken) {
+    throw new Error("회원가입 응답에 accessToken이 없습니다.");
   }
 
-  return response.data.data;
+  return data;
 };
 
 export const sendSignupSmsCode = async (
   payload: SendSignupSmsParams,
-): Promise<string> => {
-  const response = await apiClient.post<ApiEnvelope<string>>(
+): Promise<unknown> => {
+  const response = await apiClient.post<ApiEnvelope<unknown>>(
     "/api/v1/auth/signup/sms/send",
     payload,
   );
 
-  return response.data.data;
+  return unwrapApiData<unknown>(response.data);
 };

--- a/src/features/auth/api/oauthApi.ts
+++ b/src/features/auth/api/oauthApi.ts
@@ -1,4 +1,4 @@
-import apiClient from "@/shared/api/client";
+import apiClient, { unwrapApiData } from "@/shared/api/client";
 import {
   GOOGLE_REDIRECT_URI,
   KAKAO_REDIRECT_URI,
@@ -68,8 +68,7 @@ export const issueSocialState = async (
     `/api/v1/auth/${providerToPath(provider)}/state`,
   );
 
-  const payload =
-    "data" in response.data ? response.data.data : response.data;
+  const payload = unwrapApiData<SocialStateResponse>(response.data);
 
   if (!payload?.state) {
     throw new Error("Invalid social state response.");
@@ -100,8 +99,7 @@ export const submitAuthCode = async ({
     requestBody,
   );
 
-  const payload =
-    "data" in response.data ? response.data.data : response.data;
+  const payload = unwrapApiData<SubmitAuthCodeResponse>(response.data);
 
   if (!payload?.socialVerifyToken) {
     throw new Error("Invalid social verify response.");

--- a/src/pages/auth/verification-flow/ui/VerificationFlowPage.tsx
+++ b/src/pages/auth/verification-flow/ui/VerificationFlowPage.tsx
@@ -13,6 +13,7 @@ import {
 
 const VerificationFlowPage = () => {
    const navigate = useNavigate();
+   const hasResolvedSession = useAuthStore(state => state.hasResolvedSession);
    const accessToken = useAuthStore(state => state.accessToken);
    const socialVerifyToken = useAuthStore(state => state.socialVerifyToken);
    const agreements = verificationTermsAgreements;
@@ -72,6 +73,10 @@ const VerificationFlowPage = () => {
    };
 
    useEffect(() => {
+      if (!hasResolvedSession) {
+         return;
+      }
+
       if (accessToken) {
          navigate('/', { replace: true });
          return;
@@ -80,7 +85,7 @@ const VerificationFlowPage = () => {
       if (!socialVerifyToken) {
          navigate('/auth/login', { replace: true });
       }
-   }, [accessToken, navigate, socialVerifyToken]);
+   }, [accessToken, hasResolvedSession, navigate, socialVerifyToken]);
 
    return (
       <div className="bg-white text-(--color-foreground) flex flex-col justify-center items-center min-h-screen">

--- a/src/pages/signup/ui/SignUpPage.tsx
+++ b/src/pages/signup/ui/SignUpPage.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useSendSignupSmsCode, useSocialSignup } from '@/features/auth/model/useSubmitAuthCode';
 import { useAuthStore } from '@/entities/auth/model/authStore';
+import type { SignupGender } from '@/features/auth/api/authApi';
 import type { TermSignUpCode } from '@/entities/terms/model/types';
 import {
    getFieldErrorsFromZod,
@@ -194,12 +195,12 @@ const SignUpPage = () => {
       return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
    };
 
-   const mapGender = (value: string) => {
+   const mapGender = (value: string): SignupGender => {
       switch (value) {
          case 'male':
-            return 'MALE' as const;
+            return 'MALE';
          case 'female':
-            return 'FEMALE' as const;
+            return 'FEMALE';
          default:
             throw new Error('성별 값이 올바르지 않습니다.');
       }

--- a/src/pages/signup/ui/SignUpPage.tsx
+++ b/src/pages/signup/ui/SignUpPage.tsx
@@ -34,6 +34,7 @@ const SignUpPage = () => {
    const navigate = useNavigate();
    const socialSignupMutation = useSocialSignup();
    const sendSignupSmsCodeMutation = useSendSignupSmsCode();
+   const hasResolvedSession = useAuthStore(state => state.hasResolvedSession);
    const accessToken = useAuthStore(state => state.accessToken);
    const socialVerifyToken = useAuthStore(state => state.socialVerifyToken);
    const setAuthTokens = useAuthStore(state => state.setAuthTokens);
@@ -175,6 +176,10 @@ const SignUpPage = () => {
    }, [areRequiredTermsChecked, values.birthDate, values.name, values.nationality, values.phone, values.telecom]);
 
    useEffect(() => {
+      if (!hasResolvedSession) {
+         return;
+      }
+
       if (accessToken) {
          navigate('/', { replace: true });
          return;
@@ -183,7 +188,7 @@ const SignUpPage = () => {
       if (!socialVerifyToken) {
          navigate('/auth/login', { replace: true });
       }
-   }, [accessToken, navigate, socialVerifyToken]);
+   }, [accessToken, hasResolvedSession, navigate, socialVerifyToken]);
 
    useEffect(() => {
       if (!showAlert) return;

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosError, AxiosHeaders, type AxiosRequestConfig, type AxiosResponse } from "axios";
 import { useAuthStore } from "@/entities/auth/model/authStore";
-import { isMswEnabled } from "@/shared/config/runtime";
 
 export class ApiError extends Error {
    status?: number;
@@ -15,7 +14,31 @@ export class ApiError extends Error {
 }
 
 const configuredApiBaseUrl = (import.meta.env.PUBLIC_API_BASE_URL ?? "").trim();
-const shouldUseRelativeApiBase = isMswEnabled || import.meta.env.DEV;
+// dev 환경에서는 Rsbuild proxy가 /api 요청을 백엔드로 전달한다.
+// preview/build 환경에서는 정적 서버가 /api를 처리하지 않으므로 절대 base URL을 사용한다.
+const shouldUseRelativeApiBase = import.meta.env.DEV;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isHtmlDocument = (value: unknown): value is string =>
+  typeof value === "string" && /^\s*(<!DOCTYPE html>|<html[\s>])/i.test(value);
+
+export const unwrapApiData = <T>(payload: { data: T } | T): T => {
+  if (isHtmlDocument(payload)) {
+    throw new ApiError(
+      "API expected JSON but received HTML. Check PUBLIC_API_BASE_URL, dev proxy, or MSW configuration.",
+      502,
+      payload,
+    );
+  }
+
+  if (isRecord(payload) && "data" in payload) {
+    return payload.data as T;
+  }
+
+  return payload as T;
+};
 
 const getConsoleTargets = (): Console[] => {
   const targets: Console[] = [console];
@@ -125,6 +148,16 @@ apiClient.interceptors.request.use((config) => {
 
 apiClient.interceptors.response.use(
   (response) => {
+    if (isHtmlDocument(response.data)) {
+      return Promise.reject(
+        new ApiError(
+          "API expected JSON but received HTML. Check PUBLIC_API_BASE_URL, dev proxy, or MSW configuration.",
+          response.status,
+          response.data,
+        ),
+      );
+    }
+
     logResponse(response);
     return response;
   },

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -17,6 +17,12 @@ const configuredApiBaseUrl = (import.meta.env.PUBLIC_API_BASE_URL ?? "").trim();
 // dev 환경에서는 Rsbuild proxy가 /api 요청을 백엔드로 전달한다.
 // preview/build 환경에서는 정적 서버가 /api를 처리하지 않으므로 절대 base URL을 사용한다.
 const shouldUseRelativeApiBase = import.meta.env.DEV;
+const tokenReissuePath = "/api/v1/auth/reissue";
+const shouldKeepSessionAlivePathPrefixes = ["/books", "/tickets"];
+
+type RetriableAxiosRequestConfig = AxiosRequestConfig & {
+  _retry?: boolean;
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -38,6 +44,16 @@ export const unwrapApiData = <T>(payload: { data: T } | T): T => {
   }
 
   return payload as T;
+};
+
+const canAttemptTokenReissue = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return shouldKeepSessionAlivePathPrefixes.some((prefix) =>
+    window.location.pathname.startsWith(prefix),
+  );
 };
 
 const getConsoleTargets = (): Console[] => {
@@ -129,6 +145,44 @@ const apiClient = axios.create({
   },
 });
 
+let refreshAccessTokenPromise: Promise<string> | null = null;
+
+const reissueAccessTokenFromCookie = async () => {
+  if (!refreshAccessTokenPromise) {
+    refreshAccessTokenPromise = axios
+      .post(
+        tokenReissuePath,
+        undefined,
+        {
+          baseURL: shouldUseRelativeApiBase ? "" : configuredApiBaseUrl,
+          headers: {
+            "Content-Type": "application/json",
+          },
+          withCredentials: true,
+        },
+      )
+      .then((response) => {
+        const data = unwrapApiData<{ accessToken: string }>(response.data);
+
+        if (!data.accessToken) {
+          throw new ApiError("토큰 재발급 응답에 accessToken이 없습니다.", response.status, response.data);
+        }
+
+        useAuthStore.getState().setAccessToken(data.accessToken);
+        return data.accessToken;
+      })
+      .catch((error: unknown) => {
+        useAuthStore.getState().clearAuth("expired");
+        throw error;
+      })
+      .finally(() => {
+        refreshAccessTokenPromise = null;
+      });
+  }
+
+  return refreshAccessTokenPromise;
+};
+
 apiClient.interceptors.request.use((config) => {
   const accessToken = useAuthStore.getState().accessToken;
 
@@ -163,6 +217,28 @@ apiClient.interceptors.response.use(
   },
   (error: AxiosError) => {
     logError(error);
+
+    const requestConfig = error.config as RetriableAxiosRequestConfig | undefined;
+    const requestUrl = requestConfig?.url ?? "";
+    const isReissueRequest = requestUrl.includes(tokenReissuePath);
+
+    if (
+      error.response?.status === 401 &&
+      requestConfig &&
+      !requestConfig._retry &&
+      !isReissueRequest &&
+      canAttemptTokenReissue()
+    ) {
+      requestConfig._retry = true;
+
+      return reissueAccessTokenFromCookie().then((accessToken) => {
+        const nextHeaders = AxiosHeaders.from(requestConfig.headers);
+        nextHeaders.set("Authorization", `Bearer ${accessToken}`);
+        requestConfig.headers = nextHeaders;
+
+        return apiClient(requestConfig);
+      });
+    }
 
     if (error.response) {
       const status = error.response.status;

--- a/src/shared/api/mocks/handlers/auth.ts
+++ b/src/shared/api/mocks/handlers/auth.ts
@@ -6,14 +6,23 @@ type MockAuthSession = {
    provider: string;
    isRegistered: boolean;
    userId: string;
+   name?: string;
    mobile?: string;
    smsCode?: string;
    // authCode 패턴으로 로그인 시나리오 결정
    loginScenario?: MockLoginScenario;
 };
 
+type MockRefreshSession = {
+   userId: string;
+   provider: string;
+   name?: string;
+   mobile?: string;
+};
+
 // 팝업 창과 부모 창 간 세션 공유를 위해 localStorage 사용
 const MOCK_AUTH_SESSIONS_KEY = '__mock_auth_sessions__';
+const MOCK_REFRESH_SESSION_KEY = '__mock_refresh_session__';
 
 const mockAuthSessions = {
    get(token: string): MockAuthSession | undefined {
@@ -31,6 +40,31 @@ const mockAuthSessions = {
          const map: Record<string, MockAuthSession> = raw ? JSON.parse(raw) : {};
          map[token] = session;
          localStorage.setItem(MOCK_AUTH_SESSIONS_KEY, JSON.stringify(map));
+      } catch {
+         // ignore
+      }
+   },
+};
+
+const mockRefreshSession = {
+   get(): MockRefreshSession | undefined {
+      try {
+         const raw = localStorage.getItem(MOCK_REFRESH_SESSION_KEY);
+         return raw ? (JSON.parse(raw) as MockRefreshSession) : undefined;
+      } catch {
+         return undefined;
+      }
+   },
+   set(session: MockRefreshSession) {
+      try {
+         localStorage.setItem(MOCK_REFRESH_SESSION_KEY, JSON.stringify(session));
+      } catch {
+         // ignore
+      }
+   },
+   clear() {
+      try {
+         localStorage.removeItem(MOCK_REFRESH_SESSION_KEY);
       } catch {
          // ignore
       }
@@ -138,6 +172,13 @@ export const authHandlers = [
          failed_over_5: 5,
       };
 
+      mockRefreshSession.set({
+         userId: session.userId,
+         provider: session.provider,
+         name: session.name,
+         mobile: session.mobile,
+      });
+
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
@@ -218,6 +259,14 @@ export const authHandlers = [
       mockAuthSessions.set(body.socialVerifyToken, {
          ...session,
          isRegistered: true,
+         name: body.name,
+         mobile: body.mobile,
+      });
+
+      mockRefreshSession.set({
+         userId: session.userId,
+         provider: session.provider,
+         name: body.name,
          mobile: body.mobile,
       });
 
@@ -229,7 +278,29 @@ export const authHandlers = [
                sub: session.userId,
                userId: session.userId,
                mobile: body.mobile,
-               name: body.name,
+            name: body.name,
+            }),
+         },
+      });
+   }),
+
+   http.post('/api/v1/auth/reissue', async () => {
+      const session = mockRefreshSession.get();
+
+      if (!session) {
+         return HttpResponse.json({ message: 'Mock refresh token session is missing.' }, { status: 401 });
+      }
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            accessToken: buildMockAccessToken({
+               sub: session.userId,
+               userId: session.userId,
+               provider: session.provider,
+               ...(session.mobile ? { mobile: session.mobile } : {}),
+               ...(session.name ? { name: session.name } : {}),
             }),
          },
       });

--- a/src/shared/lib/use-booking-entry-flow.tsx
+++ b/src/shared/lib/use-booking-entry-flow.tsx
@@ -48,6 +48,7 @@ type PendingEntry = {
  */
 export function useBookingEntryFlow() {
   const navigate = useNavigate();
+  const hasResolvedSession = useAuthStore(state => state.hasResolvedSession);
   const accessToken = useAuthStore(state => state.accessToken);
   const setBookingEntry = useBookingEntryStore(state => state.setEntry);
   const [isGuideOpen, setIsGuideOpen] = useState(false);
@@ -65,6 +66,10 @@ export function useBookingEntryFlow() {
   };
 
   const openBookingEntry = (options?: OpenBookingEntryOptions) => {
+    if (!hasResolvedSession) {
+      return;
+    }
+
     if (!accessToken) {
       navigate('/auth/login');
       return;
@@ -74,6 +79,10 @@ export function useBookingEntryFlow() {
   };
 
   const openResellEntry = (options?: OpenBookingEntryOptions) => {
+    if (!hasResolvedSession) {
+      return;
+    }
+
     if (!accessToken) {
       navigate('/auth/login');
       return;


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #107
- #151

<br/>

## 🔎 개요
인증 응답이 html으로 왔을 때 파싱에 실패하는 버그 및 새로고침 시 로그인이 유지되지 않는 버그 수정

<br/>

## 📋 작업 내용
- 새로 배포된 백엔드 api에 맞춰 토큰 재발급 기능 추가
- html fallback 방어 로직 추가

<br/>
