### PR TITLE
[feat] 리셀 목록/예매 API 연결 및 좌석 처리 정합성 보완

### DIFF
--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -299,6 +299,14 @@ const mapResellStatus = (ticketStatus: TicketStatus): ReselStatus => {
   }
 };
 
+const closeTicketStatusForUnavailableGame = (ticketStatus: TicketStatus, gameStatus: GameStatus): TicketStatus => {
+  if (gameStatus !== '예정') {
+    return '매진';
+  }
+
+  return ticketStatus;
+};
+
 const resolveVenueNameFromGame = (game: GameScheduleResponse, homeTeamName: string) => {
   const stadiumById = STADIUM_REFERENCES[game.stadiumId];
 
@@ -337,7 +345,7 @@ const normalizeScheduleGame = (game: GameScheduleResponse): NormalizedScheduleGa
   const gameDateTime = date && time ? new Date(`${date}T${time}`) : null;
   const status: GameStatus = (apiStatus !== '종료' && gameDateTime && gameDateTime < new Date()) ? '종료' : apiStatus;
 
-  const ticket = mapTicketStatus(game.ticketingStatus);
+  const ticket = closeTicketStatusForUnavailableGame(mapTicketStatus(game.ticketingStatus), status);
   const fallbackHomeName = game.homeTeamDisplayName ?? game.homeTeamName ?? game.homeTeamCode ?? game.homeTeamId;
   const fallbackAwayName = game.awayTeamDisplayName ?? game.awayTeamName ?? game.awayTeamCode ?? game.awayTeamId;
 
@@ -383,7 +391,9 @@ export const mapGamesToDaySchedules = (games: NormalizedScheduleGame[]): DaySche
       gameId: game.id,
       homeTeamId: game.homeTeamId,
       awayTeamId: game.awayTeamId,
+      serverHomeTeamId: game.serverHomeTeamId,
       stadiumId: game.stadiumId,
+      leagueType: game.leagueType,
       queueTokenJti: game.queueTokenJti,
       rawDate: game.date,
       time: game.time,

--- a/src/entities/resale/api/resaleApi.ts
+++ b/src/entities/resale/api/resaleApi.ts
@@ -24,6 +24,7 @@ export interface ResaleListingItem {
    gameTitle?: string;
    gameDate?: string;
    stadiumName?: string;
+   isPurchasable?: boolean;
 }
 
 export const fetchMyResaleListings = async (): Promise<ResaleListingItem[]> => {
@@ -61,4 +62,80 @@ export const fetchResaleListingDetail = async (listingId: string): Promise<Resal
 
 export const cancelResaleListing = async (listingId: string): Promise<void> => {
    await apiClient.post(`/api/v1/resales/listings/${listingId}/cancel`);
+};
+
+export interface ResaleGameListingCountResponse {
+   count: number;
+}
+
+export interface ResaleHistoryPointResponse {
+   transactionPrice: number;
+   confirmedAt: string;
+}
+
+export const fetchResaleListingCountByGame = async (gameId: string): Promise<number> => {
+   const response = await apiClient.get<ApiEnvelope<ResaleGameListingCountResponse>>(
+      `/api/v1/resales/listings/games/${encodeURIComponent(gameId)}/count`,
+   );
+
+   return response.data.data.count;
+};
+
+export const fetchResaleListingCountsByGames = async (gameIds: string[]): Promise<Map<string, number>> => {
+   const uniqueGameIds = [...new Set(gameIds.filter(Boolean))];
+
+   if (uniqueGameIds.length === 0) {
+      return new Map<string, number>();
+   }
+
+   const counts = await Promise.all(
+      uniqueGameIds.map(async gameId => [gameId, await fetchResaleListingCountByGame(gameId)] as const),
+   );
+
+   return new Map<string, number>(counts);
+};
+
+export const fetchResaleListingCountByGameAndSection = async (gameId: string, sectionId: string): Promise<number> => {
+   const response = await apiClient.get<ApiEnvelope<ResaleGameListingCountResponse>>(
+      `/api/v1/resales/listings/games/${encodeURIComponent(gameId)}/section/${encodeURIComponent(sectionId)}/count`,
+   );
+
+   return response.data.data.count;
+};
+
+export const fetchResaleListingCountsBySections = async (
+   gameId: string,
+   sectionIds: string[],
+): Promise<Map<string, number>> => {
+   const uniqueSectionIds = [...new Set(sectionIds.filter(Boolean))];
+
+   if (!gameId || uniqueSectionIds.length === 0) {
+      return new Map<string, number>();
+   }
+
+   const counts = await Promise.all(
+      uniqueSectionIds.map(async (sectionId) => [
+         sectionId,
+         await fetchResaleListingCountByGameAndSection(gameId, sectionId),
+      ] as const),
+   );
+
+   return new Map<string, number>(counts);
+};
+
+export const fetchResaleListings = async (): Promise<ResaleListingItem[]> => {
+   const response = await apiClient.get<ApiEnvelope<ResaleListingItem[]>>('/api/v1/resales/listings');
+   return response.data.data;
+};
+
+export const fetchResaleHistoryGraph = async (
+   gameId: string,
+   gradeId: string,
+   range: 'HOUR' | 'DAY' | 'WEEK',
+): Promise<ResaleHistoryPointResponse[]> => {
+   const response = await apiClient.get<ApiEnvelope<ResaleHistoryPointResponse[]>>(
+      `/api/v1/resales/histories/games/${encodeURIComponent(gameId)}/grade/${encodeURIComponent(gradeId)}/ranges/${range}/graph`,
+   );
+
+   return response.data.data;
 };

--- a/src/entities/resale/model/useResaleGameCounts.ts
+++ b/src/entities/resale/model/useResaleGameCounts.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchResaleListingCountsByGames } from '@/entities/resale/api/resaleApi';
+
+export const useResaleGameCounts = (gameIds: string[]) => {
+   const normalizedGameIds = [...new Set(gameIds.filter(Boolean))].sort();
+
+   return useQuery({
+      queryKey: ['resales', 'game-counts', normalizedGameIds],
+      queryFn: () => fetchResaleListingCountsByGames(normalizedGameIds),
+      enabled: normalizedGameIds.length > 0,
+      placeholderData: previousData => previousData,
+   });
+};

--- a/src/entities/resale/model/useResaleListingMarket.ts
+++ b/src/entities/resale/model/useResaleListingMarket.ts
@@ -1,0 +1,52 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchResaleListings } from '@/entities/resale/api/resaleApi';
+
+type ResaleGameMarketSnapshot = {
+   count: number;
+   minPrice: number;
+   maxPrice: number;
+};
+
+export const useResaleListingMarket = (gameIds: string[]) => {
+   const normalizedGameIds = [...new Set(gameIds.filter(Boolean))].sort();
+
+   return useQuery({
+      queryKey: ['resales', 'listing-market', normalizedGameIds],
+      enabled: normalizedGameIds.length > 0,
+      queryFn: async () => {
+         const listings = await fetchResaleListings();
+         const gameIdSet = new Set(normalizedGameIds);
+         const marketByGameId = new Map<string, ResaleGameMarketSnapshot>();
+
+         listings.forEach((listing) => {
+            if (
+               !gameIdSet.has(listing.gameId) ||
+               listing.listingStatus !== 'LISTING' ||
+               listing.availableStatus !== 'ENABLED' ||
+               !listing.isPurchasable
+            ) {
+               return;
+            }
+
+            const current = marketByGameId.get(listing.gameId);
+
+            if (!current) {
+               marketByGameId.set(listing.gameId, {
+                  count: 1,
+                  minPrice: listing.listingPrice,
+                  maxPrice: listing.listingPrice,
+               });
+               return;
+            }
+
+            current.count += 1;
+            current.minPrice = Math.min(current.minPrice, listing.listingPrice);
+            current.maxPrice = Math.max(current.maxPrice, listing.listingPrice);
+         });
+
+         return marketByGameId;
+      },
+      placeholderData: previousData => previousData,
+   });
+};

--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -346,26 +346,35 @@ export const mapSeatSectionsToZones = ({
    grades,
    teamId,
    pricingByGradeId,
+   remainingBySectionId,
 }: {
    sections: SeatSectionResponse[];
    grades: SeatGradeResponse[];
    teamId?: string;
    pricingByGradeId?: Map<string, number>;
+   remainingBySectionId?: Map<string, number>;
 }): ZoneItem[] => {
    const gradeById = Object.fromEntries(grades.map((grade) => [grade.seatGradeId, grade]));
    const aggregatedZones = new Map<string, ZoneItem>();
    const aggregatedZoneGradeIds = new Map<string, Set<string>>();
+   const aggregatedZoneSectionIds = new Map<string, Set<string>>();
    const unmatchedZones: ZoneItem[] = [];
 
    sections.forEach((section) => {
       const matchedZone = resolveZoneTemplate(teamId, section.sectionCode);
       const grade = gradeById[section.gradeId];
+      const remainingCount = remainingBySectionId?.get(section.sectionId) ?? grade?.availableSeatCount ?? section.capacity;
+
       if (matchedZone) {
          const existingZone = aggregatedZones.get(matchedZone.id);
          const zoneGradeIds = aggregatedZoneGradeIds.get(matchedZone.id) ?? new Set<string>();
+         const zoneSectionIds = aggregatedZoneSectionIds.get(matchedZone.id) ?? new Set<string>();
          const shouldAddGradeAvailability = Boolean(grade && !zoneGradeIds.has(section.gradeId));
+
          zoneGradeIds.add(section.gradeId);
+         zoneSectionIds.add(section.sectionId);
          aggregatedZoneGradeIds.set(matchedZone.id, zoneGradeIds);
+         aggregatedZoneSectionIds.set(matchedZone.id, zoneSectionIds);
 
          if (existingZone) {
             aggregatedZones.set(matchedZone.id, {
@@ -375,9 +384,13 @@ export const mapSeatSectionsToZones = ({
                   gradeIds: zoneGradeIds,
                   pricingByGradeId: pricingByGradeId ?? new Map<string, number>(),
                }),
-               remaining: shouldAddGradeAvailability
-                  ? existingZone.remaining + grade.availableSeatCount
-                  : existingZone.remaining,
+               remaining: remainingBySectionId
+                  ? existingZone.remaining + remainingCount
+                  : shouldAddGradeAvailability
+                     ? existingZone.remaining + (grade?.availableSeatCount ?? section.capacity)
+                     : existingZone.remaining,
+               sectionIds: [...zoneSectionIds],
+               gradeIds: [...zoneGradeIds],
             });
             return;
          }
@@ -389,8 +402,10 @@ export const mapSeatSectionsToZones = ({
                gradeIds: zoneGradeIds,
                pricingByGradeId: pricingByGradeId ?? new Map<string, number>(),
             }),
-            remaining: grade?.availableSeatCount ?? section.capacity,
+            remaining: remainingCount,
             color: grade?.displayColorHex ?? matchedZone.color ?? DEFAULT_ZONE_COLOR,
+            sectionIds: [...zoneSectionIds],
+            gradeIds: [...zoneGradeIds],
          });
          return;
       }
@@ -404,10 +419,12 @@ export const mapSeatSectionsToZones = ({
             gradeIds: [section.gradeId],
             pricingByGradeId: pricingByGradeId ?? new Map<string, number>(),
          }),
-         remaining: grade?.availableSeatCount ?? section.capacity,
+         remaining: remainingCount,
          color: grade?.displayColorHex ?? DEFAULT_ZONE_COLOR,
          hotspot: [],
          sectionCode: section.sectionCode,
+         sectionIds: [section.sectionId],
+         gradeIds: [section.gradeId],
       } satisfies ZoneItem);
    });
 
