### PR TITLE
[bug] 좌석 상태 스냅샷의 무한 view 재렌더링 버그

### DIFF
--- a/src/entities/seat-selection/model/useSeatSelectionStore.ts
+++ b/src/entities/seat-selection/model/useSeatSelectionStore.ts
@@ -29,6 +29,21 @@ const createZoneState = (seats: SeatSelectionItem[]): ZoneSeatState => ({
 
 const isSelectableStatus = (status: SeatSelectionStatus) => status === 'available' || status === 'selected';
 
+const hasSameSeatOrder = (previousSeatOrder: string[], nextSeatOrder: string[]) =>
+   previousSeatOrder.length === nextSeatOrder.length &&
+   previousSeatOrder.every((seatId, index) => seatId === nextSeatOrder[index]);
+
+const hasSameSelectedSeatIds = (previousSelectedSeatIds: string[], nextSelectedSeatIds: string[]) =>
+   previousSelectedSeatIds.length === nextSelectedSeatIds.length &&
+   previousSelectedSeatIds.every((seatId, index) => seatId === nextSelectedSeatIds[index]);
+
+const hasSameSeatStatuses = (
+   previousSeatMap: Record<string, SeatSelectionItem>,
+   nextSeatMap: Record<string, SeatSelectionItem>,
+   seatOrder: string[],
+) =>
+   seatOrder.every((seatId) => previousSeatMap[seatId]?.status === nextSeatMap[seatId]?.status);
+
 export const useSeatSelectionStore = create<SeatSelectionStore>((set) => ({
    zones: {},
 
@@ -165,6 +180,15 @@ export const useSeatSelectionStore = create<SeatSelectionStore>((set) => ({
             const seat = nextZone.seatMap[seatId];
             return seat ? isSelectableStatus(seat.status) : false;
          });
+
+         const isSameSnapshot =
+            hasSameSeatOrder(previousZone.seatOrder, nextZone.seatOrder) &&
+            hasSameSeatStatuses(previousZone.seatMap, nextZone.seatMap, nextZone.seatOrder) &&
+            hasSameSelectedSeatIds(previousZone.selectedSeatIds, selectedSeatIds);
+
+         if (isSameSnapshot) {
+            return state;
+         }
 
          return {
             zones: {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #166

<br/>

## 🔎 개요
좌석 상태 스냅샷이 매번 같은 상태임에도 갱신하여 view가 무한 재렌더링 루프에 빠지는 버그 수정

<br/>

## 📋 작업 내용
- 좌석 순서/선택좌석/좌석 상태 비교 함수 추가
- applyServerSeatSnapshot에서 동일 스냅샷이면 return state로 업데이트 스킵

<br/>
