### PR TITLE
[bug] 좌석이 남아있음에도 선택가능한 좌석이 렌더링 안 되는 버그

### DIFF
--- a/src/entities/game/api/scheduleApi.ts
+++ b/src/entities/game/api/scheduleApi.ts
@@ -16,6 +16,7 @@ export type GameScheduleResponse = {
   homeTeamId: string;
   awayTeamId: string;
   stadiumId: string;
+  queueTokenJti?: string;
   gameStatus: string;
   homeTeamScore: number;
   awayTeamScore: number;

--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -358,7 +358,7 @@ const normalizeScheduleGame = (game: GameScheduleResponse): NormalizedScheduleGa
     time,
     venue: resolveVenueNameFromGame(game, homeTeam?.shortName ?? fallbackHomeName),
     stadiumId: game.stadiumId,
-    queueTokenJti: buildMockQueueTokenJti(game.gameId),
+    queueTokenJti: game.queueTokenJti ?? buildMockQueueTokenJti(game.gameId),
     score: status === '종료' ? `${game.awayTeamScore}:${game.homeTeamScore}` : null,
     status,
     ticket,

--- a/src/pages/books/model/useSeatHoldActions.ts
+++ b/src/pages/books/model/useSeatHoldActions.ts
@@ -122,6 +122,12 @@ export const useSeatHoldActions = (
       }
 
       if (!bookingEntryState?.gameId || !bookingEntryState.queueTokenJti) {
+         console.warn('[SeatMapDebug] hold blocked: missing booking token', {
+            zoneId,
+            seatId: seat.id,
+            hasGameId: Boolean(bookingEntryState?.gameId),
+            hasQueueTokenJti: Boolean(bookingEntryState?.queueTokenJti),
+         });
          window.alert('예매 정보가 없어 좌석 점유를 진행할 수 없습니다.');
          return;
       }
@@ -161,6 +167,16 @@ export const useSeatHoldActions = (
          applyServerSeatPatch(zoneId, seat.id, 'selected');
          toggleSelectedSeat(zoneId, seat.id);
       } catch (error) {
+         if (error instanceof ApiError && error.status === 404) {
+            console.error('[useSeatHoldActions] 좌석 점유 404', {
+               zoneId,
+               seatId: seat.id,
+               gameId: bookingEntryState.gameId,
+               queueTokenJti: bookingEntryState.queueTokenJti,
+               errorData: error.data,
+            });
+         }
+
          if (isSeatAlreadyHeldConflict(error)) {
             window.alert('해당 좌석은 이미 선점된 좌석입니다.');
             await options?.onSeatHoldConflict?.();

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -119,6 +119,29 @@ const createSeatItemsForLayout = (block: SeatBlock, zoneId: string, section: Api
    });
 };
 
+const summarizeSeatStatuses = (statuses: SeatStatusResponse[]) => {
+   return statuses.reduce<Record<string, number>>((summary, seatStatus) => {
+      const key = seatStatus.status?.toUpperCase?.() ?? 'UNKNOWN';
+      summary[key] = (summary[key] ?? 0) + 1;
+      return summary;
+   }, {});
+};
+
+const summarizeSeatItemStatuses = (seats: SeatItem[]) => {
+   return seats.reduce<Record<SeatItem['status'], number>>(
+      (summary, seat) => {
+         summary[seat.status] += 1;
+         return summary;
+      },
+      {
+         available: 0,
+         selected: 0,
+         held: 0,
+         disabled: 0,
+      },
+   );
+};
+
 const buildAggregatedSeatMapSnapshot = ({
    defaultBlocks,
    sections,
@@ -195,6 +218,16 @@ const fetchAggregatedSeatSections = async ({
             fetchSeatStatuses(gameId, section.sectionId),
          ]);
 
+         console.info('[SeatMapDebug] aggregated section payload', {
+            zoneId: zone.id,
+            zoneSectionCode: zone.sectionCode,
+            sectionId: section.sectionId,
+            sectionCode: section.sectionCode,
+            seatsCount: seats.length,
+            statusesCount: statuses.length,
+            statusSummary: summarizeSeatStatuses(statuses),
+         });
+
          return {
             sectionId: section.sectionId,
             sectionCode: section.sectionCode,
@@ -226,18 +259,29 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
                return null;
             }
 
+            const seatItems = createSeatItemsForLayout(
+               seatBlock,
+               zone.id,
+               {
+                  sectionId: zone.id,
+                  sectionCode: zone.sectionCode,
+                  seats,
+                  statuses,
+               },
+            );
+
+            console.info('[SeatMapDebug] single section payload', {
+               zoneId: zone.id,
+               zoneSectionCode: zone.sectionCode,
+               seatsCount: seats.length,
+               statusesCount: statuses.length,
+               statusSummary: summarizeSeatStatuses(statuses),
+               mappedStatusSummary: summarizeSeatItemStatuses(seatItems),
+            });
+
             return {
                seatBlocks: [seatBlock],
-               seatItems: createSeatItemsForLayout(
-                  seatBlock,
-                  zone.id,
-                  {
-                     sectionId: zone.id,
-                     sectionCode: zone.sectionCode,
-                     seats,
-                     statuses,
-                  },
-               ),
+               seatItems,
             };
          }
 
@@ -255,11 +299,21 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
             return null;
          }
 
-         return buildAggregatedSeatMapSnapshot({
+         const snapshot = buildAggregatedSeatMapSnapshot({
             defaultBlocks: defaultSeatBlocks,
             sections: sectionBundles,
             zoneId: zone.id,
          });
+
+         console.info('[SeatMapDebug] aggregated snapshot', {
+            zoneId: zone.id,
+            zoneSectionCode: zone.sectionCode,
+            seatBlockCount: snapshot.seatBlocks.length,
+            seatItemCount: snapshot.seatItems.length,
+            mappedStatusSummary: summarizeSeatItemStatuses(snapshot.seatItems),
+         });
+
+         return snapshot;
       },
    });
 

--- a/src/shared/types/game.ts
+++ b/src/shared/types/game.ts
@@ -28,6 +28,7 @@ export interface GameScheduleResponse {
    homeTeamId: string;
    awayTeamId: string;
    stadiumId: string;
+   queueTokenJti?: string;
    gameStatus: ApiGameStatus;
    homeTeamScore: number;
    awayTeamScore: number;


### PR DESCRIPTION
## #️⃣ 관련 이슈

  - #177

  <br/>

  ## 🔎 개요
  좌석 점유 API 404 이슈를 추적하고, 예매 진입 시 실서버 `queueTokenJti`가 유지되도록 수정. 좌석 맵 상태/좌석 점유 실패 원인을 빠르게 확인할 수 있도록 디버그 로그를 보강함

  <br/>

  ## 📋 작업 내용

  - 일정 정규화 과정에서 실서버 응답의 `queueTokenJti`를 목업 값으로 덮어쓰지 않도록 수정
  - `GameScheduleResponse` 타입에 `queueTokenJti` 필드를 반영해 일정 응답 타입과 실제 사용 흐름을 일치시킴
  - 좌석 점유 요청 전 `gameId`, `queueTokenJti` 누락 시 콘솔 경고 로그를 추가
  - 좌석 점유 API가 404로 실패할 때 `zoneId`, `seatId`, `gameId`, `queueTokenJti`, 서버 응답 본문을 함께 출력하도록 로그 보강
  - 단일 구역/집계 구역 좌석 맵 로딩 시 좌석 수, 상태 수, 상태 요약값을 확인할 수 있도록 디버그 로그 추가