### PR TITLE
[bug] feature/ticket-book-api bug 발생 시점 이전 작업분으로 롤백

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const apiTarget = (process.env.PUBLIC_API_BASE_URL ?? 'https://dev.go-ti.shop').trim();
-const isProductionBuild = process.env.NODE_ENV === 'production';
 
 // Docs: https://rsbuild.rs/config/
 export default defineConfig({
@@ -11,11 +10,6 @@ export default defineConfig({
    source: {
       alias: {
          '@': path.resolve(__dirname, 'src'),
-         ...(isProductionBuild
-            ? {
-                 '@/shared/api/mocks/browser': path.resolve(__dirname, 'src/shared/api/mocks/browser.disabled.ts'),
-              }
-            : {}),
       },
    },
    server: {

--- a/src/entities/game/api/scheduleApi.ts
+++ b/src/entities/game/api/scheduleApi.ts
@@ -16,7 +16,6 @@ export type GameScheduleResponse = {
   homeTeamId: string;
   awayTeamId: string;
   stadiumId: string;
-  queueTokenJti?: string;
   gameStatus: string;
   homeTeamScore: number;
   awayTeamScore: number;

--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -358,7 +358,7 @@ const normalizeScheduleGame = (game: GameScheduleResponse): NormalizedScheduleGa
     time,
     venue: resolveVenueNameFromGame(game, homeTeam?.shortName ?? fallbackHomeName),
     stadiumId: game.stadiumId,
-    queueTokenJti: game.queueTokenJti ?? buildMockQueueTokenJti(game.gameId),
+    queueTokenJti: buildMockQueueTokenJti(game.gameId),
     score: status === '종료' ? `${game.awayTeamScore}:${game.homeTeamScore}` : null,
     status,
     ticket,

--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -275,9 +275,8 @@ const mapTicketStatus = (value: string): TicketStatus => {
     case 'AVAILABLE':
     case 'OPEN':
       return '예매하기';
-    case 'EXHAUSTED':
     case 'SOLD_OUT':
-    case 'TERMINATED':
+    case 'CLOSED':
     case 'ENDED':
     case 'EXHAUSTED':
     case 'TERMINATED':

--- a/src/entities/seat-hold/api/seatHoldApi.ts
+++ b/src/entities/seat-hold/api/seatHoldApi.ts
@@ -17,8 +17,6 @@ export type ReleaseSeatHoldResponse = {
    holdId: string;
 };
 
-export const isMockSeatHoldId = (holdId: string) => holdId.startsWith('mock-hold-');
-
 const getSeatHoldReleaseUrl = (holdId: string) => {
    const path = `/api/v1/seat-reservations/${encodeURIComponent(holdId)}`;
 
@@ -39,10 +37,6 @@ export const holdSeatReservation = async (seatId: string, payload: HoldSeatReque
 };
 
 export const releaseSeatReservation = async (holdId: string) => {
-   if (isMockSeatHoldId(holdId)) {
-      return { holdId };
-   }
-
    const response = await apiClient.post<ApiEnvelope<ReleaseSeatHoldResponse>>(
       `/api/v1/seat-reservations/${encodeURIComponent(holdId)}`,
    );
@@ -51,7 +45,7 @@ export const releaseSeatReservation = async (holdId: string) => {
 };
 
 export const releaseSeatReservationKeepalive = (holdId: string) => {
-   if (typeof window === 'undefined' || isMockSeatHoldId(holdId)) {
+   if (typeof window === 'undefined') {
       return;
    }
 

--- a/src/features/seat-booking/ui/SeatHoldLifecycleController.tsx
+++ b/src/features/seat-booking/ui/SeatHoldLifecycleController.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { isMockSeatHoldId, releaseSeatReservation, releaseSeatReservationKeepalive } from '@/entities/seat-hold/api/seatHoldApi';
+import { releaseSeatReservation, releaseSeatReservationKeepalive } from '@/entities/seat-hold/api/seatHoldApi';
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 
@@ -16,9 +16,7 @@ const releaseAllSeatHolds = async () => {
    }
 
    const releaseResults = await Promise.allSettled(
-      seatHolds
-         .filter((seatHold) => !isMockSeatHoldId(seatHold.holdId))
-         .map((seatHold) => releaseSeatReservation(seatHold.holdId)),
+      seatHolds.map((seatHold) => releaseSeatReservation(seatHold.holdId)),
    );
    const failedReleaseCount = releaseResults.filter((result) => result.status === 'rejected').length;
 
@@ -40,11 +38,9 @@ const releaseAllSeatHoldsKeepalive = () => {
       return;
    }
 
-   seatHolds
-      .filter((seatHold) => !isMockSeatHoldId(seatHold.holdId))
-      .forEach((seatHold) => {
+   seatHolds.forEach((seatHold) => {
       releaseSeatReservationKeepalive(seatHold.holdId);
-      });
+   });
 
    useSeatHoldStore.getState().clearSeatHolds();
    useSeatSelectionStore.getState().clearAllSelections();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,10 +27,7 @@ const waitForServiceWorkerControl = async () => {
 };
 
 const startMocks = async () => {
-  if (!import.meta.env.DEV || !isMswEnabled) {
-    return;
-  }
-
+  if (!isMswEnabled) return;
   const { worker } = await import('@/shared/api/mocks/browser');
   await worker.start({
     onUnhandledRequest: 'bypass',

--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -55,50 +55,6 @@ const API_BLOCK_OFFSET_X = 120;
 const API_BLOCK_OFFSET_Y = 160;
 const SEAT_STEP = 20;
 
-type RawSeatResponse = Partial<SeatResponse> & {
-   id?: string;
-   seatNumber?: number;
-   row?: string;
-   isAvailable?: boolean;
-};
-
-const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0;
-
-const toOptionalFiniteNumber = (value: unknown) => {
-   if (typeof value === 'number' && Number.isFinite(value)) {
-      return value;
-   }
-
-   if (typeof value === 'string' && value.trim()) {
-      const parsedValue = Number(value);
-
-      if (Number.isFinite(parsedValue)) {
-         return parsedValue;
-      }
-   }
-
-   return undefined;
-};
-
-const normalizeSeatResponse = (seat: RawSeatResponse): SeatResponse | null => {
-   const seatId = isNonEmptyString(seat.seatId) ? seat.seatId : isNonEmptyString(seat.id) ? seat.id : undefined;
-   const sectionId = isNonEmptyString(seat.sectionId) ? seat.sectionId : undefined;
-   const rowName = isNonEmptyString(seat.rowName) ? seat.rowName : isNonEmptyString(seat.row) ? seat.row : undefined;
-   const seatNum = toOptionalFiniteNumber(seat.seatNum) ?? toOptionalFiniteNumber(seat.seatNumber);
-
-   if (!seatId || !sectionId || !rowName || seatNum === undefined) {
-      return null;
-   }
-
-   return {
-      seatId,
-      sectionId,
-      rowName,
-      seatNum,
-      available: typeof seat.available === 'boolean' ? seat.available : typeof seat.isAvailable === 'boolean' ? seat.isAvailable : true,
-   };
-};
-
 const normalizeSectionCode = (value: string) => value.replace(/\s+/g, '').toUpperCase();
 
 const parseTokenRange = (value: string) => {
@@ -222,21 +178,9 @@ export const fetchSeatSections = async (stadiumId: string) => {
 };
 
 export const fetchSeats = async (sectionId: string) => {
-   const response = await apiClient.get<ApiEnvelope<RawSeatResponse[]>>(`/api/v1/seats/seat-sections/${sectionId}/seats`);
+   const response = await apiClient.get<ApiEnvelope<SeatResponse[]>>(`/api/v1/seats/seat-sections/${sectionId}/seats`);
 
-   return (response.data.data ?? []).flatMap((seat) => {
-      const normalizedSeat = normalizeSeatResponse(seat);
-
-      if (normalizedSeat) {
-         return [normalizedSeat];
-      }
-
-      console.error('[bookingApi] 좌석 응답 정규화 실패', {
-         sectionId,
-         seat,
-      });
-      return [];
-   });
+   return response.data.data;
 };
 
 export const fetchSeatStatuses = async (gameId: string, sectionId: string) => {

--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -37,7 +37,8 @@ export type TicketPricingPolicyPriceResponse = {
    gradeId: string;
    ticketType: string;
    dayType: string;
-   leagueType: string;
+   leagueType?: string;
+   matchType?: string;
    price: number;
 };
 
@@ -245,7 +246,7 @@ export const resolvePricingByGradeId = ({
    }
 
    const filteredPrices = policy.prices.filter((price) => {
-      const normalizedPriceLeagueType = normalizePolicyLeagueType(price.leagueType);
+      const normalizedPriceLeagueType = normalizePolicyLeagueType(price.leagueType ?? price.matchType);
 
       return (
          normalizePolicyLeagueType(price.ticketType) === 'ADULT' &&

--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -99,7 +99,7 @@ const normalizeSeatResponse = (seat: RawSeatResponse): SeatResponse | null => {
    };
 };
 
-export const normalizeSectionCode = (value: string) => value.replace(/\s+/g, '').toUpperCase();
+const normalizeSectionCode = (value: string) => value.replace(/\s+/g, '').toUpperCase();
 
 const parseTokenRange = (value: string) => {
    const match = value.match(/^(.*?)(\d+)$/);
@@ -157,7 +157,7 @@ const resolveZoneTemplate = (teamId: string | undefined, sectionCode: string) =>
    return getBookingZones(teamId).find((zone) => matchesSectionExpression(zone.sectionCode, sectionCode));
 };
 
-export const toSeatStatus = (status: string | undefined, available: boolean): SeatStatus => {
+const toSeatStatus = (status: string | undefined, available: boolean): SeatStatus => {
    if (!available) {
       return 'disabled';
    }
@@ -219,23 +219,6 @@ export const fetchSeatSections = async (stadiumId: string) => {
    const response = await apiClient.get<ApiEnvelope<SeatSectionResponse[]>>(`/api/v1/stadium-seats/stadiums/${stadiumId}/seat-sections`);
 
    return response.data.data;
-};
-
-export const resolveSeatSectionByCode = async ({
-   stadiumId,
-   sectionCode,
-}: {
-   stadiumId?: string;
-   sectionCode: string;
-}) => {
-   if (!stadiumId) {
-      return null;
-   }
-
-   const sections = await fetchSeatSections(stadiumId);
-   const normalizedTargetSectionCode = normalizeSectionCode(sectionCode);
-
-   return sections.find((section) => normalizeSectionCode(section.sectionCode) === normalizedTargetSectionCode) ?? null;
 };
 
 export const fetchSeats = async (sectionId: string) => {

--- a/src/pages/books/model/useSeatHoldActions.ts
+++ b/src/pages/books/model/useSeatHoldActions.ts
@@ -90,15 +90,6 @@ export const useSeatHoldActions = (
    };
 
    const holdSeat = async (zoneId: string, seat: SeatItem) => {
-      if (!seat.id?.trim()) {
-         console.error('[useSeatHoldActions] seatId 없이 좌석 점유를 시도했습니다.', {
-            zoneId,
-            seat,
-         });
-         window.alert('좌석 정보를 확인할 수 없습니다. 잠시 후 다시 시도해 주세요.');
-         return;
-      }
-
       const currentZone = zonesState[zoneId];
       const isAlreadySelected = currentZone?.selectedSeatIds.includes(seat.id) ?? false;
 

--- a/src/pages/books/model/useSeatHoldActions.ts
+++ b/src/pages/books/model/useSeatHoldActions.ts
@@ -122,12 +122,6 @@ export const useSeatHoldActions = (
       }
 
       if (!bookingEntryState?.gameId || !bookingEntryState.queueTokenJti) {
-         console.warn('[SeatMapDebug] hold blocked: missing booking token', {
-            zoneId,
-            seatId: seat.id,
-            hasGameId: Boolean(bookingEntryState?.gameId),
-            hasQueueTokenJti: Boolean(bookingEntryState?.queueTokenJti),
-         });
          window.alert('예매 정보가 없어 좌석 점유를 진행할 수 없습니다.');
          return;
       }
@@ -167,16 +161,6 @@ export const useSeatHoldActions = (
          applyServerSeatPatch(zoneId, seat.id, 'selected');
          toggleSelectedSeat(zoneId, seat.id);
       } catch (error) {
-         if (error instanceof ApiError && error.status === 404) {
-            console.error('[useSeatHoldActions] 좌석 점유 404', {
-               zoneId,
-               seatId: seat.id,
-               gameId: bookingEntryState.gameId,
-               queueTokenJti: bookingEntryState.queueTokenJti,
-               errorData: error.data,
-            });
-         }
-
          if (isSeatAlreadyHeldConflict(error)) {
             window.alert('해당 좌석은 이미 선점된 좌석입니다.');
             await options?.onSeatHoldConflict?.();

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -51,25 +51,6 @@ const sortSectionBundles = (left: ApiSeatSectionBundle, right: ApiSeatSectionBun
       sensitivity: 'base',
    });
 
-const findSectionByCode = async ({
-   stadiumId,
-   sectionCode,
-}: {
-   stadiumId?: string;
-   sectionCode: string;
-}) => {
-   if (!stadiumId) {
-      return null;
-   }
-
-   const sections = await fetchSeatSections(stadiumId);
-   const normalizedTargetSectionCode = normalizeSectionCode(sectionCode);
-
-   return (
-      sections.find((section) => normalizeSectionCode(section.sectionCode) === normalizedTargetSectionCode) ?? null
-   );
-};
-
 const getSectionSeatLayoutMeta = (seats: SeatResponse[]) => {
    const rowNames = Array.from(new Set(seats.map((seat) => seat.rowName))).sort(sortRowNames);
 
@@ -271,19 +252,7 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
          }
 
          if (!isAggregatedSectionCode(zone.sectionCode)) {
-            const resolvedSection =
-               (await findSectionByCode({
-                  stadiumId,
-                  sectionCode: zone.sectionCode,
-               })) ??
-               ({
-                  sectionId: zone.id,
-                  sectionCode: zone.sectionCode,
-               } satisfies Pick<ApiSeatSectionBundle, 'sectionId' | 'sectionCode'>);
-            const [seats, statuses] = await Promise.all([
-               fetchSeats(resolvedSection.sectionId),
-               fetchSeatStatuses(gameId, resolvedSection.sectionId),
-            ]);
+            const [seats, statuses] = await Promise.all([fetchSeats(zone.id), fetchSeatStatuses(gameId, zone.id)]);
             const [seatBlock] = buildSeatBlockFromApiSeats(zone.sectionCode, seats);
 
             if (!seatBlock) {
@@ -294,8 +263,8 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
                seatBlock,
                zone.id,
                {
-                  sectionId: resolvedSection.sectionId,
-                  sectionCode: resolvedSection.sectionCode,
+                  sectionId: zone.id,
+                  sectionCode: zone.sectionCode,
                   seats,
                   statuses,
                },
@@ -304,7 +273,6 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
             console.info('[SeatMapDebug] single section payload', {
                zoneId: zone.id,
                zoneSectionCode: zone.sectionCode,
-               resolvedSectionId: resolvedSection.sectionId,
                seatsCount: seats.length,
                statusesCount: statuses.length,
                statusSummary: summarizeSeatStatuses(statuses),

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -7,9 +7,6 @@ import {
    fetchSeats,
    fetchSeatStatuses,
    matchesSectionExpression,
-   mapApiSeatsToSeatItems,
-   normalizeSectionCode,
-   resolveSeatSectionByCode,
    type SeatResponse,
    type SeatStatusResponse,
 } from '@/pages/books/api/bookingApi';
@@ -17,8 +14,7 @@ import { getSeatBlocks } from '@/pages/books/model/seatData';
 import type { SeatBlock, SeatItem, ZoneItem } from '@/pages/books/model/types';
 
 const AGGREGATED_SECTION_CODE_PATTERN = /[~,/]/;
-const API_SEAT_BASE_OFFSET_X = 120;
-const API_SEAT_BASE_OFFSET_Y = 160;
+const API_SEAT_SPACING = 20;
 
 type SeatMapDataParams = {
    gameId?: string;
@@ -38,6 +34,14 @@ type SeatMapApiSnapshot = {
    seatItems: SeatItem[];
 };
 
+const sortRowNames = (left: string, right: string) =>
+   left.localeCompare(right, 'ko-KR', {
+      numeric: true,
+      sensitivity: 'base',
+   });
+
+const normalizeSectionCode = (value: string) => value.replace(/\s+/g, '').toUpperCase();
+
 const isAggregatedSectionCode = (sectionCode?: string) =>
    Boolean(sectionCode && AGGREGATED_SECTION_CODE_PATTERN.test(sectionCode));
 
@@ -47,6 +51,53 @@ const sortSectionBundles = (left: ApiSeatSectionBundle, right: ApiSeatSectionBun
       sensitivity: 'base',
    });
 
+const findSectionByCode = async ({
+   stadiumId,
+   sectionCode,
+}: {
+   stadiumId?: string;
+   sectionCode: string;
+}) => {
+   if (!stadiumId) {
+      return null;
+   }
+
+   const sections = await fetchSeatSections(stadiumId);
+   const normalizedTargetSectionCode = normalizeSectionCode(sectionCode);
+
+   return (
+      sections.find((section) => normalizeSectionCode(section.sectionCode) === normalizedTargetSectionCode) ?? null
+   );
+};
+
+const getSectionSeatLayoutMeta = (seats: SeatResponse[]) => {
+   const rowNames = Array.from(new Set(seats.map((seat) => seat.rowName))).sort(sortRowNames);
+
+   return {
+      rowNames,
+      rowIndexByName: Object.fromEntries(rowNames.map((rowName, index) => [rowName, index])),
+      columnCount: seats.length > 0 ? Math.max(...seats.map((seat) => seat.seatNum)) : 0,
+   };
+};
+
+const toSeatItemStatus = (seat: SeatResponse, statuses: Record<string, string>): SeatItem['status'] => {
+   const status = statuses[seat.seatId]?.toUpperCase();
+
+   if (!seat.available) {
+      return 'disabled';
+   }
+
+   if (status === 'HELD') {
+      return 'held';
+   }
+
+   if (status === 'SOLD' || status === 'BLOCKED') {
+      return 'disabled';
+   }
+
+   return 'available';
+};
+
 const createSeatBlockForLayout = (block: SeatBlock, section: ApiSeatSectionBundle): SeatBlock => {
    if (section.seats.length === 0) {
       return {
@@ -54,14 +105,8 @@ const createSeatBlockForLayout = (block: SeatBlock, section: ApiSeatSectionBundl
          activeSeats: [],
       };
    }
-   const rowNames = Array.from(new Set(section.seats.map((seat) => seat.rowName))).sort((left, right) =>
-      left.localeCompare(right, 'ko-KR', {
-         numeric: true,
-         sensitivity: 'base',
-      }),
-   );
-   const rowIndexByName = Object.fromEntries(rowNames.map((rowName, index) => [rowName, index]));
-   const columnCount = Math.max(...section.seats.map((seat) => seat.seatNum));
+
+   const { rowNames, rowIndexByName, columnCount } = getSectionSeatLayoutMeta(section.seats);
 
    return {
       ...block,
@@ -74,16 +119,23 @@ const createSeatBlockForLayout = (block: SeatBlock, section: ApiSeatSectionBundl
 };
 
 const createSeatItemsForLayout = (block: SeatBlock, zoneId: string, section: ApiSeatSectionBundle): SeatItem[] => {
-   return mapApiSeatsToSeatItems({
-      sectionId: zoneId,
-      sectionCode: block.label,
-      seats: section.seats,
-      statuses: section.statuses,
-   }).map((seat) => ({
-      ...seat,
-      x: seat.x - API_SEAT_BASE_OFFSET_X + block.offsetX,
-      y: seat.y - API_SEAT_BASE_OFFSET_Y + block.offsetY,
-   }));
+   const { rowIndexByName } = getSectionSeatLayoutMeta(section.seats);
+   const statusBySeatId = Object.fromEntries(section.statuses.map((seatStatus) => [seatStatus.seatId, seatStatus.status]));
+
+   return section.seats.map((seat) => {
+      const rowIndex = rowIndexByName[seat.rowName] ?? 0;
+
+      return {
+         id: seat.seatId,
+         block: block.label,
+         rowLabel: `${seat.rowName}열`,
+         seatNumber: seat.seatNum,
+         x: block.offsetX + (seat.seatNum - 1) * API_SEAT_SPACING,
+         y: block.offsetY + rowIndex * API_SEAT_SPACING,
+         zoneId,
+         status: toSeatItemStatus(seat, statusBySeatId),
+      } satisfies SeatItem;
+   });
 };
 
 const summarizeSeatStatuses = (statuses: SeatStatusResponse[]) => {
@@ -220,7 +272,7 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
 
          if (!isAggregatedSectionCode(zone.sectionCode)) {
             const resolvedSection =
-               (await resolveSeatSectionByCode({
+               (await findSectionByCode({
                   stadiumId,
                   sectionCode: zone.sectionCode,
                })) ??

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -119,29 +119,6 @@ const createSeatItemsForLayout = (block: SeatBlock, zoneId: string, section: Api
    });
 };
 
-const summarizeSeatStatuses = (statuses: SeatStatusResponse[]) => {
-   return statuses.reduce<Record<string, number>>((summary, seatStatus) => {
-      const key = seatStatus.status?.toUpperCase?.() ?? 'UNKNOWN';
-      summary[key] = (summary[key] ?? 0) + 1;
-      return summary;
-   }, {});
-};
-
-const summarizeSeatItemStatuses = (seats: SeatItem[]) => {
-   return seats.reduce<Record<SeatItem['status'], number>>(
-      (summary, seat) => {
-         summary[seat.status] += 1;
-         return summary;
-      },
-      {
-         available: 0,
-         selected: 0,
-         held: 0,
-         disabled: 0,
-      },
-   );
-};
-
 const buildAggregatedSeatMapSnapshot = ({
    defaultBlocks,
    sections,
@@ -218,16 +195,6 @@ const fetchAggregatedSeatSections = async ({
             fetchSeatStatuses(gameId, section.sectionId),
          ]);
 
-         console.info('[SeatMapDebug] aggregated section payload', {
-            zoneId: zone.id,
-            zoneSectionCode: zone.sectionCode,
-            sectionId: section.sectionId,
-            sectionCode: section.sectionCode,
-            seatsCount: seats.length,
-            statusesCount: statuses.length,
-            statusSummary: summarizeSeatStatuses(statuses),
-         });
-
          return {
             sectionId: section.sectionId,
             sectionCode: section.sectionCode,
@@ -259,29 +226,18 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
                return null;
             }
 
-            const seatItems = createSeatItemsForLayout(
-               seatBlock,
-               zone.id,
-               {
-                  sectionId: zone.id,
-                  sectionCode: zone.sectionCode,
-                  seats,
-                  statuses,
-               },
-            );
-
-            console.info('[SeatMapDebug] single section payload', {
-               zoneId: zone.id,
-               zoneSectionCode: zone.sectionCode,
-               seatsCount: seats.length,
-               statusesCount: statuses.length,
-               statusSummary: summarizeSeatStatuses(statuses),
-               mappedStatusSummary: summarizeSeatItemStatuses(seatItems),
-            });
-
             return {
                seatBlocks: [seatBlock],
-               seatItems,
+               seatItems: createSeatItemsForLayout(
+                  seatBlock,
+                  zone.id,
+                  {
+                     sectionId: zone.id,
+                     sectionCode: zone.sectionCode,
+                     seats,
+                     statuses,
+                  },
+               ),
             };
          }
 
@@ -299,21 +255,11 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
             return null;
          }
 
-         const snapshot = buildAggregatedSeatMapSnapshot({
+         return buildAggregatedSeatMapSnapshot({
             defaultBlocks: defaultSeatBlocks,
             sections: sectionBundles,
             zoneId: zone.id,
          });
-
-         console.info('[SeatMapDebug] aggregated snapshot', {
-            zoneId: zone.id,
-            zoneSectionCode: zone.sectionCode,
-            seatBlockCount: snapshot.seatBlocks.length,
-            seatItemCount: snapshot.seatItems.length,
-            mappedStatusSummary: summarizeSeatItemStatuses(snapshot.seatItems),
-         });
-
-         return snapshot;
       },
    });
 

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -19,7 +19,6 @@ import ResellSeatSidebar from './components/ResellSeatSidebar';
 import ResellZonePreviewSheet from './components/ResellZonePreviewSheet';
 import SelectedSeatSummaryList from './components/SelectedSeatSummaryList';
 import { useBotDetector } from '@/shared/lib/useBotDetector';
-import { isMswEnabled } from '@/shared/config/runtime';
 
 const MIN_SCALE = 0.8;
 const MAX_SCALE = 2.4;
@@ -75,7 +74,7 @@ function SeatsPage() {
          onSeatHoldConflict: async () => {
             await refetchSeatMap();
          },
-         useMockSeatHold: isMswEnabled && Boolean(seatMapLoadError),
+         useMockSeatHold: Boolean(seatMapLoadError),
       },
    );
 

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -532,8 +532,6 @@ function SeatsPage() {
                      defaultHeight={isResellMode ? 488 : 280}
                      minHeight={isResellMode ? 280 : 152}
                      maxHeight={560}
-                     title={isResellMode ? '리셀 예매 하단 패널' : '선택 좌석 하단 패널'}
-                     description={isResellMode ? '리셀 좌석 정보를 확인하고 예매를 진행할 수 있습니다.' : '선택한 좌석과 결제 금액을 확인할 수 있습니다.'}
                      className="overflow-hidden border-none p-0 xl:hidden"
                   >
                      <div className="h-full overflow-y-auto">

--- a/src/pages/books/ui/components/BookingCaptchaGate.tsx
+++ b/src/pages/books/ui/components/BookingCaptchaGate.tsx
@@ -1,7 +1,7 @@
 import { RefreshCcw, Volume2 } from 'lucide-react';
 
 import { Button } from '@/shared/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 import { Input } from '@/shared/ui/input';
 
 type BookingCaptchaGateProps = {
@@ -35,9 +35,6 @@ function BookingCaptchaGate({
                <DialogTitle align="center" className="text-[18px] font-bold leading-[1.55]">
                   문자 인증 후 예매를 진행할 수 있어요
                </DialogTitle>
-               <DialogDescription className="sr-only" align="center">
-                  화면에 표시된 보안 문자를 입력해 예매를 진행하는 인증 단계입니다.
-               </DialogDescription>
             </DialogHeader>
 
             <div className="px-5 pb-5">

--- a/src/pages/books/ui/components/BookingZoneMobileLayout.tsx
+++ b/src/pages/books/ui/components/BookingZoneMobileLayout.tsx
@@ -66,8 +66,6 @@ function BookingZoneMobileLayout({
                   defaultHeight={360}
                   minHeight={232}
                   maxHeight={488}
-                  title={bookingFlowMode === 'resell' ? '리셀 좌석 구역 목록' : '좌석 등급과 잔여석 목록'}
-                  description={bookingFlowMode === 'resell' ? '리셀 예매 가능한 좌석 구역 목록입니다.' : '예매 가능한 좌석 등급과 잔여석을 확인할 수 있습니다.'}
                   className="overflow-hidden border-none p-0"
                >
                   <div className="h-full overflow-y-auto">

--- a/src/pages/books/ui/components/SeatBlockGrid.tsx
+++ b/src/pages/books/ui/components/SeatBlockGrid.tsx
@@ -90,7 +90,7 @@ function SeatBlockGrid({ block, blockIndex, seats, selectedSeatIdSet, onToggleSe
                            seat.status === 'disabled'
                               ? 'bg-[#f1f2f4]'
                               : seat.status === 'held'
-                                ? 'bg-[#f1f2f4]'
+                                ? 'border-[1.5px] border-[#7c68ed] bg-[#7c68ed]'
                                 : isSelected
                                   ? 'bg-[#7c68ed]'
                                   : 'border border-[#867eed] bg-[rgba(124,104,237,0.12)] group-hover:border-[1.5px] group-hover:border-[#7c68ed] group-hover:bg-[#7c68ed] group-focus-visible:border-[1.5px] group-focus-visible:border-[#7c68ed] group-focus-visible:bg-[#7c68ed]',

--- a/src/pages/home/ui/game-schedule/BookingCaptchaDialog.tsx
+++ b/src/pages/home/ui/game-schedule/BookingCaptchaDialog.tsx
@@ -1,7 +1,7 @@
 import { RefreshCcw, Volume2 } from 'lucide-react';
 
 import { Button } from '@/shared/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 import { Input } from '@/shared/ui/input';
 
 type BookingCaptchaDialogProps = {
@@ -35,9 +35,6 @@ function BookingCaptchaDialog({
           <DialogTitle align="center" className="text-[18px] font-bold leading-[1.55]">
             문자 인증 후 예매를 진행할 수 있어요
           </DialogTitle>
-          <DialogDescription className="sr-only" align="center">
-            화면에 표시된 보안 문자를 입력해 예매를 진행하는 인증 단계입니다.
-          </DialogDescription>
         </DialogHeader>
 
         <div className="px-5 pb-5">

--- a/src/pages/tickets/api/paymentApi.ts
+++ b/src/pages/tickets/api/paymentApi.ts
@@ -86,20 +86,20 @@ type CreateOrderResponse = {
 };
 
 type OrderPaymentRequest = {
-   paymentMethod: ApiPaymentMethodCode;
+   paymentMethod: string;
    idempotencyKey: string;
 };
 
-export type OrderPaymentResponse = {
+type OrderPaymentResponse = {
    paymentId: string;
    orderId: string;
    paymentType: string;
-   paymentMethod: ApiPaymentMethodCode;
+   paymentMethod: string;
    paymentAmount: number;
    pgProvider: string;
    pgTid: string;
    paymentStatus: string;
-   paidAt?: string | null;
+   paidAt: string;
    failedReason?: string | null;
 };
 
@@ -137,13 +137,11 @@ type ResalePaymentRequest = {
    totalBuyerFee: number;
    totalSellerFee: number;
    items: ResalePaymentItem[];
-   paymentMethod: ApiPaymentMethodCode;
+   paymentMethod: string;
    idempotencyKey: string;
 };
 
-type ApiPaymentMethodCode = 'CARD' | 'ACCOUNT_TRANSFER';
-
-const UNSUPPORTED_PAYMENT_METHOD_MESSAGE = '아직 지원하지 않는 결제수단입니다.';
+type PaymentMethodCode = 'CARD' | 'KAKAO_PAY' | 'NAVER_PAY' | 'TOSS_PAY' | 'ACCOUNT_TRANSFER';
 
 const formatOrderedAt = (date: Date) => {
    return date.toLocaleString('ko-KR', {
@@ -168,16 +166,18 @@ const assertNever = (value: never): never => {
    throw new Error(`지원하지 않는 결제 수단입니다: ${String(value)}`);
 };
 
-const toPaymentMethodCode = (paymentMethod: PaymentMethod): ApiPaymentMethodCode => {
+const toPaymentMethodCode = (paymentMethod: PaymentMethod): PaymentMethodCode => {
    switch (paymentMethod) {
       case 'card':
          return 'CARD';
+      case 'kakao':
+         return 'KAKAO_PAY';
+      case 'naver':
+         return 'NAVER_PAY';
+      case 'toss':
+         return 'TOSS_PAY';
       case 'bank':
          return 'ACCOUNT_TRANSFER';
-      case 'kakao':
-      case 'naver':
-      case 'toss':
-         throw new Error(UNSUPPORTED_PAYMENT_METHOD_MESSAGE);
       default:
          return assertNever(paymentMethod);
    }
@@ -202,12 +202,6 @@ const toPaymentMethodLabel = (paymentMethod: PaymentMethod) => {
 
 const createOrder = async (payload: CreateOrderRequest) => {
    const response = await apiClient.post<ApiEnvelope<CreateOrderResponse>>('/api/v1/orders', payload);
-
-   return response.data.data;
-};
-
-export const getOrderPayment = async (orderId: string) => {
-   const response = await apiClient.get<ApiEnvelope<OrderPaymentResponse>>(`/api/v1/payments/orders/${orderId}`);
 
    return response.data.data;
 };
@@ -245,53 +239,6 @@ const createResalePayment = async (payload: ResalePaymentRequest) => {
    return response.data.data;
 };
 
-const buildPaymentResponse = ({
-   amount,
-   order,
-   payment,
-   paymentMethod,
-   gameTitle,
-   gameDate,
-   gameVenue,
-   seats,
-   recipient,
-}: {
-   amount: number;
-   order: CreateOrderResponse | ResaleOrderResponse;
-   payment: OrderPaymentResponse;
-   paymentMethod: PaymentMethod;
-   gameTitle: string;
-   gameDate: string;
-   gameVenue: string;
-   seats: string[];
-   recipient?: {
-      name: string;
-      phone: string;
-      address: string;
-   };
-}): PaymentResponse => {
-   return {
-      orderId: order.orderId,
-      orderNumber: order.orderNumber,
-      orderStatus: order.orderStatus,
-      paymentStatus: payment.paymentStatus,
-      paidAt: payment.paidAt ?? undefined,
-      gameTitle,
-      gameDate,
-      gameVenue,
-      quantity: order.totalQuantity,
-      seats,
-      paymentMethod: toPaymentMethodLabel(paymentMethod),
-      orderedAt: formatOrderedAt(new Date()),
-      amount,
-      ...(recipient && {
-         recipientName: recipient.name,
-         recipientPhone: recipient.phone,
-         recipientAddress: recipient.address,
-      }),
-   };
-};
-
 export const submitTicketOrder = async (payload: TicketCheckoutRequest): Promise<PaymentResponse> => {
    const heldSeats = payload.selectedSeats.map(({ seatId, holdId, label }) => ({
       seatId,
@@ -316,24 +263,26 @@ export const submitTicketOrder = async (payload: TicketCheckoutRequest): Promise
       idempotencyKey: createClientTransactionId('idempotency'),
    });
 
-   return buildPaymentResponse({
-      amount: payment.paymentAmount,
-      order,
-      payment,
-      paymentMethod: payload.paymentMethod,
+   return {
+      orderId: order.orderId,
+      orderNumber: order.orderNumber,
+      orderStatus: order.orderStatus,
+      paymentStatus: payment.paymentStatus,
+      paidAt: payment.paidAt,
       gameTitle: payload.matchTitle,
       gameDate: payload.gameDate,
       gameVenue: payload.gameVenue,
+      quantity: order.totalQuantity,
       seats: heldSeats.map(({ seatLabel }) => seatLabel),
-      recipient:
-         payload.deliveryMethod === 'delivery'
-            ? {
-                 name: payload.ordererName,
-                 phone: payload.ordererPhone,
-                 address: `${payload.address ?? ''} ${payload.addressDetail ?? ''}`.trim(),
-              }
-            : undefined,
-   });
+      paymentMethod: toPaymentMethodLabel(payload.paymentMethod),
+      orderedAt: formatOrderedAt(new Date()),
+      amount: payload.amount,
+      ...(payload.deliveryMethod === 'delivery' && {
+         recipientName: payload.ordererName,
+         recipientPhone: payload.ordererPhone,
+         recipientAddress: `${payload.address ?? ''} ${payload.addressDetail ?? ''}`.trim(),
+      }),
+   };
 };
 
 export const submitResaleOrder = async (payload: ResaleCheckoutRequest): Promise<PaymentResponse> => {
@@ -367,14 +316,19 @@ export const submitResaleOrder = async (payload: ResaleCheckoutRequest): Promise
       idempotencyKey: createClientTransactionId('resale-idempotency'),
    });
 
-   return buildPaymentResponse({
-      amount: payment.paymentAmount,
-      order,
-      payment,
-      paymentMethod: payload.paymentMethod,
+   return {
+      orderId: order.orderId,
+      orderNumber: order.orderNumber,
+      orderStatus: order.orderStatus,
+      paymentStatus: payment.paymentStatus,
+      paidAt: payment.paidAt,
       gameTitle: payload.matchTitle,
       gameDate: payload.gameDate,
       gameVenue: payload.gameVenue,
+      quantity: order.totalQuantity,
       seats: [payload.seatInfo],
-   });
+      paymentMethod: toPaymentMethodLabel(payload.paymentMethod),
+      orderedAt: formatOrderedAt(new Date()),
+      amount: payload.totalAmount,
+   };
 };

--- a/src/pages/tickets/api/paymentApi.ts
+++ b/src/pages/tickets/api/paymentApi.ts
@@ -144,8 +144,6 @@ type ResalePaymentRequest = {
 type ApiPaymentMethodCode = 'CARD' | 'ACCOUNT_TRANSFER';
 
 const UNSUPPORTED_PAYMENT_METHOD_MESSAGE = '아직 지원하지 않는 결제수단입니다.';
-const configuredApiBaseUrl = (import.meta.env.PUBLIC_API_BASE_URL ?? '').trim();
-const shouldUseRelativeApiBase = import.meta.env.DEV;
 
 const formatOrderedAt = (date: Date) => {
    return date.toLocaleString('ko-KR', {
@@ -164,16 +162,6 @@ const createClientTransactionId = (prefix: string) => {
    }
 
    return `${prefix}-${Date.now()}`;
-};
-
-const getResaleHoldReleaseUrl = (holdId: string) => {
-   const path = `/api/v1/resales/holds/${encodeURIComponent(holdId)}/release`;
-
-   if (shouldUseRelativeApiBase || !configuredApiBaseUrl) {
-      return path;
-   }
-
-   return new URL(path, configuredApiBaseUrl).toString();
 };
 
 const assertNever = (value: never): never => {
@@ -237,29 +225,6 @@ const createResaleHold = async (payload: ResaleHoldRequest) => {
    const response = await apiClient.post<ApiEnvelope<ResaleHoldResponse>>('/api/v1/resales/holds', payload);
 
    return response.data.data;
-};
-
-export const releaseResaleHold = async (holdId: string) => {
-   const response = await apiClient.patch<ApiEnvelope<ResaleHoldResponse>>(
-      `/api/v1/resales/holds/${encodeURIComponent(holdId)}/release`,
-   );
-
-   return response.data.data;
-};
-
-export const releaseResaleHoldKeepalive = (holdId: string) => {
-   if (typeof window === 'undefined') {
-      return;
-   }
-
-   void fetch(getResaleHoldReleaseUrl(holdId), {
-      method: 'PATCH',
-      headers: {
-         'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-      keepalive: true,
-   });
 };
 
 const createResaleOrder = async (payload: ResaleOrderRequest) => {
@@ -371,68 +336,45 @@ export const submitTicketOrder = async (payload: TicketCheckoutRequest): Promise
    });
 };
 
-export const submitResaleOrder = async (
-   payload: ResaleCheckoutRequest,
-   options?: { onHoldCreated?: (holdId: string) => void; onHoldReleased?: () => void },
-): Promise<PaymentResponse> => {
-   let resaleHoldId: string | null = null;
+export const submitResaleOrder = async (payload: ResaleCheckoutRequest): Promise<PaymentResponse> => {
+   const hold = await createResaleHold({
+      listingId: payload.listingId,
+      queueTokenJti: payload.queueTokenJti,
+   });
 
-   try {
-      const hold = await createResaleHold({
-         listingId: payload.listingId,
-         queueTokenJti: payload.queueTokenJti,
-      });
-      resaleHoldId = hold.holdId;
-      options?.onHoldCreated?.(hold.holdId);
+   const order = await createResaleOrder({
+      holdIds: [hold.holdId],
+   });
 
-      const order = await createResaleOrder({
-         holdIds: [hold.holdId],
-      });
+   const transactionIds = await getResaleTransactions(order.orderId);
 
-      const transactionIds = await getResaleTransactions(order.orderId);
-
-      if (transactionIds.length === 0) {
-         throw new Error('리셀 거래 정보가 없어 결제를 진행할 수 없습니다.');
-      }
-
-      const payment = await createResalePayment({
-         orderId: order.orderId,
-         buyerId: payload.buyerId,
-         totalAmount: payload.totalAmount,
-         totalBuyerFee: payload.totalBuyerFee,
-         totalSellerFee: payload.totalSellerFee,
-         items: transactionIds.map((transactionId) => ({
-            transactionId,
-            sellerId: payload.sellerId,
-            settlementAmount: payload.settlementAmount,
-         })),
-         paymentMethod: toPaymentMethodCode(payload.paymentMethod),
-         idempotencyKey: createClientTransactionId('resale-idempotency'),
-      });
-
-      return buildPaymentResponse({
-         amount: payment.paymentAmount,
-         order,
-         payment,
-         paymentMethod: payload.paymentMethod,
-         gameTitle: payload.matchTitle,
-         gameDate: payload.gameDate,
-         gameVenue: payload.gameVenue,
-         seats: [payload.seatInfo],
-      });
-   } catch (error) {
-      if (resaleHoldId) {
-         try {
-            await releaseResaleHold(resaleHoldId);
-            options?.onHoldReleased?.();
-         } catch (releaseError) {
-            console.error('[submitResaleOrder] failed to release resale hold after payment failure', {
-               holdId: resaleHoldId,
-               releaseError,
-            });
-         }
-      }
-
-      throw error;
+   if (transactionIds.length === 0) {
+      throw new Error('리셀 거래 정보가 없어 결제를 진행할 수 없습니다.');
    }
+
+   const payment = await createResalePayment({
+      orderId: order.orderId,
+      buyerId: payload.buyerId,
+      totalAmount: payload.totalAmount,
+      totalBuyerFee: payload.totalBuyerFee,
+      totalSellerFee: payload.totalSellerFee,
+      items: transactionIds.map((transactionId) => ({
+         transactionId,
+         sellerId: payload.sellerId,
+         settlementAmount: payload.settlementAmount,
+      })),
+      paymentMethod: toPaymentMethodCode(payload.paymentMethod),
+      idempotencyKey: createClientTransactionId('resale-idempotency'),
+   });
+
+   return buildPaymentResponse({
+      amount: payment.paymentAmount,
+      order,
+      payment,
+      paymentMethod: payload.paymentMethod,
+      gameTitle: payload.matchTitle,
+      gameDate: payload.gameDate,
+      gameVenue: payload.gameVenue,
+      seats: [payload.seatInfo],
+   });
 };

--- a/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
@@ -113,10 +113,8 @@ export default function PaymentCompletePage() {
    const deliveryMethod = (searchParams.get('delivery') as DeliveryMethod) ?? 'mobile';
    const orderId = searchParams.get('orderId');
    const locationOrder = state as PaymentResponse | null;
-   const storedOrder = readStoredPaymentCompleteState(orderId);
-   const cachedOrder = locationOrder ?? storedOrder;
    const [order, setOrder] = useState<PaymentResponse>(() => {
-      return cachedOrder ?? (MOCK_ORDER as PaymentResponse);
+      return locationOrder ?? readStoredPaymentCompleteState(orderId) ?? (MOCK_ORDER as PaymentResponse);
    });
    const [paymentReloadError, setPaymentReloadError] = useState<string | null>(null);
 
@@ -160,11 +158,6 @@ export default function PaymentCompletePage() {
                return;
             }
 
-            if (cachedOrder) {
-               setPaymentReloadError(null);
-               return;
-            }
-
             setPaymentReloadError(
                error instanceof ApiError ? error.message : '결제 정보를 다시 불러오지 못했습니다.',
             );
@@ -176,7 +169,7 @@ export default function PaymentCompletePage() {
       return () => {
          isCancelled = true;
       };
-   }, [cachedOrder, orderId]);
+   }, [orderId]);
 
    const actionButton =
       deliveryMethod === 'delivery'

--- a/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
@@ -2,12 +2,11 @@
 
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
-import { getOrderPayment, type PaymentResponse } from '@/pages/tickets/api/paymentApi';
+import type { PaymentResponse } from '@/pages/tickets/api/paymentApi';
 import { Calendar, CheckCircle, ChevronLeft, MapPin } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import BooksHeader from '@/shared/widgets/layout/books/BooksHeader';
 import { useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
-import { ApiError } from '@/shared/api/client';
 
 function useTimerStr() {
    const [now, setNow] = useState(Date.now());
@@ -30,37 +29,6 @@ const DELIVERY_LABELS: Record<DeliveryMethod, string> = {
    mobile: '모바일 티켓',
    onsite: '현장 수령',
    delivery: '배송 수령',
-};
-
-const PAYMENT_COMPLETE_STORAGE_KEY = 'ticket-payment-complete';
-
-const readStoredPaymentCompleteState = (orderId: string | null) => {
-   if (typeof window === 'undefined' || !orderId) {
-      return null;
-   }
-
-   const storedValue = window.sessionStorage.getItem(`${PAYMENT_COMPLETE_STORAGE_KEY}:${orderId}`);
-
-   if (!storedValue) {
-      return null;
-   }
-
-   try {
-      return JSON.parse(storedValue) as PaymentResponse;
-   } catch {
-      return null;
-   }
-};
-
-const writeStoredPaymentCompleteState = (order: PaymentResponse) => {
-   if (typeof window === 'undefined' || !order.orderId) {
-      return;
-   }
-
-   window.sessionStorage.setItem(
-      `${PAYMENT_COMPLETE_STORAGE_KEY}:${order.orderId}`,
-      JSON.stringify(order),
-   );
 };
 
 const ENTRANCE_GUIDES: Record<DeliveryMethod, string[]> = {
@@ -111,65 +79,8 @@ export default function PaymentCompletePage() {
    const { state } = useLocation();
    const timeStr = useTimerStr();
    const deliveryMethod = (searchParams.get('delivery') as DeliveryMethod) ?? 'mobile';
-   const orderId = searchParams.get('orderId');
-   const locationOrder = state as PaymentResponse | null;
-   const [order, setOrder] = useState<PaymentResponse>(() => {
-      return locationOrder ?? readStoredPaymentCompleteState(orderId) ?? (MOCK_ORDER as PaymentResponse);
-   });
-   const [paymentReloadError, setPaymentReloadError] = useState<string | null>(null);
-
-   useEffect(() => {
-      if (locationOrder?.orderId) {
-         writeStoredPaymentCompleteState(locationOrder);
-      }
-   }, [locationOrder]);
-
-   useEffect(() => {
-      let isCancelled = false;
-
-      if (!orderId) {
-         return;
-      }
-
-      const restorePayment = async () => {
-         try {
-            const payment = await getOrderPayment(orderId);
-
-            if (isCancelled) {
-               return;
-            }
-
-            setPaymentReloadError(null);
-            setOrder((currentOrder) => {
-               const nextOrder: PaymentResponse = {
-                  ...currentOrder,
-                  orderId: payment.orderId,
-                  paymentStatus: payment.paymentStatus,
-                  paidAt: payment.paidAt ?? currentOrder.paidAt,
-                  amount: payment.paymentAmount,
-                  orderStatus: payment.paymentStatus === 'SUCCESS' ? 'CONFIRMED' : currentOrder.orderStatus,
-               };
-
-               writeStoredPaymentCompleteState(nextOrder);
-               return nextOrder;
-            });
-         } catch (error) {
-            if (isCancelled) {
-               return;
-            }
-
-            setPaymentReloadError(
-               error instanceof ApiError ? error.message : '결제 정보를 다시 불러오지 못했습니다.',
-            );
-         }
-      };
-
-      restorePayment();
-
-      return () => {
-         isCancelled = true;
-      };
-   }, [orderId]);
+   // API 응답이 있으면 사용, 없으면 MOCK_ORDER로 폴백
+   const order = (state as PaymentResponse | null) ?? (MOCK_ORDER as PaymentResponse);
 
    const actionButton =
       deliveryMethod === 'delivery'
@@ -225,12 +136,6 @@ export default function PaymentCompletePage() {
                      티켓이 성공적으로 발급되었습니다
                   </p>
                </div>
-
-               {paymentReloadError ? (
-                  <div className="w-full rounded-[14px] border border-destructive/20 bg-destructive/5 px-5 py-4 text-[14px] text-destructive">
-                     {paymentReloadError}
-                  </div>
-               ) : null}
 
                {/* 예매 정보 카드 */}
                <div className="w-full border-2 border-border-light rounded-[14px] p-[26px] flex flex-col gap-6 bg-background">

--- a/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
@@ -2,15 +2,11 @@ import { useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import {
-   releaseResaleHold,
-   releaseResaleHoldKeepalive,
    submitResaleOrder,
    submitTicketOrder,
    type ResaleCheckoutRequest,
-   type PaymentResponse,
    type TicketCheckoutRequest,
 } from '@/pages/tickets/api/paymentApi';
-import { releaseSeatReservation, releaseSeatReservationKeepalive } from '@/entities/seat-hold/api/seatHoldApi';
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 import { ApiError } from '@/shared/api/client';
@@ -24,69 +20,15 @@ const MOCK_GAME = {
    dateTime: '3.21 (토) 오후 18:30',
 };
 
-const PAYMENT_COMPLETE_STORAGE_KEY = 'ticket-payment-complete';
-
-const savePaymentCompleteState = (order: PaymentResponse) => {
-   if (typeof window === 'undefined' || !order.orderId) {
-      return;
-   }
-
-   window.sessionStorage.setItem(
-      `${PAYMENT_COMPLETE_STORAGE_KEY}:${order.orderId}`,
-      JSON.stringify(order),
-   );
-};
-
-const releasePendingTicketSeatHolds = async () => {
-   const seatHolds = Object.values(useSeatHoldStore.getState().holdsBySeatId);
-
-   if (seatHolds.length === 0) {
-      return;
-   }
-
-   const releaseResults = await Promise.allSettled(
-      seatHolds.map((seatHold) => releaseSeatReservation(seatHold.holdId)),
-   );
-   const failedReleaseCount = releaseResults.filter((result) => result.status === 'rejected').length;
-
-   if (failedReleaseCount > 0) {
-      console.error('[PaymentProcessingPage] failed to release ticket seat holds', {
-         failedReleaseCount,
-         totalReleaseCount: seatHolds.length,
-      });
-   }
-
-   useSeatHoldStore.getState().clearSeatHolds();
-   useSeatSelectionStore.getState().clearAllSelections();
-};
-
-const releasePendingTicketSeatHoldsKeepalive = () => {
-   const seatHolds = Object.values(useSeatHoldStore.getState().holdsBySeatId);
-
-   if (seatHolds.length === 0) {
-      return;
-   }
-
-   seatHolds.forEach((seatHold) => {
-      releaseSeatReservationKeepalive(seatHold.holdId);
-   });
-
-   useSeatHoldStore.getState().clearSeatHolds();
-   useSeatSelectionStore.getState().clearAllSelections();
-};
-
 export default function PaymentProcessingPage() {
    const navigate = useNavigate();
    const { state } = useLocation();
    const locationState = state as { request: TicketCheckoutRequest | ResaleCheckoutRequest; amount: number } | null;
    const hasStartedRef = useRef(false);
    const isMountedRef = useRef(false);
-   const hasCompletedRef = useRef(false);
-   const resaleHoldIdRef = useRef<string | null>(null);
 
    useEffect(() => {
       isMountedRef.current = true;
-      hasCompletedRef.current = false;
 
       if (!locationState?.request) {
          navigate('/tickets/payment', { replace: true });
@@ -101,58 +43,25 @@ export default function PaymentProcessingPage() {
 
       const { request: paymentRequest, amount: clientAmount } = locationState;
       const isStillOnProcessingPage = () => window.location.pathname === '/tickets/payment/processing';
-      const isResaleRequest = 'listingId' in paymentRequest;
-
-      const releasePendingHolds = async () => {
-         if (isResaleRequest) {
-            const resaleHoldId = resaleHoldIdRef.current;
-
-            if (!resaleHoldId) {
-               return;
-            }
-
-            resaleHoldIdRef.current = null;
-            await releaseResaleHold(resaleHoldId);
-            return;
-         }
-
-         await releasePendingTicketSeatHolds();
-      };
 
       const process = async () => {
          try {
-            const submitOrder = 'gameId' in paymentRequest && 'selectedSeats' in paymentRequest
-               ? () => submitTicketOrder(paymentRequest)
-               : () =>
-                    submitResaleOrder(paymentRequest, {
-                       onHoldCreated: (holdId) => {
-                          resaleHoldIdRef.current = holdId;
-                       },
-                       onHoldReleased: () => {
-                          resaleHoldIdRef.current = null;
-                       },
-                    });
+            const submitOrder =
+               'gameId' in paymentRequest && 'selectedSeats' in paymentRequest ? submitTicketOrder : submitResaleOrder;
             const [result] = await Promise.all([
-               submitOrder(),
+               submitOrder(paymentRequest),
                new Promise(resolve => setTimeout(resolve, 1000)),
             ]);
             if (isMountedRef.current && isStillOnProcessingPage()) {
-               hasCompletedRef.current = true;
-               resaleHoldIdRef.current = null;
-               savePaymentCompleteState({ ...result, amount: clientAmount });
                useSeatHoldStore.getState().clearSeatHolds();
                useSeatSelectionStore.getState().clearAllSelections();
                navigate(
-                  `/tickets/payment/complete?delivery=${paymentRequest.deliveryMethod}&orderId=${encodeURIComponent(result.orderId ?? '')}`,
+                  `/tickets/payment/complete?delivery=${paymentRequest.deliveryMethod}`,
                   { state: { ...result, amount: clientAmount }, replace: true },
                );
             }
          } catch (error) {
             if (isMountedRef.current && isStillOnProcessingPage()) {
-               if (!isResaleRequest) {
-                  await releasePendingHolds();
-               }
-
                const message =
                   error instanceof ApiError
                      ? error.message
@@ -165,30 +74,7 @@ export default function PaymentProcessingPage() {
 
       process();
 
-      const handlePageHide = () => {
-         if (hasCompletedRef.current) {
-            return;
-         }
-
-         if (isResaleRequest) {
-            const resaleHoldId = resaleHoldIdRef.current;
-
-            if (!resaleHoldId) {
-               return;
-            }
-
-            releaseResaleHoldKeepalive(resaleHoldId);
-            resaleHoldIdRef.current = null;
-            return;
-         }
-
-         releasePendingTicketSeatHoldsKeepalive();
-      };
-
-      window.addEventListener('pagehide', handlePageHide);
-
       return () => {
-         window.removeEventListener('pagehide', handlePageHide);
          isMountedRef.current = false;
       };
    }, [locationState, navigate]);

--- a/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
@@ -10,7 +10,7 @@ import {
    type PaymentResponse,
    type TicketCheckoutRequest,
 } from '@/pages/tickets/api/paymentApi';
-import { isMockSeatHoldId, releaseSeatReservation, releaseSeatReservationKeepalive } from '@/entities/seat-hold/api/seatHoldApi';
+import { releaseSeatReservation, releaseSeatReservationKeepalive } from '@/entities/seat-hold/api/seatHoldApi';
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 import { ApiError } from '@/shared/api/client';
@@ -45,9 +45,7 @@ const releasePendingTicketSeatHolds = async () => {
    }
 
    const releaseResults = await Promise.allSettled(
-      seatHolds
-         .filter((seatHold) => !isMockSeatHoldId(seatHold.holdId))
-         .map((seatHold) => releaseSeatReservation(seatHold.holdId)),
+      seatHolds.map((seatHold) => releaseSeatReservation(seatHold.holdId)),
    );
    const failedReleaseCount = releaseResults.filter((result) => result.status === 'rejected').length;
 
@@ -69,11 +67,9 @@ const releasePendingTicketSeatHoldsKeepalive = () => {
       return;
    }
 
-   seatHolds
-      .filter((seatHold) => !isMockSeatHoldId(seatHold.holdId))
-      .forEach((seatHold) => {
+   seatHolds.forEach((seatHold) => {
       releaseSeatReservationKeepalive(seatHold.holdId);
-      });
+   });
 
    useSeatHoldStore.getState().clearSeatHolds();
    useSeatSelectionStore.getState().clearAllSelections();

--- a/src/pages/tickets/ui/payment/ResellPaymentPage.tsx
+++ b/src/pages/tickets/ui/payment/ResellPaymentPage.tsx
@@ -32,9 +32,6 @@ const MOCK_GAME = {
    dateTime: '3.21 (토) 오후 18:30',
 };
 
-const SUPPORTED_PAYMENT_METHODS: PaymentMethod[] = ['card', 'bank'];
-const UNSUPPORTED_PAYMENT_METHOD_MESSAGE = '아직 지원하지 않는 결제수단입니다.';
-
 const MOCK_RESALE_ENTRY = {
    buyerId: '8df84c70-833e-4374-85ad-fa52f92f939e',
    listingId: '2df84c70-833e-4374-85ad-fa52f92f939e',
@@ -121,15 +118,6 @@ export default function ResellPaymentPage() {
    const totalPayment = resaleEntry.totalAmount;
    const ticketPrice = Math.max(totalPayment - fee, 0);
 
-   const handleSelectPaymentMethod = (method: PaymentMethod) => {
-      if (!SUPPORTED_PAYMENT_METHODS.includes(method)) {
-         window.alert(UNSUPPORTED_PAYMENT_METHOD_MESSAGE);
-         return;
-      }
-
-      setPaymentMethod(method);
-   };
-
    const handlePay = () => {
       if (!resolvedBuyerId) {
          window.alert('구매자 정보를 확인할 수 없습니다. 다시 로그인한 뒤 시도해 주세요.');
@@ -210,7 +198,7 @@ export default function ResellPaymentPage() {
                         <DiscountCard />
 
                         {/* 결제 방법 */}
-                        <PaymentMethodCard selected={paymentMethod} onSelect={handleSelectPaymentMethod} />
+                        <PaymentMethodCard selected={paymentMethod} onSelect={setPaymentMethod} />
 
                         {/* 현금영수증 (무통장 입금 선택 시에만 표시) */}
                         {paymentMethod === 'bank' && (

--- a/src/pages/tickets/ui/payment/TicketPaymentPage.tsx
+++ b/src/pages/tickets/ui/payment/TicketPaymentPage.tsx
@@ -44,9 +44,6 @@ const MOCK_GAME = {
    dateTime: '3.21 (토) 오후 18:30',
 };
 
-const SUPPORTED_PAYMENT_METHODS: PaymentMethod[] = ['card', 'bank'];
-const UNSUPPORTED_PAYMENT_METHOD_MESSAGE = '아직 지원하지 않는 결제수단입니다.';
-
 export default function TicketPaymentPage() {
    const navigate = useNavigate();
    const location = useLocation();
@@ -180,15 +177,6 @@ export default function TicketPaymentPage() {
       selectedSeats.length,
    ]);
 
-   const handleSelectPaymentMethod = (method: PaymentMethod) => {
-      if (!SUPPORTED_PAYMENT_METHODS.includes(method)) {
-         window.alert(UNSUPPORTED_PAYMENT_METHOD_MESSAGE);
-         return;
-      }
-
-      setPaymentMethod(method);
-   };
-
    const handlePay = () => {
       if (!bookingEntryState?.gameId || !bookingEntryState.queueTokenJti) {
          return;
@@ -287,7 +275,7 @@ export default function TicketPaymentPage() {
                         <DiscountCard />
 
                         {/* 결제 방법 */}
-                        <PaymentMethodCard selected={paymentMethod} onSelect={handleSelectPaymentMethod} />
+                        <PaymentMethodCard selected={paymentMethod} onSelect={setPaymentMethod} />
 
                         {/* 현금영수증 (무통장 입금 선택 시에만 표시) */}
                         {paymentMethod === 'bank' && (

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -107,11 +107,6 @@ const shouldSkipAuthorizationHeader = (config: AxiosRequestConfig) => {
       // 일부 배포 게이트웨이에서 Authorization 헤더가 붙으면 인증 리다이렉트 루프가 발생할 수 있어 제외한다.
       case pathname === "/api/v1/games/schedules":
       case /^\/api\/v1\/baseball-teams\/[^/]+$/.test(pathname):
-      // 좌석 등급/구역/좌석 메타 조회도 문서상 공개 조회 API다.
-      // dev 게이트웨이에서 일반 사용자 토큰이 붙으면 RBAC 403이 발생할 수 있어 인증 헤더를 제외한다.
-      case /^\/api\/v1\/stadium-seats\/stadiums\/[^/]+\/seat-sections$/.test(pathname):
-      case /^\/api\/v1\/stadium-seats\/stadiums\/[^/]+\/games\/[^/]+\/seat-grades$/.test(pathname):
-      case /^\/api\/v1\/seats\/seat-sections\/[^/]+\/seats$/.test(pathname):
         return true;
       default:
         return false;

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -107,6 +107,11 @@ const shouldSkipAuthorizationHeader = (config: AxiosRequestConfig) => {
       // 일부 배포 게이트웨이에서 Authorization 헤더가 붙으면 인증 리다이렉트 루프가 발생할 수 있어 제외한다.
       case pathname === "/api/v1/games/schedules":
       case /^\/api\/v1\/baseball-teams\/[^/]+$/.test(pathname):
+      // 좌석 등급/구역/좌석 메타 조회도 문서상 공개 조회 API다.
+      // dev 게이트웨이에서 일반 사용자 토큰이 붙으면 RBAC 403이 발생할 수 있어 인증 헤더를 제외한다.
+      case /^\/api\/v1\/stadium-seats\/stadiums\/[^/]+\/seat-sections$/.test(pathname):
+      case /^\/api\/v1\/stadium-seats\/stadiums\/[^/]+\/games\/[^/]+\/seat-grades$/.test(pathname):
+      case /^\/api\/v1\/seats\/seat-sections\/[^/]+\/seats$/.test(pathname):
         return true;
       default:
         return false;

--- a/src/shared/api/mocks/browser.disabled.ts
+++ b/src/shared/api/mocks/browser.disabled.ts
@@ -1,3 +1,0 @@
-export const worker = {
-   start: async () => undefined,
-};

--- a/src/shared/api/mocks/handlers/game.ts
+++ b/src/shared/api/mocks/handlers/game.ts
@@ -12,7 +12,7 @@ type MockGameSchedule = {
   homeTeamScore: number;
   awayTeamScore: number;
   gameResult: 'HOME_WIN' | 'AWAY_WIN' | 'DRAW';
-  ticketingStatus: 'AVAILABLE' | 'SCHEDULED' | 'TERMINATED';
+  ticketingStatus: 'AVAILABLE' | 'SCHEDULED' | 'CLOSED';
   ticketingOpenedAt: string;
 };
 
@@ -46,7 +46,7 @@ export const mockGameSchedules: MockGameSchedule[] = [
     homeTeamScore: 6,
     awayTeamScore: 2,
     gameResult: 'HOME_WIN',
-    ticketingStatus: 'TERMINATED',
+    ticketingStatus: 'CLOSED',
     ticketingOpenedAt: '2026-03-11 11:00',
   },
   {

--- a/src/shared/api/mocks/handlers/index.ts
+++ b/src/shared/api/mocks/handlers/index.ts
@@ -1,9 +1,7 @@
-import { authHandlers } from "./auth";
 import { gameHandlers } from "./game";
 import { paymentHandlers } from "./payment";
 
 export const handlers = [
-  ...authHandlers,
   ...gameHandlers,
   ...paymentHandlers,
 ];

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -636,32 +636,6 @@ export const paymentHandlers = [
       });
    }),
 
-   http.get('/api/v1/payments/orders/:orderId', async ({ params }) => {
-      const orderId = String(params.orderId);
-      const payment = Array.from(ticketPayments.values()).find((item) => item.orderId === orderId);
-
-      if (!payment) {
-         return buildErrorResponse('Payment not found.', 404);
-      }
-
-      return HttpResponse.json({
-         code: 'SUCCESS',
-         message: 'ok',
-         data: {
-            paymentId: payment.paymentId,
-            orderId: payment.orderId,
-            paymentType: 'PAYMENT',
-            paymentMethod: payment.paymentMethod,
-            paymentAmount: payment.paymentAmount,
-            pgProvider: 'MOCK',
-            pgTid: payment.pgTid,
-            paymentStatus: payment.paymentStatus,
-            paidAt: payment.paidAt,
-            failedReason: null,
-         },
-      });
-   }),
-
    http.post('/api/v1/resales/holds', async ({ request }) => {
       const body = (await request.json()) as {
          listingId?: string;
@@ -678,22 +652,6 @@ export const paymentHandlers = [
          listingId: body.listingId,
          queueTokenJti: body.queueTokenJti,
       });
-
-      return HttpResponse.json({
-         code: 'SUCCESS',
-         message: 'ok',
-         data: { holdId },
-      });
-   }),
-
-   http.patch('/api/v1/resales/holds/:holdId/release', async ({ params }) => {
-      const holdId = String(params.holdId);
-
-      if (!resaleHolds.has(holdId)) {
-         return buildErrorResponse('Resale hold not found.', 404);
-      }
-
-      resaleHolds.delete(holdId);
 
       return HttpResponse.json({
          code: 'SUCCESS',

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -91,7 +91,7 @@ type TicketPricingPolicy = {
       gradeId: string;
       ticketType: 'ADULT';
       dayType: 'WEEKDAY' | 'WEEKEND';
-      leagueType: 'EXHIBITION' | 'REGULAR' | 'POST_SEASON';
+      leagueType: 'PRE_SEASON' | 'REGULAR' | 'POSTSEASON';
       price: number;
    }>;
 };

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -383,7 +383,13 @@ const parseJsonBody = async <T>(request: Request): Promise<T | null> => {
 };
 
 const isTicketPaymentMethod = (paymentMethod: unknown) => {
-   return paymentMethod === 'CARD' || paymentMethod === 'ACCOUNT_TRANSFER';
+   return (
+      paymentMethod === 'CARD' ||
+      paymentMethod === 'KAKAO_PAY' ||
+      paymentMethod === 'NAVER_PAY' ||
+      paymentMethod === 'TOSS_PAY' ||
+      paymentMethod === 'ACCOUNT_TRANSFER'
+   );
 };
 
 const buildPageResponse = <T>(content: T[], page = 0, size = content.length || 10) => {

--- a/src/shared/config/runtime.ts
+++ b/src/shared/config/runtime.ts
@@ -1,4 +1,4 @@
 const mswFlag = (import.meta.env.PUBLIC_ENABLE_MSW ?? "").trim().toLowerCase();
 
 // 기본값은 실제 API 호출이다. 데모/목업이 필요할 때만 명시적으로 켠다.
-export const isMswEnabled = import.meta.env.DEV && mswFlag === "true";
+export const isMswEnabled = mswFlag === "true";

--- a/src/shared/types/game.ts
+++ b/src/shared/types/game.ts
@@ -28,7 +28,6 @@ export interface GameScheduleResponse {
    homeTeamId: string;
    awayTeamId: string;
    stadiumId: string;
-   queueTokenJti?: string;
    gameStatus: ApiGameStatus;
    homeTeamScore: number;
    awayTeamScore: number;

--- a/src/shared/types/game.ts
+++ b/src/shared/types/game.ts
@@ -19,7 +19,7 @@ export type ApiTicketingStatus =
 
 export type ApiGameResult = 'NONE' | 'HOME_WIN' | 'AWAY_WIN' | 'DRAW' | 'CANCELLED';
 
-export type ApiLeagueType = 'EXHIBITION' | 'REGULAR' | 'POST_SEASON';
+export type ApiLeagueType = 'PRE_SEASON' | 'REGULAR' | 'POSTSEASON';
 
 export interface GameScheduleResponse {
    gameId: string;

--- a/src/shared/ui/booking-guide-dialog.tsx
+++ b/src/shared/ui/booking-guide-dialog.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/shared/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 
 type BookingGuideDialogProps = {
   open: boolean;
@@ -21,9 +21,6 @@ function BookingGuideDialog({ open, onOpenChange, onConfirm }: BookingGuideDialo
           <DialogTitle align="center" className="text-[18px] font-bold leading-[1.55]">
             예매안내
           </DialogTitle>
-          <DialogDescription className="sr-only" align="center">
-            예매 진행 전에 확인해야 할 주요 유의사항을 안내하는 대화상자입니다.
-          </DialogDescription>
         </DialogHeader>
 
         <div className="px-5 pb-5">

--- a/src/shared/ui/drawer.tsx
+++ b/src/shared/ui/drawer.tsx
@@ -86,8 +86,6 @@ function DrawerContent({
    defaultHeight = 320,
    minHeight = 180,
    maxHeight = 560,
-   title = '하단 시트',
-   description = '추가 옵션을 확인하고 선택할 수 있는 하단 시트입니다.',
    ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
    showOverlay?: boolean;
@@ -97,8 +95,6 @@ function DrawerContent({
    defaultHeight?: number;
    minHeight?: number;
    maxHeight?: number;
-   title?: string;
-   description?: string;
 }) {
    const { open, setOpen } = useDrawerContext();
    const touchStartYRef = React.useRef<number | null>(null);
@@ -185,8 +181,6 @@ function DrawerContent({
             }}
             {...props}
          >
-            <DialogPrimitive.Title className="sr-only">{title}</DialogPrimitive.Title>
-            <DialogPrimitive.Description className="sr-only">{description}</DialogPrimitive.Description>
             {showHandle ? (
                <div
                   className={cn('flex justify-center pt-[10px]', resizable ? 'touch-none cursor-row-resize' : '')}


### PR DESCRIPTION
 ## #️⃣ 관련 이슈
  - #177
  - #115
  - #114

  <br/>

  ## 🔎 개요
  `feature/ticket-book-api` 브랜치에서 이슈 번호 #177 버그가 발생 시점 이전의 커밋으로 롤백

  <br/>

  ## 📋 작업 내용
  - 예매 결제 플로우 관련 최신 API 스펙 반영 코드 롤백
  - 경기 일정 예매 상태 enum 및 가격 정책 관련 변경 롤백
  - 좌석 상태 조회/매핑/sectionId 해석 보정 로직 롤백
  - 좌석 hold 조기 해제 방지, queueTokenJti 보존, 좌석 조회 인증 복구 관련 변경 롤백
  - mock seat hold 분리 및 관련 mock 핸들러 변경 롤백
  - 작업 과정에서 추가했던 사용자 프로필 조회 관련 파일 제거
  - 다른 작성자의 디자인/마이페이지 변경사항은 제외하고 유지