@@ -439,6 +456,8 @@ export const mergeBookingZones = ({
          price: apiZone.price,
          remaining: apiZone.remaining,
          color: apiZone.color,
+         sectionIds: apiZone.sectionIds,
+         gradeIds: apiZone.gradeIds,
       } satisfies ZoneItem;
    });
 };

--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -21,6 +21,7 @@ export type SeatSectionResponse = {
 
 export type SeatResponse = {
    seatId: string;
+   apiSeatId: string;
    sectionId: string;
    rowName: string;
    seatNum: number;
@@ -81,17 +82,21 @@ const toOptionalFiniteNumber = (value: unknown) => {
 };
 
 const normalizeSeatResponse = (seat: RawSeatResponse): SeatResponse | null => {
-   const seatId = isNonEmptyString(seat.seatId) ? seat.seatId : isNonEmptyString(seat.id) ? seat.id : undefined;
+   const rawSeatId = isNonEmptyString(seat.seatId) ? seat.seatId : undefined;
+   const rawId = isNonEmptyString(seat.id) ? seat.id : undefined;
+   const seatId = rawSeatId ?? rawId;
+   const apiSeatId = rawId ?? rawSeatId;
    const sectionId = isNonEmptyString(seat.sectionId) ? seat.sectionId : undefined;
    const rowName = isNonEmptyString(seat.rowName) ? seat.rowName : isNonEmptyString(seat.row) ? seat.row : undefined;
    const seatNum = toOptionalFiniteNumber(seat.seatNum) ?? toOptionalFiniteNumber(seat.seatNumber);
 
-   if (!seatId || !sectionId || !rowName || seatNum === undefined) {
+   if (!seatId || !apiSeatId || !sectionId || !rowName || seatNum === undefined) {
       return null;
    }
 
    return {
       seatId,
+      apiSeatId,
       sectionId,
       rowName,
       seatNum,
@@ -500,16 +505,18 @@ export const mapApiSeatsToSeatItems = ({
 
    return seats.map((seat) => {
       const rowIndex = rowIndexByName[seat.rowName] ?? 0;
+      const status = statusBySeatId[seat.apiSeatId] ?? statusBySeatId[seat.seatId];
 
       return {
          id: seat.seatId,
+         apiSeatId: seat.apiSeatId,
          zoneId: sectionId,
          block: sectionCode,
          rowLabel: `${seat.rowName}열`,
          seatNumber: seat.seatNum,
          x: API_BLOCK_OFFSET_X + (seat.seatNum - 1) * SEAT_STEP,
          y: API_BLOCK_OFFSET_Y + rowIndex * SEAT_STEP,
-         status: toSeatStatus(statusBySeatId[seat.seatId], seat.available),
+         status: toSeatStatus(status, seat.available),
       } satisfies SeatItem;
    });
 };

--- a/src/pages/books/model/resellData.ts
+++ b/src/pages/books/model/resellData.ts
@@ -1,4 +1,4 @@
-import type { SeatItem, ZoneItem } from './types';
+import type { ZoneItem } from './types';
 
 export type ResellTradeRange = 'minute' | 'day';
 
@@ -30,6 +30,11 @@ export type ResellListingItem = {
    isPurchasable: boolean;
 };
 
+export type ResellGraphPoint = {
+   transactionPrice: number;
+   confirmedAt: string;
+};
+
 export type ResellZoneInsights = {
    changeAmount: number;
    changeRate: number;
@@ -42,114 +47,112 @@ export type ResellZoneInsights = {
    listings: ResellListingItem[];
 };
 
-const minuteLabels = ['14:00', '14:45', '15:30', '16:15', '17:00', '17:45', '18:30'];
-const dayLabels = ['03/14', '03/15', '03/16', '03/17', '03/18', '03/19', '03/20'];
-const minuteOccurredAt = [
-   '2026-03-20T14:00:00+09:00',
-   '2026-03-20T14:45:00+09:00',
-   '2026-03-20T15:30:00+09:00',
-   '2026-03-20T16:15:00+09:00',
-   '2026-03-20T17:00:00+09:00',
-   '2026-03-20T17:45:00+09:00',
-   '2026-03-20T18:30:00+09:00',
-];
-const dayOccurredAt = [
-   '2026-03-14T18:00:00+09:00',
-   '2026-03-15T18:00:00+09:00',
-   '2026-03-16T18:00:00+09:00',
-   '2026-03-17T18:00:00+09:00',
-   '2026-03-18T18:00:00+09:00',
-   '2026-03-19T18:00:00+09:00',
-   '2026-03-20T18:00:00+09:00',
-];
+const minuteLabelFormatter = new Intl.DateTimeFormat('ko-KR', {
+   hour: '2-digit',
+   minute: '2-digit',
+   hour12: false,
+   timeZone: 'Asia/Seoul',
+});
 
-const formatSeatInfo = (zone: ZoneItem, seat: SeatItem) => `${zone.name} ${seat.rowLabel} ${seat.seatNumber}번`;
+const dayLabelFormatter = new Intl.DateTimeFormat('ko-KR', {
+   month: '2-digit',
+   day: '2-digit',
+   timeZone: 'Asia/Seoul',
+});
 
-const formatSeatLabel = (zone: ZoneItem, seat: SeatItem) => `${zone.sectionCode}구역 ${seat.rowLabel} ${seat.seatNumber}번`;
+const sortGraphPointsByTime = (left: ResellGraphPoint, right: ResellGraphPoint) =>
+   new Date(left.confirmedAt).getTime() - new Date(right.confirmedAt).getTime();
 
-const createPricePoints = (labels: string[], prices: number[], occurredAtList: string[]): PricePoint[] => {
-   return labels.map((time, index) => ({
-      time,
-      price: prices[index] ?? prices[prices.length - 1] ?? 0,
-      occurredAt: occurredAtList[index] ?? occurredAtList[occurredAtList.length - 1] ?? '',
-   }));
-};
+const createPricePointsFromGraph = (points: ResellGraphPoint[], range: ResellTradeRange): PricePoint[] => {
+   const sortedPoints = [...points].sort(sortGraphPointsByTime);
 
-const createListingPrice = (zonePrice: number, seat: SeatItem, index: number) => {
-   const basePrice = Math.max(zonePrice, 10000);
-   const rowPremium = Math.max(0, 6 - Math.min(6, Number.parseInt(seat.rowLabel, 10) || 6)) * 1000;
-   const seatPremium = (seat.seatNumber % 5) * 500;
-
-   return basePrice + rowPremium + seatPremium + index * 500;
-};
-
-export function getResellZoneInsights({
-   zone,
-   seats,
-}: {
-   zone: ZoneItem;
-   seats: SeatItem[];
-}): ResellZoneInsights {
-   const listedSeats = seats
-      .filter((seat) => seat.status === 'available')
-      .sort(
-         (left, right) =>
-            left.block.localeCompare(right.block, 'ko-KR', { numeric: true, sensitivity: 'base' }) ||
-            left.rowLabel.localeCompare(right.rowLabel, 'ko-KR', { numeric: true, sensitivity: 'base' }) ||
-            left.seatNumber - right.seatNumber,
-      )
-      .slice(0, 8);
-
-   const listings = listedSeats.map((seat, index) => {
-      const listingPrice = createListingPrice(zone.price, seat, index);
-      const totalBuyerFee = 2000;
-      const totalSellerFee = Math.max(1000, Math.round(listingPrice * 0.05 / 1000) * 1000);
+   return sortedPoints.map((point) => {
+      const confirmedAt = new Date(point.confirmedAt);
 
       return {
-         listingId: `listing-${seat.id}`,
-         sellerId: `seller-${zone.id}-${index + 1}`,
-         seatId: seat.id,
-         seatInfo: formatSeatInfo(zone, seat),
-         seatLabel: formatSeatLabel(zone, seat),
-         listingPrice,
-         totalAmount: listingPrice + totalBuyerFee,
-         totalBuyerFee,
-         totalSellerFee,
-         settlementAmount: Math.max(0, listingPrice - totalSellerFee),
-         listedAt: `2026-03-20T0${Math.min(index, 9)}:00:00.000Z`,
-         isPurchasable: true,
-      } satisfies ResellListingItem;
+         time: range === 'minute' ? minuteLabelFormatter.format(confirmedAt) : dayLabelFormatter.format(confirmedAt).replace('. ', '/').replace('.', ''),
+         price: point.transactionPrice,
+         occurredAt: point.confirmedAt,
+      };
    });
+};
 
-   const previousClose = Math.max(zone.price, 10000);
-   const recentTrade = listings[0]?.listingPrice ?? previousClose;
+const toRelativeTradeTime = (value: string) => {
+   const now = Date.now();
+   const target = new Date(value).getTime();
+
+   if (Number.isNaN(target)) {
+      return value;
+   }
+
+   const diffMinutes = Math.max(0, Math.floor((now - target) / (1000 * 60)));
+
+   if (diffMinutes < 1) {
+      return '방금 전';
+   }
+
+   if (diffMinutes < 60) {
+      return `${diffMinutes}분 전`;
+   }
+
+   const diffHours = Math.floor(diffMinutes / 60);
+
+   if (diffHours < 24) {
+      return `${diffHours}시간 전`;
+   }
+
+   const date = new Date(target);
+   const month = String(date.getMonth() + 1).padStart(2, '0');
+   const day = String(date.getDate()).padStart(2, '0');
+   const hours = String(date.getHours()).padStart(2, '0');
+   const minutes = String(date.getMinutes()).padStart(2, '0');
+
+   return `${month}/${day} ${hours}:${minutes}`;
+};
+
+const createTradeHistoryFromGraph = (zone: ZoneItem, points: ResellGraphPoint[]): TradeHistoryItem[] => {
+   return [...points]
+      .sort((left, right) => new Date(right.confirmedAt).getTime() - new Date(left.confirmedAt).getTime())
+      .slice(0, 4)
+      .map((point, index) => ({
+         id: `${zone.id}-trade-${index}-${point.confirmedAt}`,
+         price: point.transactionPrice,
+         seatLabel: zone.name,
+         tradedAt: toRelativeTradeTime(point.confirmedAt),
+      }));
+};
+
+const getFallbackPrice = (zone: ZoneItem, listings: ResellListingItem[]) => {
+   return listings[0]?.listingPrice ?? Math.max(zone.price, 10000);
+};
+
+export const buildResellZoneInsightsFromApi = ({
+   zone,
+   listings,
+   minuteGraph,
+   dayGraph,
+}: {
+   zone: ZoneItem;
+   listings: ResellListingItem[];
+   minuteGraph: ResellGraphPoint[];
+   dayGraph: ResellGraphPoint[];
+}): ResellZoneInsights => {
+   const pricePointsByMinute = createPricePointsFromGraph(minuteGraph, 'minute');
+   const pricePointsByDay = createPricePointsFromGraph(dayGraph, 'day');
+   const fallbackPrice = getFallbackPrice(zone, listings);
+   const previousClose =
+      pricePointsByDay.length >= 2
+         ? pricePointsByDay[pricePointsByDay.length - 2]?.price ?? fallbackPrice
+         : pricePointsByDay[0]?.price ?? fallbackPrice;
+   const recentTrade =
+      pricePointsByMinute[pricePointsByMinute.length - 1]?.price ??
+      pricePointsByDay[pricePointsByDay.length - 1]?.price ??
+      listings[0]?.listingPrice ??
+      previousClose;
+   const dayPrices = pricePointsByDay.map((point) => point.price);
+   const dayLow = dayPrices.length > 0 ? Math.min(...dayPrices) : Math.min(previousClose, recentTrade);
+   const dayHigh = dayPrices.length > 0 ? Math.max(...dayPrices) : Math.max(previousClose, recentTrade);
    const changeAmount = recentTrade - previousClose;
-   const dayLow = Math.max(5000, previousClose - Math.round(previousClose * 0.3));
-   const dayHigh = Math.max(recentTrade, previousClose + Math.round(previousClose * 0.3));
-   const minutePrices = [
-      previousClose - 2000,
-      previousClose + 500,
-      previousClose + 3500,
-      previousClose + 6000,
-      previousClose + 4500,
-      previousClose + 8000,
-      previousClose + 7000,
-   ];
-   const dayPrices = [
-      previousClose - 3000,
-      previousClose - 1500,
-      previousClose + 500,
-      previousClose + 1500,
-      previousClose + 2800,
-      previousClose + 4200,
-      recentTrade,
-   ];
-   const tradeHistory = listings.slice(0, 4).map((listing, index) => ({
-      id: `${listing.listingId}-history`,
-      price: listing.listingPrice,
-      seatLabel: listing.seatLabel,
-      tradedAt: ['40분 전', '6시간 전', '03/07 14:23', '03/07 14:23'][index] ?? '방금 전',
-   }));
 
    return {
       changeAmount,
@@ -159,10 +162,14 @@ export function getResellZoneInsights({
       dayLow,
       dayHigh,
       pricePointsByRange: {
-         minute: createPricePoints(minuteLabels, minutePrices, minuteOccurredAt),
-         day: createPricePoints(dayLabels, dayPrices, dayOccurredAt),
+         minute: pricePointsByMinute.length > 0
+            ? pricePointsByMinute
+            : [{ time: '00:00', price: recentTrade, occurredAt: new Date().toISOString() }],
+         day: pricePointsByDay.length > 0
+            ? pricePointsByDay
+            : [{ time: '00/00', price: recentTrade, occurredAt: new Date().toISOString() }],
       },
-      tradeHistory,
+      tradeHistory: createTradeHistoryFromGraph(zone, dayGraph.length > 0 ? dayGraph : minuteGraph),
       listings,
    };
-}
+};

--- a/src/pages/books/model/seatData.ts
+++ b/src/pages/books/model/seatData.ts
@@ -296,6 +296,7 @@ export const createSeatsForZone = (zone: ZoneItem): SeatItem[] => {
 
          return {
             id: `${zone.id}-${block.id}-${rowIndex + 1}-${colIndex + 1}`,
+            apiSeatId: `${zone.id}-${block.id}-${rowIndex + 1}-${colIndex + 1}`,
             zoneId: zone.id,
             block: block.id,
             rowLabel: `${rowIndex + 1}열`,

--- a/src/pages/books/model/types.ts
+++ b/src/pages/books/model/types.ts
@@ -11,6 +11,8 @@ export type ZoneItem = {
    color: string;
    hotspot: ZoneHotspot[];
    sectionCode: string;
+   sectionIds?: string[];
+   gradeIds?: string[];
 };
 
 export type SeatStatus = 'available' | 'selected' | 'held' | 'disabled';

--- a/src/pages/books/model/types.ts
+++ b/src/pages/books/model/types.ts
@@ -19,6 +19,7 @@ export type SeatStatus = 'available' | 'selected' | 'held' | 'disabled';
 
 export type SeatItem = {
    id: string;
+   apiSeatId: string;
    zoneId: string;
    block: string;
    rowLabel: string;

--- a/src/pages/books/model/useResellZoneInsights.ts
+++ b/src/pages/books/model/useResellZoneInsights.ts
@@ -1,0 +1,93 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import {
+   fetchResaleHistoryGraph,
+   fetchResaleListings,
+   type ResaleListingItem as ApiResaleListingItem,
+} from '@/entities/resale/api/resaleApi';
+import type { SeatItem, ZoneItem } from './types';
+import {
+   buildResellZoneInsightsFromApi,
+   type ResellListingItem,
+} from './resellData';
+
+const sortListings = (left: ApiResaleListingItem, right: ApiResaleListingItem) => {
+   const leftTime = new Date(left.listedAt).getTime();
+   const rightTime = new Date(right.listedAt).getTime();
+
+   if (leftTime !== rightTime) {
+      return rightTime - leftTime;
+   }
+
+   return left.listingPrice - right.listingPrice;
+};
+
+const buildSeatLabel = (zone: ZoneItem, seatInfo: string) => {
+   return seatInfo.includes(zone.sectionCode) ? seatInfo : `${zone.name} ${seatInfo}`.trim();
+};
+
+const toResellListingItem = (zone: ZoneItem, listing: ApiResaleListingItem): ResellListingItem => ({
+   listingId: listing.listingId,
+   sellerId: listing.sellerId,
+   seatId: listing.seatId,
+   seatInfo: listing.seatInfo,
+   seatLabel: buildSeatLabel(zone, listing.seatInfo),
+   listingPrice: listing.listingPrice,
+   totalAmount: listing.listingPrice + 2000,
+   totalBuyerFee: 2000,
+   totalSellerFee: Math.max(1000, Math.round(listing.listingPrice * 0.05 / 1000) * 1000),
+   settlementAmount: Math.max(0, listing.listingPrice - Math.max(1000, Math.round(listing.listingPrice * 0.05 / 1000) * 1000)),
+   listedAt: listing.listedAt,
+   isPurchasable: listing.isPurchasable,
+});
+
+export const useResellZoneInsights = ({
+   enabled,
+   gameId,
+   zone,
+   seats,
+}: {
+   enabled: boolean;
+   gameId?: string;
+   zone: ZoneItem;
+   seats: SeatItem[];
+}) => {
+   const seatIdSet = useMemo(() => new Set(seats.map((seat) => seat.id)), [seats]);
+   const primaryGradeId = zone.gradeIds?.[0];
+
+   return useQuery({
+      queryKey: ['resell-zone-insights', gameId, zone.id, primaryGradeId, [...seatIdSet].sort()],
+      enabled: enabled && Boolean(gameId),
+      queryFn: async () => {
+         if (!gameId) {
+            return null;
+         }
+
+         const [listings, minuteGraph, dayGraph] = await Promise.all([
+            fetchResaleListings(),
+            primaryGradeId ? fetchResaleHistoryGraph(gameId, primaryGradeId, 'HOUR') : Promise.resolve([]),
+            primaryGradeId ? fetchResaleHistoryGraph(gameId, primaryGradeId, 'DAY') : Promise.resolve([]),
+         ]);
+
+         const filteredListings = listings
+            .filter((listing) =>
+               listing.gameId === gameId &&
+               seatIdSet.has(listing.seatId) &&
+               listing.listingStatus === 'LISTING' &&
+               listing.availableStatus === 'ENABLED' &&
+               listing.isPurchasable,
+            )
+            .sort(sortListings)
+            .map((listing) => toResellListingItem(zone, listing));
+
+         return buildResellZoneInsightsFromApi({
+            zone,
+            listings: filteredListings,
+            minuteGraph,
+            dayGraph,
+         });
+      },
+      placeholderData: previousData => previousData,
+   });
+};

--- a/src/pages/books/model/useSeatHoldActions.ts
+++ b/src/pages/books/model/useSeatHoldActions.ts
@@ -120,6 +120,7 @@ export const useSeatHoldActions = (
          console.info('[SeatHoldDebug] request', {
             zoneId,
             seatId: seat.id,
+            apiSeatId: seat.apiSeatId,
             seatRowLabel: seat.rowLabel,
             seatNumber: seat.seatNumber,
             seatStatus: seat.status,
@@ -127,7 +128,7 @@ export const useSeatHoldActions = (
             bookingQueueTokenJti: bookingEntryState.queueTokenJti,
          });
 
-         const hold = await holdSeatReservation(seat.id, {
+         const hold = await holdSeatReservation(seat.apiSeatId, {
             gameId: bookingEntryState.gameId,
             queueTokenJti: bookingEntryState.queueTokenJti,
          });
@@ -146,6 +147,7 @@ export const useSeatHoldActions = (
          console.error('[SeatHoldDebug] request failed', {
             zoneId,
             seatId: seat.id,
+            apiSeatId: seat.apiSeatId,
             seatRowLabel: seat.rowLabel,
             seatNumber: seat.seatNumber,
             seatStatus: seat.status,

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -64,7 +64,7 @@ const getSectionSeatLayoutMeta = (seats: SeatResponse[]) => {
 };
 
 const toSeatItemStatus = (seat: SeatResponse, statuses: Record<string, string>): SeatItem['status'] => {
-   const status = statuses[seat.seatId]?.toUpperCase();
+   const status = (statuses[seat.apiSeatId] ?? statuses[seat.seatId])?.toUpperCase();
 
    if (!seat.available) {
       return 'disabled';
@@ -110,6 +110,7 @@ const createSeatItemsForLayout = (block: SeatBlock, zoneId: string, section: Api
 
       return {
          id: seat.seatId,
+         apiSeatId: seat.apiSeatId,
          block: block.label,
          rowLabel: `${seat.rowName}열`,
          seatNumber: seat.seatNum,
@@ -212,7 +213,7 @@ const fetchAggregatedSeatSections = async ({
 export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) => {
    const defaultSeatBlocks = useMemo(() => getSeatBlocks(zone), [zone]);
 
-   const { data, refetch } = useQuery({
+   const { data, isFetching, isLoading, refetch } = useQuery({
       queryKey: ['booking-seat-map', gameId, stadiumId, zone.id, zone.sectionCode],
       enabled: Boolean(gameId && zone.id && zone.sectionCode),
       queryFn: async (): Promise<SeatMapApiSnapshot | null> => {
@@ -296,6 +297,7 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
       seatBlocks: data?.seatBlocks ?? defaultSeatBlocks,
       apiSeatItems: data?.seatItems ?? [],
       hasApiSeatMap: Boolean(data),
+      isSeatMapLoading: isLoading || isFetching,
       refetchSeatMap: refetch,
    };
 };

--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { fetchResaleListingCountsBySections } from '@/entities/resale/api/resaleApi';
 
 import {
    fetchSeatGrades,
@@ -50,6 +51,7 @@ const BooksPage = () => {
    const { data: apiZones } = useQuery({
       queryKey: [
          'booking-zones',
+         bookingFlowMode,
          bookingEntryState?.stadiumId,
          bookingEntryState?.gameId,
          bookingEntryState?.serverHomeTeamId,
@@ -69,6 +71,13 @@ const BooksPage = () => {
             fetchSeatSections(bookingEntryState!.stadiumId!),
             fetchTicketPricingPolicy(bookingEntryState!.serverHomeTeamId!).catch(() => undefined),
          ]);
+         const remainingBySectionId =
+            bookingFlowMode === 'resell'
+               ? await fetchResaleListingCountsBySections(
+                    bookingEntryState!.gameId!,
+                    sections.map((section) => section.sectionId),
+                 )
+               : undefined;
          const pricingByGradeId = resolvePricingByGradeId({
             policy: pricingPolicy,
             gameDate: bookingEntryState?.gameDate,
@@ -80,6 +89,7 @@ const BooksPage = () => {
             grades,
             teamId: bookingEntryState?.homeTeamId,
             pricingByGradeId,
+            remainingBySectionId,
          });
       },
    });

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -3,12 +3,13 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 
 import { createSeatsForZone } from '@/pages/books/model/seatData';
-import { getResellZoneInsights, type ResellListingItem } from '@/pages/books/model/resellData';
+import type { ResellListingItem } from '@/pages/books/model/resellData';
 import { getSelectedSeatDetails } from '@/pages/books/model/selectedSeats';
 import { useSeatHoldActions } from '@/pages/books/model/useSeatHoldActions';
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 import { useSeatMapData } from '@/pages/books/model/useSeatMapData';
+import { useResellZoneInsights } from '@/pages/books/model/useResellZoneInsights';
 import { formatPrice, getBookingZones, getZoneOverviewImage, getStadiumName } from '@/pages/books/model/zoneData';
 import type { SeatItem } from '@/pages/books/model/types';
 import { getBookingFlowMode } from '@/shared/lib/booking-flow';
@@ -168,16 +169,13 @@ function SeatsPage() {
    );
 
    const selectedPrice = selectedSeats.reduce((total, item) => total + item.price, 0);
-   const resellInsights = useMemo(
-      () =>
-         isResellMode
-            ? getResellZoneInsights({
-                 zone,
-                 seats,
-              })
-            : null,
-      [isResellMode, seats, zone],
-   );
+   const resellInsightsQuery = useResellZoneInsights({
+      enabled: isResellMode,
+      gameId: bookingEntryState?.gameId,
+      zone,
+      seats,
+   });
+   const resellInsights = resellInsightsQuery.data ?? null;
    const resellListingBySeatId = useMemo(
       () => new Map((resellInsights?.listings ?? []).map((listing) => [listing.seatId, listing])),
       [resellInsights?.listings],
@@ -534,7 +532,15 @@ function SeatsPage() {
                      className="overflow-hidden border-none p-0 xl:hidden"
                   >
                      <div className="h-full overflow-y-auto">
-                        {isResellMode && resellInsights ? (
+                        {isResellMode && resellInsightsQuery.isPending ? (
+                           <div className="flex h-full min-h-[240px] items-center justify-center px-5 text-center text-body-1-medium text-muted-foreground">
+                              리셀 좌석 정보를 불러오는 중입니다.
+                           </div>
+                        ) : isResellMode && resellInsightsQuery.isError ? (
+                           <div className="flex h-full min-h-[240px] items-center justify-center px-5 text-center text-body-1-medium text-muted-foreground">
+                              리셀 좌석 정보를 불러오지 못했습니다.
+                           </div>
+                        ) : isResellMode && resellInsights ? (
                            <ResellZonePreviewSheet
                               insights={resellInsights}
                               zone={zone}
@@ -596,7 +602,11 @@ function SeatsPage() {
                </Drawer>
             </section>
 
-            {isResellMode && resellInsights ? (
+            {isResellMode && resellInsightsQuery.isPending ? (
+               <aside className="hidden w-full shrink-0 items-center justify-center border-l border-border-light bg-background px-5 text-center text-body-1-medium text-muted-foreground xl:flex xl:w-[420px]">
+                  리셀 좌석 정보를 불러오는 중입니다.
+               </aside>
+            ) : isResellMode && resellInsights ? (
                <ResellSeatSidebar
                   insights={resellInsights}
                   selectedListingId={selectedResellListing?.listingId}
@@ -606,6 +616,10 @@ function SeatsPage() {
                   onSelectListing={handleSelectResellListing}
                   onSubmit={handleProceedToPayment}
                />
+            ) : isResellMode && resellInsightsQuery.isError ? (
+               <aside className="hidden w-full shrink-0 items-center justify-center border-l border-border-light bg-background px-5 text-center text-body-1-medium text-muted-foreground xl:flex xl:w-[420px]">
+                  리셀 좌석 정보를 불러오지 못했습니다.
+               </aside>
             ) : (
                <aside className="hidden w-full shrink-0 flex-col border-l border-border-light bg-background xl:flex xl:w-[420px]">
                   <div className="relative h-[220px] overflow-hidden border-b border-border-light bg-[#e9ebee] px-5 py-4">

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -58,7 +58,7 @@ function SeatsPage() {
    const stadiumName = useMemo(() => getStadiumName(bookingEntryState?.homeTeamId), [bookingEntryState?.homeTeamId]);
 
    const initialSeats = useMemo(() => createSeatsForZone(zone), [zone]);
-   const { apiSeatItems, seatBlocks, hasApiSeatMap, refetchSeatMap } = useSeatMapData({
+   const { apiSeatItems, seatBlocks, hasApiSeatMap, isSeatMapLoading, refetchSeatMap } = useSeatMapData({
       gameId: bookingEntryState?.gameId,
       stadiumId: bookingEntryState?.stadiumId,
       zone,
@@ -169,6 +169,7 @@ function SeatsPage() {
    );
 
    const selectedPrice = selectedSeats.reduce((total, item) => total + item.price, 0);
+   const isSeatInteractionLocked = isSeatMapLoading && !hasApiSeatMap && Boolean(bookingEntryState?.gameId);
    const resellInsightsQuery = useResellZoneInsights({
       enabled: isResellMode,
       gameId: bookingEntryState?.gameId,
@@ -195,6 +196,13 @@ function SeatsPage() {
    const allSelectedSeatsAreHeld = selectedSeats.every((selectedSeat) => Boolean(holdsBySeatId[selectedSeat.seat.id]?.holdId));
    const bookingButtonLabel = isResellMode ? '예매하기' : `${selectedSeats.length}매 예매하기`;
    const displaySeats = useMemo(() => {
+      if (isSeatInteractionLocked) {
+         return seats.map((seat) => ({
+            ...seat,
+            status: 'disabled',
+         } satisfies SeatItem));
+      }
+
       if (!isResellMode) {
          return seats;
       }
@@ -209,7 +217,7 @@ function SeatsPage() {
             status: 'disabled',
          } satisfies SeatItem;
       });
-   }, [isResellMode, resellListingBySeatId, seats]);
+   }, [isResellMode, isSeatInteractionLocked, resellListingBySeatId, seats]);
 
    const handleProceedToPayment = () => {
       const botData = getBotReport();
@@ -353,6 +361,10 @@ function SeatsPage() {
    };
 
    const toggleSeat = (seat: SeatItem) => {
+      if (isSeatInteractionLocked) {
+         return;
+      }
+
       if (pendingSeatIds.includes(seat.id)) {
          return;
       }

--- a/src/pages/home/ui/FavoriteTeamMatchCard.tsx
+++ b/src/pages/home/ui/FavoriteTeamMatchCard.tsx
@@ -6,12 +6,15 @@ import { Link } from 'react-router-dom';
 import { teams } from '@/entities/team/model/teams';
 import type { Team } from '@/entities/team/model/types';
 import { getClosestMatch, getDDay, useGameSchedules } from '@/entities/game/model/schedule';
+import { useResaleGameCounts } from '@/entities/resale/model/useResaleGameCounts';
 import { Button } from '@/shared/ui/button';
 import { useBookingEntryFlow } from '@/shared/lib/use-booking-entry-flow';
 
 const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
    const { openBookingEntry, openResellEntry, bookingGuideDialog } = useBookingEntryFlow();
    const { data, isPending } = useGameSchedules();
+   const resaleGameIds = (data ?? []).map((game) => game.id);
+   const resaleCountsQuery = useResaleGameCounts(resaleGameIds);
    const match = getClosestMatch(data ?? [], team.id);
 
    /** 헤더 — 경기 없을 때도 공통 사용 */
@@ -77,12 +80,18 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
    const formattedDate = `${match.date.replace(/-/g, '.')} ${match.time}`;
    const awayTeamName = match.awayTeamFullName;
    const homeTeamName = match.homeTeamFullName;
+   const resaleCount = resaleCountsQuery.data?.get(match.id);
+   const canResellBook = match.resell === '리셀예매' && typeof resaleCount === 'number' && resaleCount > 0;
+   const resellButtonLabel = match.resell === '리셀예정' ? '리셀예정' : canResellBook ? '리셀예매' : '리셀매진';
 
    const handleBookingClick = () => {
       openBookingEntry({
          homeTeamId: match.homeTeamId,
+         serverHomeTeamId: match.serverHomeTeamId,
          gameId: match.id,
          stadiumId: match.stadiumId,
+         leagueType: match.leagueType,
+         gameDate: match.date,
          queueTokenJti: match.queueTokenJti,
          matchTitle: `${awayTeamName} vs ${homeTeamName}`,
          venue: match.venue,
@@ -91,14 +100,17 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
    };
 
    const handleResellClick = () => {
-      if (match.resell !== '리셀예매') {
+      if (!canResellBook) {
          return;
       }
 
       openResellEntry({
          homeTeamId: match.homeTeamId,
+         serverHomeTeamId: match.serverHomeTeamId,
          gameId: match.id,
          stadiumId: match.stadiumId,
+         leagueType: match.leagueType,
+         gameDate: match.date,
          queueTokenJti: match.queueTokenJti,
          matchTitle: `${awayTeamName} vs ${homeTeamName}`,
          venue: match.venue,
@@ -175,10 +187,10 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
                <Button
                   variant="secondary"
                   className="flex-1 max-w-[300px] h-[46px] text-[14px] font-bold rounded-[10px] tracking-[-0.15px]"
-                  disabled={match.resell !== '리셀예매'}
+                  disabled={!canResellBook}
                   onClick={handleResellClick}
                >
-                  리셀예매
+                  {resellButtonLabel}
                </Button>
             </div>
          </div>
@@ -250,10 +262,10 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
                   <Button
                      variant="secondary"
                      className="h-12 text-[16px] font-bold rounded-lg"
-                     disabled={match.resell !== '리셀예매'}
+                     disabled={!canResellBook}
                      onClick={handleResellClick}
                   >
-                     리셀예매
+                     {resellButtonLabel}
                   </Button>
                </div>
             </div>

--- a/src/pages/home/ui/GameSchedule.tsx
+++ b/src/pages/home/ui/GameSchedule.tsx
@@ -21,18 +21,7 @@ import WeekNavigator from './game-schedule/WeekNavigator';
 import { filterScheduleData } from './game-schedule/utils';
 import type { DaySchedule, ReselStatus } from './game-schedule/types';
 
-const getResellStatus = (rawDate: string | undefined, resaleCount: number | undefined, fallbackStatus: ReselStatus): ReselStatus => {
-   if (!rawDate) {
-      return fallbackStatus;
-   }
-
-   const now = new Date();
-   const resaleOpenTime = new Date(`${rawDate}T13:00:00`);
-
-   if (now < resaleOpenTime) {
-      return '리셀예정';
-   }
-
+const getResellStatus = (resaleCount: number | undefined, fallbackStatus: ReselStatus): ReselStatus => {
    if (typeof resaleCount === 'number') {
       return resaleCount > 0 ? '리셀예매' : '리셀매진';
    }
@@ -87,7 +76,7 @@ const GameSchedule = () => {
          ...day,
          games: day.games.map((game) => {
             const resaleCount = game.gameId ? resaleCountsQuery.data?.get(game.gameId) : undefined;
-            const resell = getResellStatus(game.rawDate, resaleCount, game.resell);
+            const resell = getResellStatus(resaleCount, game.resell);
 
             return {
                ...game,

--- a/src/pages/home/ui/GameSchedule.tsx
+++ b/src/pages/home/ui/GameSchedule.tsx
@@ -2,6 +2,7 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useGameSchedules, mapGamesToDaySchedules } from '@/entities/game/model/schedule';
+import { useResaleGameCounts } from '@/entities/resale/model/useResaleGameCounts';
 
 import {
    AVAILABLE_YEARS,
@@ -18,6 +19,26 @@ import ScheduleList from './game-schedule/ScheduleList';
 import TeamLogoNav from './game-schedule/TeamLogoNav';
 import WeekNavigator from './game-schedule/WeekNavigator';
 import { filterScheduleData } from './game-schedule/utils';
+import type { DaySchedule, ReselStatus } from './game-schedule/types';
+
+const getResellStatus = (rawDate: string | undefined, resaleCount: number | undefined, fallbackStatus: ReselStatus): ReselStatus => {
+   if (!rawDate) {
+      return fallbackStatus;
+   }
+
+   const now = new Date();
+   const resaleOpenTime = new Date(`${rawDate}T13:00:00`);
+
+   if (now < resaleOpenTime) {
+      return '리셀예정';
+   }
+
+   if (typeof resaleCount === 'number') {
+      return resaleCount > 0 ? '리셀예매' : '리셀매진';
+   }
+
+   return fallbackStatus;
+};
 
 const GameSchedule = () => {
    const navigate = useNavigate();
@@ -50,6 +71,8 @@ const GameSchedule = () => {
    })();
 
    const scheduleQuery = useGameSchedules(scheduleParams);
+   const resaleGameIds = useMemo(() => (scheduleQuery.data ?? []).map((game) => game.id), [scheduleQuery.data]);
+   const resaleCountsQuery = useResaleGameCounts(resaleGameIds);
 
    const scheduleData = useMemo(() => {
       const TARGET_TEAMS = ['kia', 'samsung'];
@@ -58,8 +81,22 @@ const GameSchedule = () => {
             TARGET_TEAMS.includes(game.homeTeamId ?? '') ||
             TARGET_TEAMS.includes(game.awayTeamId ?? ''),
       );
-      return mapGamesToDaySchedules(filtered);
-   }, [scheduleQuery.data]);
+      const daySchedules = mapGamesToDaySchedules(filtered);
+
+      return daySchedules.map((day): DaySchedule => ({
+         ...day,
+         games: day.games.map((game) => {
+            const resaleCount = game.gameId ? resaleCountsQuery.data?.get(game.gameId) : undefined;
+            const resell = getResellStatus(game.rawDate, resaleCount, game.resell);
+
+            return {
+               ...game,
+               resell,
+               reselInfo: resell === '리셀예정' ? '정식 예매 오픈\n2시간 후' : undefined,
+            };
+         }),
+      }));
+   }, [resaleCountsQuery.data, scheduleQuery.data]);
 
    const filteredData = useMemo(
       () =>
@@ -169,6 +206,10 @@ const GameSchedule = () => {
             ) : scheduleQuery.isError ? (
                <div className="rounded-[10px] border border-border bg-surface px-5 py-10 text-center text-body-1-medium text-muted-foreground">
                   경기 일정을 불러오지 못했습니다.
+               </div>
+            ) : resaleCountsQuery.isError ? (
+               <div className="rounded-[10px] border border-border bg-surface px-5 py-10 text-center text-body-1-medium text-muted-foreground">
+                  리셀 경기 정보를 불러오지 못했습니다.
                </div>
             ) : (
                <ScheduleList activeTab={activeTab} filteredData={filteredData} />

--- a/src/pages/home/ui/game-schedule/ScheduleList.tsx
+++ b/src/pages/home/ui/game-schedule/ScheduleList.tsx
@@ -173,16 +173,8 @@ function ActionButtons({
    onOpenBookingFlow: (game: GameRow) => void;
    onOpenResellFlow: (game: GameRow) => void;
 }) {
-   // rawDate(YYYY-MM-DD) 기준 오전 11시 → 예매, 오후 1시 → 리셀 전환
-   const now = new Date();
-   const saleOpenTime = game.rawDate ? new Date(`${game.rawDate}T11:00:00`) : null;
-   const resellOpenTime = game.rawDate ? new Date(`${game.rawDate}T13:00:00`) : null;
-   const saleNowOpen = saleOpenTime !== null && now >= saleOpenTime;
-   const resellNowOpen = resellOpenTime !== null && now >= resellOpenTime;
-
-   // API가 판매예정이라도 오전 11시 지났으면 예매하기로 전환
-   const effectiveTicket = (game.ticket === '판매예정' && saleNowOpen) ? '예매하기' : game.ticket;
-   const effectiveResell = (game.resell === '리셀예정' && resellNowOpen) ? '리셀예매' : game.resell;
+   const effectiveTicket = game.ticket;
+   const effectiveResell = game.resell;
 
    const canBook = effectiveTicket === '예매하기';
    const canResellBook = effectiveResell === '리셀예매';
@@ -319,8 +311,9 @@ function MobileGameRow({
 
    return (
       <div
+         style={{ zIndex: day.games.length - index }}
          className={cn(
-            'md:hidden border border-t-0 border-(--border-normal) px-[17px] pt-[16px] pb-[16px] flex flex-col gap-[12px]',
+            'relative md:hidden border border-t-0 border-(--border-normal) px-[17px] pt-[16px] pb-[16px] flex flex-col gap-[12px]',
             isLast && 'rounded-bl-[16px] rounded-br-[16px]',
             isEnded ? 'bg-[#f7f8f9]' : 'bg-background',
          )}
@@ -379,8 +372,9 @@ function DesktopGameRow({
 
    return (
       <div
+         style={{ zIndex: day.games.length - index }}
          className={cn(
-            'hidden md:flex border border-t-0 border-(--border-normal) px-[20px] py-[6px] items-center justify-between',
+            'relative hidden md:flex border border-t-0 border-(--border-normal) px-[20px] py-[6px] items-center justify-between',
             isLast && 'rounded-bl-[20px] rounded-br-[20px]',
             isEnded ? 'bg-[#f7f8f9]' : 'bg-background',
          )}
@@ -463,8 +457,11 @@ function ScheduleList({ activeTab, filteredData }: ScheduleListProps) {
 
       openBookingEntry({
          homeTeamId: game.homeTeamId ?? TEAM_IDS[game.home],
+         serverHomeTeamId: game.serverHomeTeamId,
          gameId: game.gameId,
          stadiumId: game.stadiumId,
+         leagueType: game.leagueType,
+         gameDate: game.rawDate,
          queueTokenJti: game.queueTokenJti,
          matchTitle: `${game.away} vs ${game.home}`,
          venue: game.venue,
@@ -482,8 +479,11 @@ function ScheduleList({ activeTab, filteredData }: ScheduleListProps) {
 
       openResellEntry({
          homeTeamId: game.homeTeamId ?? TEAM_IDS[game.home],
+         serverHomeTeamId: game.serverHomeTeamId,
          gameId: game.gameId,
          stadiumId: game.stadiumId,
+         leagueType: game.leagueType,
+         gameDate: game.rawDate,
          queueTokenJti: game.queueTokenJti,
          matchTitle: `${game.away} vs ${game.home}`,
          venue: game.venue,

--- a/src/pages/home/ui/game-schedule/types.ts
+++ b/src/pages/home/ui/game-schedule/types.ts
@@ -6,7 +6,9 @@ export type GameRow = {
    gameId?: string;
    homeTeamId?: string;
    awayTeamId?: string;
+   serverHomeTeamId?: string;
    stadiumId?: string;
+   leagueType?: import('@/shared/types/game').ApiLeagueType;
    queueTokenJti?: string;
    rawDate?: string; // YYYY-MM-DD — 시간 기반 상태 전환용
    time: string;

--- a/src/pages/tickets/ui/FilterSidebar.tsx
+++ b/src/pages/tickets/ui/FilterSidebar.tsx
@@ -18,6 +18,7 @@ import type { FilterState, TabType } from './types';
 interface FilterSidebarProps {
    /** 마지막으로 적용된 탭 (초기값 및 초기화 기준) */
    activeTab: TabType;
+   filters: FilterState;
    onApply: (filters: FilterState) => void;
    className?: string;
    /** 바텀시트 모드: 내부 너비 full + 버튼 우측 정렬 */
@@ -31,24 +32,35 @@ const venueOptions = VENUES.map(v => ({ value: v, label: v }));
 const inputBase =
    'bg-surface border border-border-light rounded-lg px-3 py-2 text-body-2-medium text-neutral-600 outline-none w-full';
 
-export function FilterSidebar({ activeTab, onApply, className, sheetMode = false }: FilterSidebarProps) {
+export function FilterSidebar({ activeTab, filters, onApply, className, sheetMode = false }: FilterSidebarProps) {
    // 로컬 탭 상태 — 조회하기 클릭 시에만 부모에 전파
-   const [localTab, setLocalTab] = useState<TabType>(activeTab);
+   const [localTab, setLocalTab] = useState<TabType>(filters.tab);
+   const [showUpcoming, setShowUpcoming] = useState(filters.showUpcoming);
+   const [showSoldOut, setShowSoldOut] = useState(filters.showSoldOut);
+   const [dateTime, setDateTime] = useState(filters.dateTime);
+   const [minPrice, setMinPrice] = useState(filters.minPrice);
+   const [maxPrice, setMaxPrice] = useState(filters.maxPrice);
+   const [venue, setVenue] = useState(filters.venue);
+   const [searchQuery, setSearchQuery] = useState(filters.searchQuery);
 
    // 외부에서 탭이 변경되면 (모바일 탭 클릭 등) 로컬 탭도 sync
    useEffect(() => {
       setLocalTab(activeTab);
    }, [activeTab]);
-   const [showUpcoming, setShowUpcoming] = useState(true);
-   const [showSoldOut, setShowSoldOut] = useState(true);
-   const [dateTime, setDateTime] = useState('');
-   const [minPrice, setMinPrice] = useState(0);
-   const [maxPrice, setMaxPrice] = useState(MAX_PRICE);
-   const [venue, setVenue] = useState('');
-   const [searchQuery, setSearchQuery] = useState('');
+
+   useEffect(() => {
+      setLocalTab(filters.tab);
+      setShowUpcoming(filters.showUpcoming);
+      setShowSoldOut(filters.showSoldOut);
+      setDateTime(filters.dateTime);
+      setMinPrice(filters.minPrice);
+      setMaxPrice(filters.maxPrice);
+      setVenue(filters.venue);
+      setSearchQuery(filters.searchQuery);
+   }, [filters]);
 
    const handleReset = () => {
-      setLocalTab(activeTab); // 마지막 적용 탭으로 복원
+      setLocalTab(activeTab);
       setShowUpcoming(true);
       setShowSoldOut(true);
       setDateTime('');

--- a/src/pages/tickets/ui/GameCard.tsx
+++ b/src/pages/tickets/ui/GameCard.tsx
@@ -50,15 +50,8 @@ function getButtonConfig(status: string, activeTab: TabType): { label: string; i
 }
 
 export function GameCard({ game, activeTab, onActionClick }: GameCardProps) {
-   // game.date(YYYY-MM-DD) 기준 오전 11시→예매, 오후 1시→리셀 전환
-   const now = new Date();
-   const saleOpenTime = new Date(`${game.date}T11:00:00`);
-   const resellOpenTime = new Date(`${game.date}T13:00:00`);
-
-   const effectiveBookingStatus =
-      game.bookingStatus === '판매 예정' && now >= saleOpenTime ? '예매 가능' : game.bookingStatus;
-   const effectiveResellStatus =
-      game.resellStatus === '리셀 예정' && now >= resellOpenTime ? '리셀 가능' : game.resellStatus;
+   const effectiveBookingStatus = game.bookingStatus;
+   const effectiveResellStatus = game.resellStatus;
 
    const status = activeTab === '예매' ? effectiveBookingStatus : effectiveResellStatus;
    const { label: buttonLabel, isActive } = getButtonConfig(status, activeTab);

--- a/src/pages/tickets/ui/GameCard.tsx
+++ b/src/pages/tickets/ui/GameCard.tsx
@@ -64,6 +64,7 @@ export function GameCard({ game, activeTab, onActionClick }: GameCardProps) {
    const { label: buttonLabel, isActive } = getButtonConfig(status, activeTab);
    const showPrice = game.minPrice > 0;
    const formattedDateTime = formatBookingCardDateTime(game.dateTime);
+   const remainingSeats = activeTab === '리셀' ? (game.resellRemainingSeats ?? 0) : game.remainingSeats;
 
    const [, gameMonth, gameDay] = game.date.split('-').map(Number);
 
@@ -101,7 +102,7 @@ export function GameCard({ game, activeTab, onActionClick }: GameCardProps) {
             <div className="flex items-center gap-2 h-5">
                <Ticket className="size-5 text-primary shrink-0" />
                <span className="text-body-2-bold text-primary whitespace-nowrap">
-                  잔여 {game.remainingSeats.toLocaleString('ko-KR')}석
+                  잔여 {remainingSeats.toLocaleString('ko-KR')}석
                </span>
             </div>
          </div>

--- a/src/pages/tickets/ui/TicketsPage.tsx
+++ b/src/pages/tickets/ui/TicketsPage.tsx
@@ -1,18 +1,33 @@
-// src/pages/tickets/ui/TicketsPage.tsx
-
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQueries } from '@tanstack/react-query';
 import { RefreshCw, SlidersHorizontal } from 'lucide-react';
 
 import { useGameSchedules } from '@/entities/game/model/schedule';
+import { useResaleGameCounts } from '@/entities/resale/model/useResaleGameCounts';
+import { useResaleListingMarket } from '@/entities/resale/model/useResaleListingMarket';
+import { fetchSeatGrades } from '@/pages/books/api/bookingApi';
 import { useBookingEntryFlow } from '@/shared/lib/use-booking-entry-flow';
 import { Button } from '@/shared/ui/button';
 import { FilterSidebar } from './FilterSidebar';
 import { GameCard } from './GameCard';
 import { MAX_PRICE } from './constants';
-import type { FilterState, GameItem, TabType } from './types';
+import type { FilterState, GameItem, ResellStatus, TabType } from './types';
+
+const DEFAULT_FILTERS: FilterState = {
+   tab: '예매',
+   showUpcoming: true,
+   showSoldOut: true,
+   dateTime: '',
+   minPrice: 0,
+   maxPrice: MAX_PRICE,
+   venue: '',
+   searchQuery: '',
+};
+
+const PAGE_SIZE = 12;
 
 function applyFilters(games: GameItem[], filters: FilterState, activeTab: TabType): GameItem[] {
-   return games.filter(game => {
+   return games.filter((game) => {
       const status = activeTab === '예매' ? game.bookingStatus : game.resellStatus;
 
       if (!filters.showUpcoming && (status === '판매 예정' || status === '리셀 예정')) return false;
@@ -22,7 +37,6 @@ function applyFilters(games: GameItem[], filters: FilterState, activeTab: TabTyp
       if (filters.minPrice > 0 && game.minPrice < filters.minPrice) return false;
       if (filters.maxPrice < MAX_PRICE && game.maxPrice > filters.maxPrice) return false;
 
-      // 공백 제거 후 2자 이상일 때만 검색 적용
       const trimmedQuery = filters.searchQuery.trim();
       if (trimmedQuery.length >= 2) {
          const q = trimmedQuery.toLowerCase();
@@ -34,53 +48,156 @@ function applyFilters(games: GameItem[], filters: FilterState, activeTab: TabTyp
    });
 }
 
+function getResellStatus(date: string, resaleCount: number | undefined, fallbackStatus: ResellStatus): ResellStatus {
+   const now = new Date();
+   const resaleOpenTime = new Date(`${date}T13:00:00`);
+
+   if (now < resaleOpenTime) {
+      return '리셀 예정';
+   }
+
+   if (typeof resaleCount === 'number') {
+      return resaleCount > 0 ? '리셀 가능' : '매진';
+   }
+
+   return fallbackStatus;
+}
+
 const TicketsPage = () => {
    const { openBookingEntry, openResellEntry, bookingGuideDialog } = useBookingEntryFlow();
    const scheduleQuery = useGameSchedules();
-   const [activeTab, setActiveTab] = useState<TabType>('예매');
+   const resaleGameIds = useMemo(() => (scheduleQuery.data ?? []).map((game) => game.id), [scheduleQuery.data]);
+   const resaleCountsQuery = useResaleGameCounts(resaleGameIds);
+   const resaleListingMarketQuery = useResaleListingMarket(resaleGameIds);
    const [isFilterOpen, setIsFilterOpen] = useState(false);
-   /** 마지막 조회 시 적용된 검색어 (결과 없음 문구 분기용) */
-   const [appliedSearchQuery, setAppliedSearchQuery] = useState('');
-   /** 조회하기 버튼이 한 번이라도 눌렸는지 여부 */
-   const [hasApplied, setHasApplied] = useState(false);
+   const [appliedFilters, setAppliedFilters] = useState<FilterState>(DEFAULT_FILTERS);
+   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+   const loadMoreTriggerRef = useRef<HTMLDivElement | null>(null);
+   const activeTab: TabType = appliedFilters.tab;
 
-   const allGames = useMemo<GameItem[]>(() => {
-      return (scheduleQuery.data ?? []).map(game => ({
-         id: game.id,
-         homeTeamId: game.homeTeamId ?? '',
-         serverHomeTeamId: game.serverHomeTeamId,
-         stadiumId: game.stadiumId,
-         queueTokenJti: game.queueTokenJti,
-         leagueType: game.leagueType,
-         awayTeam: game.awayTeamFullName,
-         homeTeam: game.homeTeamFullName,
-         date: game.date,
-         dateTime: `${game.date.replace(/-/g, '.')} ${game.time}`,
-         venue: game.venue,
-         remainingSeats: game.ticket === '매진' ? 0 : 999,
-         minPrice: 0,
-         maxPrice: 0,
-         bookingStatus: game.ticket === '예매하기' ? '예매 가능' : game.ticket === '판매예정' ? '판매 예정' : '매진',
-         resellStatus: game.resell === '리셀예매' ? '리셀 가능' : game.resell === '리셀예정' ? '리셀 예정' : '매진',
-      }));
-   }, [scheduleQuery.data]);
+   const baseGames = useMemo<GameItem[]>(() => {
+      const resaleCountByGameId = resaleCountsQuery.data;
+      const resaleMarketByGameId = resaleListingMarketQuery.data;
 
-   const [displayedGames, setDisplayedGames] = useState<GameItem[]>([]);
+      return (scheduleQuery.data ?? [])
+         .filter((game) => game.status === '예정')
+         .map((game) => {
+            const fallbackResellStatus =
+               game.resell === '리셀예매' ? '리셀 가능' : game.resell === '리셀예정' ? '리셀 예정' : '매진';
+            const resaleMarket = resaleMarketByGameId?.get(game.id);
+            const resaleCount = resaleCountByGameId?.get(game.id) ?? resaleMarket?.count;
 
-   /** 필터 사이드바에서 조회하기 클릭 시 */
+            return {
+               id: game.id,
+               homeTeamId: game.homeTeamId ?? '',
+               serverHomeTeamId: game.serverHomeTeamId,
+               stadiumId: game.stadiumId,
+               queueTokenJti: game.queueTokenJti,
+               leagueType: game.leagueType,
+               awayTeam: game.awayTeamFullName,
+               homeTeam: game.homeTeamFullName,
+               date: game.date,
+               dateTime: `${game.date.replace(/-/g, '.')} ${game.time}`,
+               venue: game.venue,
+               remainingSeats: game.ticket === '매진' ? 0 : 999,
+               resellRemainingSeats: resaleCount ?? (fallbackResellStatus === '리셀 가능' ? 999 : 0),
+               minPrice: resaleMarket?.minPrice ?? 0,
+               maxPrice: resaleMarket?.maxPrice ?? 0,
+               bookingStatus: game.ticket === '예매하기' ? '예매 가능' : game.ticket === '판매예정' ? '판매 예정' : '매진',
+               resellStatus: getResellStatus(game.date, resaleCount, fallbackResellStatus),
+            };
+         });
+   }, [resaleCountsQuery.data, resaleListingMarketQuery.data, scheduleQuery.data]);
+
+   const filteredGames = useMemo(
+      () => applyFilters(baseGames, appliedFilters, activeTab),
+      [activeTab, appliedFilters, baseGames],
+   );
+   const visibleGames = useMemo(() => filteredGames.slice(0, visibleCount), [filteredGames, visibleCount]);
+   const hasMoreGames = visibleCount < filteredGames.length;
+
+   const seatGradeQueries = useQueries({
+      queries: visibleGames.map((game) => ({
+         queryKey: ['ticket-remaining-seat-grades', game.id, game.stadiumId],
+         enabled: Boolean(game.id && game.stadiumId),
+         queryFn: async () => {
+            const grades = await fetchSeatGrades(game.id, game.stadiumId!);
+
+            return grades.reduce((total, grade) => total + grade.availableSeatCount, 0);
+         },
+      })),
+   });
+
+   const remainingSeatsByGameId = useMemo(() => {
+      return new Map(
+         visibleGames.flatMap((game, index) => {
+            const remainingSeats = seatGradeQueries[index]?.data;
+
+            if (typeof remainingSeats !== 'number') {
+               return [];
+            }
+
+            return [[game.id, remainingSeats] as const];
+         }),
+      );
+   }, [seatGradeQueries, visibleGames]);
+
+   const gamesToRender = useMemo(
+      () =>
+         visibleGames.map((game) => ({
+            ...game,
+            remainingSeats: remainingSeatsByGameId.get(game.id) ?? game.remainingSeats,
+         })),
+      [remainingSeatsByGameId, visibleGames],
+   );
+   const appliedSearchQuery = appliedFilters.searchQuery.trim();
+
+   useEffect(() => {
+      setVisibleCount(PAGE_SIZE);
+   }, [appliedFilters]);
+
+   useEffect(() => {
+      const trigger = loadMoreTriggerRef.current;
+
+      if (!trigger || !hasMoreGames) {
+         return;
+      }
+
+      const observer = new IntersectionObserver(
+         (entries) => {
+            const [entry] = entries;
+
+            if (!entry?.isIntersecting) {
+               return;
+            }
+
+            setVisibleCount((current) => Math.min(current + PAGE_SIZE, filteredGames.length));
+         },
+         {
+            rootMargin: '240px 0px',
+         },
+      );
+
+      observer.observe(trigger);
+
+      return () => {
+         observer.disconnect();
+      };
+   }, [filteredGames.length, hasMoreGames]);
+
    const handleApply = (filters: FilterState) => {
-      setHasApplied(true);
-      setActiveTab(filters.tab);
-      setAppliedSearchQuery(filters.searchQuery.trim());
-      setDisplayedGames(applyFilters(allGames, filters, filters.tab));
+      setAppliedFilters(filters);
       setIsFilterOpen(false);
    };
 
    const handleRefresh = () => {
-      setHasApplied(false);
-      setActiveTab('예매');
-      setAppliedSearchQuery('');
-      setDisplayedGames([]);
+      setAppliedFilters(DEFAULT_FILTERS);
+      void scheduleQuery.refetch();
+      void resaleCountsQuery.refetch();
+      void resaleListingMarketQuery.refetch();
+      seatGradeQueries.forEach((query) => {
+         void query.refetch();
+      });
    };
 
    const handleGameActionClick = (game: GameItem) => {
@@ -114,19 +231,14 @@ const TicketsPage = () => {
       });
    };
 
-   const gamesToRender = hasApplied ? displayedGames : allGames;
-
    return (
-      <div className="w-full px-4 py-12.5 pb-30 flex justify-center bg-white min-h-screen">
-         <div className="flex items-start justify-between max-w-300 w-full gap-5 h-200">
-            {/* 데스크톱 필터 사이드바 */}
+      <div className="w-full px-4 py-12.5 pb-30 flex justify-center bg-white h-full">
+         <div className="flex items-start justify-between max-w-300 w-full gap-5 ">
             <div className="hidden md:block">
                <FilterSidebar activeTab={activeTab} onApply={handleApply} />
             </div>
 
-            {/* 경기 목록 */}
-            <div className="flex flex-1 flex-col gap-5 max-w-210  h-full min-w-0">
-               {/* 모바일 전용: 예매/리셀 토글 + 필터 버튼 */}
+            <div className="flex flex-1 flex-col gap-5 max-w-210 min-w-0 h-full">
                <div className="md:hidden flex flex-col gap-3">
                   <Button
                      variant="tertiary"
@@ -139,11 +251,10 @@ const TicketsPage = () => {
                   </Button>
                </div>
 
-               {/* 헤더 */}
                <div className="flex items-center justify-between h-8 ">
                   <h2 className="text-heading-1-bold text-foreground">경기일정</h2>
                   <div className="flex items-center gap-4">
-                     <span className="text-body-2-regular text-muted-foreground">총 {gamesToRender.length}개</span>
+                     <span className="text-body-2-regular text-muted-foreground">총 {filteredGames.length}개</span>
                      <button
                         onClick={handleRefresh}
                         className="flex items-center gap-2 bg-background border border-border rounded-lg px-3 py-1 text-body-2-medium text-foreground h-8 hover:bg-surface transition-colors"
@@ -154,21 +265,26 @@ const TicketsPage = () => {
                   </div>
                </div>
 
-               {/* 게임 카드 목록 */}
                <div className="flex flex-col gap-4 h-full">
                   {scheduleQuery.isError ? (
                      <div className="flex items-center justify-center py-20 bg-surface rounded-[14px] h-full text-body-1-medium text-muted-foreground">
                         경기 일정을 불러오지 못했습니다.
                      </div>
+                  ) : activeTab === '리셀' && resaleCountsQuery.isError ? (
+                     <div className="flex items-center justify-center h-full bg-surface rounded-[14px] text-body-1-medium text-muted-foreground">
+                        리셀 경기 정보를 불러오지 못했습니다.
+                     </div>
+                  ) : activeTab === '리셀' && resaleListingMarketQuery.isError ? (
+                     <div className="flex items-center justify-center h-full bg-surface rounded-[14px] text-body-1-medium text-muted-foreground">
+                        리셀 목록 정보를 불러오지 못했습니다.
+                     </div>
                   ) : gamesToRender.length > 0 ? (
-                     gamesToRender.map(game => (
-                        <GameCard
-                           key={game.id}
-                           game={game}
-                           activeTab={activeTab}
-                           onActionClick={handleGameActionClick}
-                        />
-                     ))
+                     <>
+                        {gamesToRender.map((game) => (
+                           <GameCard key={game.id} game={game} activeTab={activeTab} onActionClick={handleGameActionClick} />
+                        ))}
+                        {hasMoreGames ? <div ref={loadMoreTriggerRef} className="h-1 w-full" aria-hidden="true" /> : null}
+                     </>
                   ) : (
                      <div className="flex items-center justify-center py-20 bg-surface rounded-[14px] h-full text-body-1-medium text-muted-foreground">
                         {appliedSearchQuery.length >= 2 ? '해당 데이터가 없습니다' : '조건에 맞는 경기가 없습니다.'}
@@ -179,7 +295,6 @@ const TicketsPage = () => {
          </div>
          {bookingGuideDialog}
 
-         {/* 모바일 필터 바텀시트 */}
          {isFilterOpen && (
             <div className="md:hidden fixed inset-0 z-50 w-full">
                <div className="absolute inset-0 bg-black/50 w-full" onClick={() => setIsFilterOpen(false)} />

--- a/src/pages/tickets/ui/TicketsPage.tsx
+++ b/src/pages/tickets/ui/TicketsPage.tsx
@@ -48,14 +48,7 @@ function applyFilters(games: GameItem[], filters: FilterState, activeTab: TabTyp
    });
 }
 
-function getResellStatus(date: string, resaleCount: number | undefined, fallbackStatus: ResellStatus): ResellStatus {
-   const now = new Date();
-   const resaleOpenTime = new Date(`${date}T13:00:00`);
-
-   if (now < resaleOpenTime) {
-      return '리셀 예정';
-   }
-
+function getResellStatus(resaleCount: number | undefined, fallbackStatus: ResellStatus): ResellStatus {
    if (typeof resaleCount === 'number') {
       return resaleCount > 0 ? '리셀 가능' : '매진';
    }
@@ -104,7 +97,7 @@ const TicketsPage = () => {
                minPrice: resaleMarket?.minPrice ?? 0,
                maxPrice: resaleMarket?.maxPrice ?? 0,
                bookingStatus: game.ticket === '예매하기' ? '예매 가능' : game.ticket === '판매예정' ? '판매 예정' : '매진',
-               resellStatus: getResellStatus(game.date, resaleCount, fallbackResellStatus),
+               resellStatus: getResellStatus(resaleCount, fallbackResellStatus),
             };
          });
    }, [resaleCountsQuery.data, resaleListingMarketQuery.data, scheduleQuery.data]);
@@ -235,7 +228,7 @@ const TicketsPage = () => {
       <div className="w-full px-4 py-12.5 pb-30 flex justify-center bg-white h-full">
          <div className="flex items-start justify-between max-w-300 w-full gap-5 ">
             <div className="hidden md:block">
-               <FilterSidebar activeTab={activeTab} onApply={handleApply} />
+               <FilterSidebar activeTab={activeTab} filters={appliedFilters} onApply={handleApply} />
             </div>
 
             <div className="flex flex-1 flex-col gap-5 max-w-210 min-w-0 h-full">
@@ -301,6 +294,7 @@ const TicketsPage = () => {
                <div className="absolute bottom-0 left-0 right-0 bg-white rounded-t-[14px] p-6 max-h-[90vh] overflow-y-auto w-full">
                   <FilterSidebar
                      activeTab={activeTab}
+                     filters={appliedFilters}
                      onApply={handleApply}
                      className="border-0 rounded-none p-0 self-auto w-full"
                      sheetMode

--- a/src/pages/tickets/ui/types.ts
+++ b/src/pages/tickets/ui/types.ts
@@ -19,6 +19,7 @@ export interface GameItem {
    dateTime: string;  // 표시용 "2026.07.03 (금) 18:30"
    venue: string;
    remainingSeats: number;
+   resellRemainingSeats?: number;
    minPrice: number;
    maxPrice: number;
    bookingStatus: BookingStatus;

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -263,6 +263,13 @@ const seatGradesByStadium: Record<string, SeatGrade[]> = {
          displayColorHex: '#2FA84F',
          availableSeatCount: 20,
       },
+      {
+         seatGradeId: 'grade-samsung-outfield',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '외야 지정석',
+         displayColorHex: '#3AA66B',
+         availableSeatCount: 218,
+      },
    ],
 };
 
@@ -300,9 +307,11 @@ const pricingPoliciesByTeamId: Record<string, TicketPricingPolicy> = {
          { priceId: 'price-samsung-first-base-weekday', gradeId: 'grade-samsung-first-base-infield', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 22000 },
          { priceId: 'price-samsung-blue-weekday', gradeId: 'grade-samsung-blue-zone', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 20000 },
          { priceId: 'price-samsung-wheelchair-weekday', gradeId: 'grade-samsung-wheelchair', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 10000 },
+         { priceId: 'price-samsung-outfield-weekday', gradeId: 'grade-samsung-outfield', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 12000 },
          { priceId: 'price-samsung-first-base-weekend', gradeId: 'grade-samsung-first-base-infield', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 24000 },
          { priceId: 'price-samsung-blue-weekend', gradeId: 'grade-samsung-blue-zone', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 22000 },
          { priceId: 'price-samsung-wheelchair-weekend', gradeId: 'grade-samsung-wheelchair', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 10000 },
+         { priceId: 'price-samsung-outfield-weekend', gradeId: 'grade-samsung-outfield', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 14000 },
       ],
    },
 };
@@ -400,6 +409,20 @@ const seatSectionsByStadium: Record<string, SeatSection[]> = {
          codes: ['W-1', 'W-2'],
          capacity: 12,
       }),
+      {
+         sectionId: 'section-samsung-lf-1',
+         gradeId: 'grade-samsung-outfield',
+         stadiumId: 'stadium-samsung-lions-park',
+         sectionCode: 'LF-1',
+         capacity: 220,
+      },
+      {
+         sectionId: 'section-samsung-rf-1',
+         gradeId: 'grade-samsung-outfield',
+         stadiumId: 'stadium-samsung-lions-park',
+         sectionCode: 'RF-1',
+         capacity: 220,
+      },
    ],
 };
 

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -550,6 +550,136 @@ const buildSectionSeats = (sectionId: string) => {
    );
 };
 
+const createMockResaleListings = ({
+   gameId,
+   seatIds,
+   sellerId,
+   listedAtSeed,
+}: {
+   gameId: string;
+   seatIds: string[];
+   sellerId: string;
+   listedAtSeed: string;
+}) => {
+   const matchedGame = mockGameSchedules.find((game) => game.gameId === gameId);
+
+   if (!matchedGame) {
+      return [];
+   }
+
+   return seatIds.map((seatId, index) => {
+      const sectionId = extractSectionId(seatId);
+      const section = Object.values(seatSectionsByStadium).flat().find((item) => item.sectionId === sectionId);
+      const seatPrice = resolveSeatPrice(matchedGame.homeTeamId, seatId, matchedGame.startAt);
+      const listingPrice = seatPrice + (index % 4) * 1000 + 2000;
+      const minPrice = Math.max(1000, listingPrice - 4000);
+      const maxPrice = listingPrice + 6000;
+
+      return {
+         listingId: `listing-${gameId}-${index + 1}`,
+         ticketId: `ticket-${gameId}-${index + 1}`,
+         sellerId,
+         gameId,
+         seatId,
+         gradeId: section?.gradeId ?? 'grade-unknown',
+         seatInfo: buildSeatInfoStr(seatId),
+         dailyBasePrice: seatPrice,
+         listingPrice,
+         listingStatus: 'LISTING',
+         availableStatus: 'ENABLED',
+         lastTransactionPrice: Math.max(seatPrice, listingPrice - 2000),
+         listedAt: new Date(new Date(listedAtSeed).getTime() + index * 15 * 60 * 1000).toISOString(),
+         soldAt: undefined,
+         canceledAt: undefined,
+         isCancelable: true,
+         isPurchasable: true,
+         minPrice,
+         maxPrice,
+      };
+   });
+};
+
+const mockResaleListings = [
+   ...createMockResaleListings({
+      gameId: 'game-samsung-home-today',
+      sellerId: 'seller-samsung-001',
+      listedAtSeed: '2026-03-27T04:00:00.000Z',
+      seatIds: [
+         'section-samsung-1-6-A-1',
+         'section-samsung-1-6-A-2',
+         'section-samsung-1-6-B-1',
+         'section-samsung-1-6-B-2',
+         'section-samsung-1-7-A-3',
+         'section-samsung-1-7-A-4',
+         'section-samsung-1-7-B-3',
+         'section-samsung-3-1-A-1',
+      ],
+   }),
+   ...createMockResaleListings({
+      gameId: 'game-kia-home-tomorrow',
+      sellerId: 'seller-kia-001',
+      listedAtSeed: '2026-03-28T02:00:00.000Z',
+      seatIds: [
+         'section-stadium-kia-champions-field-104-A-1',
+         'section-stadium-kia-champions-field-104-A-2',
+         'section-stadium-kia-champions-field-105-B-1',
+         'section-stadium-kia-champions-field-108-A-1',
+         'section-stadium-kia-champions-field-108-B-1',
+         'section-stadium-kia-champions-field-118-A-1',
+      ],
+   }),
+   ...createMockResaleListings({
+      gameId: 'game-samsung-home-this-weekend',
+      sellerId: 'seller-samsung-002',
+      listedAtSeed: '2026-03-30T03:00:00.000Z',
+      seatIds: [
+         'section-samsung-1-6-C-1',
+         'section-samsung-1-6-C-2',
+         'section-samsung-1-7-C-1',
+         'section-samsung-1-7-C-2',
+         'section-samsung-3-1-B-1',
+         'section-samsung-3-1-B-2',
+      ],
+   }),
+   ...createMockResaleListings({
+      gameId: 'game-kia-home-two-weeks',
+      sellerId: 'seller-kia-002',
+      listedAtSeed: '2026-04-10T03:30:00.000Z',
+      seatIds: [
+         'section-stadium-kia-champions-field-519-A-1',
+         'section-stadium-kia-champions-field-520-A-1',
+         'section-stadium-kia-champions-field-521-B-1',
+      ],
+   }),
+];
+
+const mockResaleHistoryGraphByKey: Record<string, Array<{ transactionPrice: number; confirmedAt: string }>> = {
+   'game-samsung-home-today:grade-samsung-first-base-infield:HOUR': [
+      { transactionPrice: 22000, confirmedAt: '2026-03-27T05:00:00.000Z' },
+      { transactionPrice: 23000, confirmedAt: '2026-03-27T05:40:00.000Z' },
+      { transactionPrice: 24000, confirmedAt: '2026-03-27T06:20:00.000Z' },
+      { transactionPrice: 25000, confirmedAt: '2026-03-27T07:00:00.000Z' },
+   ],
+   'game-samsung-home-today:grade-samsung-first-base-infield:DAY': [
+      { transactionPrice: 21000, confirmedAt: '2026-03-23T09:00:00.000Z' },
+      { transactionPrice: 22000, confirmedAt: '2026-03-24T09:00:00.000Z' },
+      { transactionPrice: 23000, confirmedAt: '2026-03-25T09:00:00.000Z' },
+      { transactionPrice: 24000, confirmedAt: '2026-03-26T09:00:00.000Z' },
+      { transactionPrice: 25000, confirmedAt: '2026-03-27T09:00:00.000Z' },
+   ],
+   'game-kia-home-tomorrow:grade-kia-k5:HOUR': [
+      { transactionPrice: 13000, confirmedAt: '2026-03-28T04:00:00.000Z' },
+      { transactionPrice: 14000, confirmedAt: '2026-03-28T05:10:00.000Z' },
+      { transactionPrice: 15000, confirmedAt: '2026-03-28T06:20:00.000Z' },
+   ],
+   'game-kia-home-tomorrow:grade-kia-k5:DAY': [
+      { transactionPrice: 12000, confirmedAt: '2026-03-24T09:00:00.000Z' },
+      { transactionPrice: 13000, confirmedAt: '2026-03-25T09:00:00.000Z' },
+      { transactionPrice: 14000, confirmedAt: '2026-03-26T09:00:00.000Z' },
+      { transactionPrice: 15000, confirmedAt: '2026-03-27T09:00:00.000Z' },
+   ],
+};
+
 const buildErrorResponse = (message: string, status = 400) => {
    return HttpResponse.json({ message }, { status });
 };
@@ -615,11 +745,53 @@ const buildPageResponse = <T>(content: T[], page = 0, size = content.length || 1
 };
 
 export const paymentHandlers = [
+   http.get('/api/v1/resales/listings/games/:gameId/count', async ({ params }) => {
+      const gameId = String(params.gameId);
+      const gameExists = mockGameSchedules.some((game) => game.gameId === gameId);
+
+      if (!gameExists) {
+         return HttpResponse.json(
+            {
+               code: 'NOT_FOUND',
+               message: 'game not found',
+               data: null,
+            },
+            { status: 404 },
+         );
+      }
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            count: mockResaleListings.filter((listing) => listing.gameId === gameId && listing.isPurchasable).length,
+         },
+      });
+   }),
+
+   http.get('/api/v1/resales/listings/games/:gameId/section/:sectionId/count', async ({ params }) => {
+      const gameId = String(params.gameId);
+      const sectionId = String(params.sectionId);
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            count: mockResaleListings.filter(
+               (listing) =>
+                  listing.gameId === gameId &&
+                  listing.isPurchasable &&
+                  extractSectionId(listing.seatId) === sectionId,
+            ).length,
+         },
+      });
+   }),
+
    http.get('/api/v1/resales/listings', async () => {
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
-         data: [],
+         data: mockResaleListings,
       });
    }),
 
@@ -637,6 +809,19 @@ export const paymentHandlers = [
             isCancelable: true,
             isPurchasable: true,
          },
+      });
+   }),
+
+   http.get('/api/v1/resales/histories/games/:gameId/grade/:gradeId/ranges/:range/graph', async ({ params }) => {
+      const gameId = String(params.gameId);
+      const gradeId = String(params.gradeId);
+      const range = String(params.range).toUpperCase();
+      const key = `${gameId}:${gradeId}:${range}`;
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: mockResaleHistoryGraphByKey[key] ?? [],
       });
    }),
 
@@ -972,6 +1157,7 @@ export const paymentHandlers = [
          data: { holdId },
       });
    }),
+
 
    http.post('/api/v1/resales/orders', async ({ request }) => {
       const body = (await request.json()) as {

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -1158,6 +1158,21 @@ export const paymentHandlers = [
       });
    }),
 
+   http.patch('/api/v1/resales/holds/:holdId/release', async ({ params }) => {
+      const holdId = String(params.holdId);
+
+      if (!resaleHolds.has(holdId)) {
+         return buildErrorResponse(`Resale hold not found: ${holdId}`, 404);
+      }
+
+      resaleHolds.delete(holdId);
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: { holdId },
+      });
+   }),
 
    http.post('/api/v1/resales/orders', async ({ request }) => {
       const body = (await request.json()) as {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #199
- #200
  <br/>

  ## 🔎 개요
리셀 목록 및 예매 페이지에 공개 API 연결을 반영하고, 좌석 hold/경기 목록 처리의 정합성을 보완. 추가로 삼성 라이온즈 파크 외야석 mock 데이터를 확장해 예매 플로우에서 사용하는 좌석/가격/구역 정보를 보강

  <br/>

  ## 📋 작업 내용

  - 리셀 목록 및 예매 페이지에 공개 API 연동을 추가했습니다.
  - 리셀 관련 API/상태 모델을 정리하고, 리셀 게임 수 집계 및 리셀 마켓 조회 로직을 보완했습니다.
  - 예매 페이지에서 좌석 맵/리셀 존 인사이트/좌석 hold 액션 연결을 개선했습니다.
  - 좌석 hold 요청 시 사용하는 seat id 처리와 초기 로딩 동작을 보완했습니다.
  - 경기 목록의 상태값 및 필터 정합성을 수정해 홈/티켓 페이지의 목록 표시 일관성을 맞췄습니다.
  - 리셀 hold release mock 동작을 복원했습니다.
  - 삼성 라이온즈 파크 mock 데이터에 외야석 등급, 가격, 구역 정보를 추가했습니다.
  - 머지 과정에서 충돌이 발생한 `src/shared/api/mocks/handlers/payment.ts`를 정리해 기존 휠체어석 데이터와 신규 외야석 데이터가 함께 유지되도록 반영했습니다.