### PR TITLE
[bug] 로그아웃 이후에도 새로고침으로 인한 재로그인이 가능한 버그 수정

### DIFF
--- a/src/entities/auth/model/authStore.ts
+++ b/src/entities/auth/model/authStore.ts
@@ -133,7 +133,9 @@ export const useAuthStore = create<AuthState>()(
           sessionRemainingSeconds: 0,
           socialVerifyToken: null,
           hasResolvedSession: true,
-          isManualLogout: reason === "manual",
+          // 수동/자동 로그아웃 모두 새로고침 시 자동 reissue 복원을 막는다.
+          // 다음 정상 로그인(setAccessToken/setAuthTokens) 시 false로 초기화된다.
+          isManualLogout: true,
           logoutReason: reason,
           sessionTimerId: null,
         });

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -197,11 +197,17 @@ const reissueAccessTokenFromCookie = async () => {
           throw new ApiError("토큰 재발급 응답에 accessToken이 없습니다.", response.status, response.data);
         }
 
+        if (useAuthStore.getState().isManualLogout) {
+          throw new ApiError("로그아웃 이후 도착한 토큰 재발급 응답은 무시합니다.", 401, response.data);
+        }
+
         useAuthStore.getState().setAccessToken(data.accessToken);
         return data.accessToken;
       })
       .catch((error: unknown) => {
-        useAuthStore.getState().clearAuth("expired");
+        if (!useAuthStore.getState().isManualLogout) {
+          useAuthStore.getState().clearAuth("expired");
+        }
         throw error;
       })
       .finally(() => {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #163

<br/>

## 🔎 개요
로그아웃 이후에도 새로고침으로 인한 재로그인이 가능한 버그 수정

<br/>

## 📋 작업 내용

- 재로그인 로직 확인
- 자동 로그아웃 시 새로고침 재로그인 로직 제어 변수 재정의 과정 추가
- API 인터셉터에 로직 제어 변수 조건부 추가

<br/>
