### PR TITLE
[bug] 액세스 토큰 인증 헤더 복구 및 mock 데이터 배포 서버 차단

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const apiTarget = (process.env.PUBLIC_API_BASE_URL ?? 'https://dev.go-ti.shop').trim();
+const isProductionBuild = process.env.NODE_ENV === 'production';
 
 // Docs: https://rsbuild.rs/config/
 export default defineConfig({
@@ -10,6 +11,11 @@ export default defineConfig({
    source: {
       alias: {
          '@': path.resolve(__dirname, 'src'),
+         ...(isProductionBuild
+            ? {
+                 '@/shared/api/mocks/browser': path.resolve(__dirname, 'src/shared/api/mocks/browser.disabled.ts'),
+              }
+            : {}),
       },
    },
    server: {

--- a/src/entities/seat-hold/api/seatHoldApi.ts
+++ b/src/entities/seat-hold/api/seatHoldApi.ts
@@ -17,6 +17,8 @@ export type ReleaseSeatHoldResponse = {
    holdId: string;
 };
 
+export const isMockSeatHoldId = (holdId: string) => holdId.startsWith('mock-hold-');
+
 const getSeatHoldReleaseUrl = (holdId: string) => {
    const path = `/api/v1/seat-reservations/${encodeURIComponent(holdId)}`;
 
@@ -37,6 +39,10 @@ export const holdSeatReservation = async (seatId: string, payload: HoldSeatReque
 };
 
 export const releaseSeatReservation = async (holdId: string) => {
+   if (isMockSeatHoldId(holdId)) {
+      return { holdId };
+   }
+
    const response = await apiClient.post<ApiEnvelope<ReleaseSeatHoldResponse>>(
       `/api/v1/seat-reservations/${encodeURIComponent(holdId)}`,
    );
@@ -45,7 +51,7 @@ export const releaseSeatReservation = async (holdId: string) => {
 };
 
 export const releaseSeatReservationKeepalive = (holdId: string) => {
-   if (typeof window === 'undefined') {
+   if (typeof window === 'undefined' || isMockSeatHoldId(holdId)) {
       return;
    }
 

--- a/src/features/seat-booking/ui/SeatHoldLifecycleController.tsx
+++ b/src/features/seat-booking/ui/SeatHoldLifecycleController.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { releaseSeatReservation, releaseSeatReservationKeepalive } from '@/entities/seat-hold/api/seatHoldApi';
+import { isMockSeatHoldId, releaseSeatReservation, releaseSeatReservationKeepalive } from '@/entities/seat-hold/api/seatHoldApi';
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 
@@ -16,7 +16,9 @@ const releaseAllSeatHolds = async () => {
    }
 
    const releaseResults = await Promise.allSettled(
-      seatHolds.map((seatHold) => releaseSeatReservation(seatHold.holdId)),
+      seatHolds
+         .filter((seatHold) => !isMockSeatHoldId(seatHold.holdId))
+         .map((seatHold) => releaseSeatReservation(seatHold.holdId)),
    );
    const failedReleaseCount = releaseResults.filter((result) => result.status === 'rejected').length;
 
@@ -38,9 +40,11 @@ const releaseAllSeatHoldsKeepalive = () => {
       return;
    }
 
-   seatHolds.forEach((seatHold) => {
+   seatHolds
+      .filter((seatHold) => !isMockSeatHoldId(seatHold.holdId))
+      .forEach((seatHold) => {
       releaseSeatReservationKeepalive(seatHold.holdId);
-   });
+      });
 
    useSeatHoldStore.getState().clearSeatHolds();
    useSeatSelectionStore.getState().clearAllSelections();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,10 @@ const waitForServiceWorkerControl = async () => {
 };
 
 const startMocks = async () => {
-  if (!isMswEnabled) return;
+  if (!import.meta.env.DEV || !isMswEnabled) {
+    return;
+  }
+
   const { worker } = await import('@/shared/api/mocks/browser');
   await worker.start({
     onUnhandledRequest: 'bypass',

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -19,6 +19,7 @@ import ResellSeatSidebar from './components/ResellSeatSidebar';
 import ResellZonePreviewSheet from './components/ResellZonePreviewSheet';
 import SelectedSeatSummaryList from './components/SelectedSeatSummaryList';
 import { useBotDetector } from '@/shared/lib/useBotDetector';
+import { isMswEnabled } from '@/shared/config/runtime';
 
 const MIN_SCALE = 0.8;
 const MAX_SCALE = 2.4;
@@ -74,7 +75,7 @@ function SeatsPage() {
          onSeatHoldConflict: async () => {
             await refetchSeatMap();
          },
-         useMockSeatHold: Boolean(seatMapLoadError),
+         useMockSeatHold: isMswEnabled && Boolean(seatMapLoadError),
       },
    );
 

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -532,6 +532,8 @@ function SeatsPage() {
                      defaultHeight={isResellMode ? 488 : 280}
                      minHeight={isResellMode ? 280 : 152}
                      maxHeight={560}
+                     title={isResellMode ? '리셀 예매 하단 패널' : '선택 좌석 하단 패널'}
+                     description={isResellMode ? '리셀 좌석 정보를 확인하고 예매를 진행할 수 있습니다.' : '선택한 좌석과 결제 금액을 확인할 수 있습니다.'}
                      className="overflow-hidden border-none p-0 xl:hidden"
                   >
                      <div className="h-full overflow-y-auto">

--- a/src/pages/books/ui/components/BookingCaptchaGate.tsx
+++ b/src/pages/books/ui/components/BookingCaptchaGate.tsx
@@ -1,7 +1,7 @@
 import { RefreshCcw, Volume2 } from 'lucide-react';
 
 import { Button } from '@/shared/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 import { Input } from '@/shared/ui/input';
 
 type BookingCaptchaGateProps = {
@@ -35,6 +35,9 @@ function BookingCaptchaGate({
                <DialogTitle align="center" className="text-[18px] font-bold leading-[1.55]">
                   문자 인증 후 예매를 진행할 수 있어요
                </DialogTitle>
+               <DialogDescription className="sr-only" align="center">
+                  화면에 표시된 보안 문자를 입력해 예매를 진행하는 인증 단계입니다.
+               </DialogDescription>
             </DialogHeader>
 
             <div className="px-5 pb-5">

--- a/src/pages/books/ui/components/BookingZoneMobileLayout.tsx
+++ b/src/pages/books/ui/components/BookingZoneMobileLayout.tsx
@@ -66,6 +66,8 @@ function BookingZoneMobileLayout({
                   defaultHeight={360}
                   minHeight={232}
                   maxHeight={488}
+                  title={bookingFlowMode === 'resell' ? '리셀 좌석 구역 목록' : '좌석 등급과 잔여석 목록'}
+                  description={bookingFlowMode === 'resell' ? '리셀 예매 가능한 좌석 구역 목록입니다.' : '예매 가능한 좌석 등급과 잔여석을 확인할 수 있습니다.'}
                   className="overflow-hidden border-none p-0"
                >
                   <div className="h-full overflow-y-auto">

--- a/src/pages/home/ui/game-schedule/BookingCaptchaDialog.tsx
+++ b/src/pages/home/ui/game-schedule/BookingCaptchaDialog.tsx
@@ -1,7 +1,7 @@
 import { RefreshCcw, Volume2 } from 'lucide-react';
 
 import { Button } from '@/shared/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 import { Input } from '@/shared/ui/input';
 
 type BookingCaptchaDialogProps = {
@@ -35,6 +35,9 @@ function BookingCaptchaDialog({
           <DialogTitle align="center" className="text-[18px] font-bold leading-[1.55]">
             문자 인증 후 예매를 진행할 수 있어요
           </DialogTitle>
+          <DialogDescription className="sr-only" align="center">
+            화면에 표시된 보안 문자를 입력해 예매를 진행하는 인증 단계입니다.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="px-5 pb-5">

--- a/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
@@ -10,7 +10,7 @@ import {
    type PaymentResponse,
    type TicketCheckoutRequest,
 } from '@/pages/tickets/api/paymentApi';
-import { releaseSeatReservation, releaseSeatReservationKeepalive } from '@/entities/seat-hold/api/seatHoldApi';
+import { isMockSeatHoldId, releaseSeatReservation, releaseSeatReservationKeepalive } from '@/entities/seat-hold/api/seatHoldApi';
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 import { ApiError } from '@/shared/api/client';
@@ -45,7 +45,9 @@ const releasePendingTicketSeatHolds = async () => {
    }
 
    const releaseResults = await Promise.allSettled(
-      seatHolds.map((seatHold) => releaseSeatReservation(seatHold.holdId)),
+      seatHolds
+         .filter((seatHold) => !isMockSeatHoldId(seatHold.holdId))
+         .map((seatHold) => releaseSeatReservation(seatHold.holdId)),
    );
    const failedReleaseCount = releaseResults.filter((result) => result.status === 'rejected').length;
 
@@ -67,9 +69,11 @@ const releasePendingTicketSeatHoldsKeepalive = () => {
       return;
    }
 
-   seatHolds.forEach((seatHold) => {
+   seatHolds
+      .filter((seatHold) => !isMockSeatHoldId(seatHold.holdId))
+      .forEach((seatHold) => {
       releaseSeatReservationKeepalive(seatHold.holdId);
-   });
+      });
 
    useSeatHoldStore.getState().clearSeatHolds();
    useSeatSelectionStore.getState().clearAllSelections();

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -107,11 +107,6 @@ const shouldSkipAuthorizationHeader = (config: AxiosRequestConfig) => {
       // 일부 배포 게이트웨이에서 Authorization 헤더가 붙으면 인증 리다이렉트 루프가 발생할 수 있어 제외한다.
       case pathname === "/api/v1/games/schedules":
       case /^\/api\/v1\/baseball-teams\/[^/]+$/.test(pathname):
-      // 좌석 등급/구역/좌석 메타 조회도 문서상 공개 조회 API다.
-      // dev 게이트웨이에서 일반 사용자 토큰이 붙으면 RBAC 403이 발생할 수 있어 인증 헤더를 제외한다.
-      case /^\/api\/v1\/stadium-seats\/stadiums\/[^/]+\/seat-sections$/.test(pathname):
-      case /^\/api\/v1\/stadium-seats\/stadiums\/[^/]+\/games\/[^/]+\/seat-grades$/.test(pathname):
-      case /^\/api\/v1\/seats\/seat-sections\/[^/]+\/seats$/.test(pathname):
         return true;
       default:
         return false;

--- a/src/shared/api/mocks/browser.disabled.ts
+++ b/src/shared/api/mocks/browser.disabled.ts
@@ -1,0 +1,3 @@
+export const worker = {
+   start: async () => undefined,
+};

--- a/src/shared/config/runtime.ts
+++ b/src/shared/config/runtime.ts
@@ -1,4 +1,4 @@
 const mswFlag = (import.meta.env.PUBLIC_ENABLE_MSW ?? "").trim().toLowerCase();
 
 // 기본값은 실제 API 호출이다. 데모/목업이 필요할 때만 명시적으로 켠다.
-export const isMswEnabled = mswFlag === "true";
+export const isMswEnabled = import.meta.env.DEV && mswFlag === "true";

--- a/src/shared/ui/booking-guide-dialog.tsx
+++ b/src/shared/ui/booking-guide-dialog.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/shared/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 
 type BookingGuideDialogProps = {
   open: boolean;
@@ -21,6 +21,9 @@ function BookingGuideDialog({ open, onOpenChange, onConfirm }: BookingGuideDialo
           <DialogTitle align="center" className="text-[18px] font-bold leading-[1.55]">
             예매안내
           </DialogTitle>
+          <DialogDescription className="sr-only" align="center">
+            예매 진행 전에 확인해야 할 주요 유의사항을 안내하는 대화상자입니다.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="px-5 pb-5">

--- a/src/shared/ui/drawer.tsx
+++ b/src/shared/ui/drawer.tsx
@@ -86,6 +86,8 @@ function DrawerContent({
    defaultHeight = 320,
    minHeight = 180,
    maxHeight = 560,
+   title = '하단 시트',
+   description = '추가 옵션을 확인하고 선택할 수 있는 하단 시트입니다.',
    ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
    showOverlay?: boolean;
@@ -95,6 +97,8 @@ function DrawerContent({
    defaultHeight?: number;
    minHeight?: number;
    maxHeight?: number;
+   title?: string;
+   description?: string;
 }) {
    const { open, setOpen } = useDrawerContext();
    const touchStartYRef = React.useRef<number | null>(null);
@@ -181,6 +185,8 @@ function DrawerContent({
             }}
             {...props}
          >
+            <DialogPrimitive.Title className="sr-only">{title}</DialogPrimitive.Title>
+            <DialogPrimitive.Description className="sr-only">{description}</DialogPrimitive.Description>
             {showHandle ? (
                <div
                   className={cn('flex justify-center pt-[10px]', resizable ? 'touch-none cursor-row-resize' : '')}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #115

<br/>

## 🔎 개요
액세스 토큰 인증 헤더 복구 및 api 통신 오류시 mock 데이터로 정상 작동하는 동작 삭제

<br/>

## 📋 작업 내용
- 좌석 조회 인증 헤더 복구
- api 통신 오류 시 mock 데이터 기반 통신 시도 삭제

<br/>
