### PR TITLE
[bug] 티켓 목록 통신 최적화 및 예매 플로우 정합성 수정

### DIFF
--- a/src/app/providers/router/ui/BookingFlowStateGuard.tsx
+++ b/src/app/providers/router/ui/BookingFlowStateGuard.tsx
@@ -1,17 +1,24 @@
 import { useEffect, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
+import { useBookingEntryStore } from '@/shared/lib/useBookingEntryStore';
 import { useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
 
 const isBookingFlowPath = (pathname: string) => pathname.startsWith('/books') || pathname.startsWith('/tickets');
+const requiresBookingEntry = (pathname: string) =>
+   pathname.startsWith('/books') || pathname === '/tickets/payment' || pathname === '/tickets/resell-payment';
 
 const BookingFlowStateGuard = () => {
+   const navigate = useNavigate();
    const { pathname } = useLocation();
    const previousPathnameRef = useRef<string | null>(null);
+   const bookingEntry = useBookingEntryStore((state) => state.entry);
 
    useEffect(() => {
       const previousPathname = previousPathnameRef.current;
       const isCurrentBookingFlow = isBookingFlowPath(pathname);
+      const requiresEntry = requiresBookingEntry(pathname);
       const selectedSeatCount = Object.values(useSeatSelectionStore.getState().zones).reduce(
          (count, zone) => count + zone.selectedSeatIds.length,
          0,
@@ -21,21 +28,34 @@ const BookingFlowStateGuard = () => {
          previousPathname,
          pathname,
          isCurrentBookingFlow,
+         requiresEntry,
+         hasBookingEntry: Boolean(bookingEntry),
          selectedSeatCount,
       });
 
+      if (requiresEntry && !bookingEntry) {
+         console.info('[BookingFlowStateGuard] booking entry missing, redirecting to home');
+         useSeatHoldStore.getState().clearSeatHolds();
+         useSeatSelectionStore.getState().clearAllSelections();
+         useBookingFlowTimerStore.getState().clearTimer();
+         navigate('/', { replace: true });
+         return;
+      }
+
       if (!isCurrentBookingFlow) {
          console.info('[BookingFlowStateGuard] booking flow exited, clearing seat selections and timer');
+         useSeatHoldStore.getState().clearSeatHolds();
          useSeatSelectionStore.getState().clearAllSelections();
          useBookingFlowTimerStore.getState().clearTimer();
       } else if (previousPathname && isBookingFlowPath(previousPathname) && !isCurrentBookingFlow) {
          console.info('[BookingFlowStateGuard] moved out of booking flow, clearing seat selections and timer');
+         useSeatHoldStore.getState().clearSeatHolds();
          useSeatSelectionStore.getState().clearAllSelections();
          useBookingFlowTimerStore.getState().clearTimer();
       }
 
       previousPathnameRef.current = pathname;
-   }, [pathname]);
+   }, [bookingEntry, navigate, pathname]);
 
    return null;
 };

--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -36,6 +36,7 @@ export type NormalizedScheduleGame = {
   reselInfo?: string;
   isToday: boolean;
   ticketingOpenedAt?: string;
+  ticketingEndAt?: string;
 };
 
 type TeamReference = {
@@ -245,10 +246,38 @@ const toDateLabel = (date: string) => {
   return `${month}월 ${day}일 (${DAY_LABELS[parsed.getDay()]})`;
 };
 
-/** 게임 날짜(YYYY-MM-DD) 기준 당일 11시 오픈 레이블 */
-const computeTicketOpenLabel = (date: string): string => {
-  const [, month, day] = date.split('-').map(Number);
-  return `${month}월 ${day}일\n오전 11시 오픈`;
+const parseScheduleBoundary = (value?: string) => {
+  if (!value?.trim()) {
+    return null;
+  }
+
+  const normalized = value.includes('T') ? value : value.replace(' ', 'T');
+  const parsedDate = new Date(normalized);
+
+  return Number.isNaN(parsedDate.getTime()) ? null : parsedDate;
+};
+
+const formatOpenBoundaryLabel = (value?: string, fallbackDate?: string): string => {
+  const parsedDate = parseScheduleBoundary(value);
+
+  if (parsedDate) {
+    const month = parsedDate.getMonth() + 1;
+    const day = parsedDate.getDate();
+    const hours = parsedDate.getHours();
+    const minutes = parsedDate.getMinutes();
+    const meridiem = hours < 12 ? '오전' : '오후';
+    const displayHour = hours % 12 || 12;
+    const minuteLabel = minutes === 0 ? '' : ` ${minutes}분`;
+
+    return `${month}월 ${day}일\n${meridiem} ${displayHour}시${minuteLabel} 오픈`;
+  }
+
+  if (fallbackDate) {
+    const [, month, day] = fallbackDate.split('-').map(Number);
+    return `${month}월 ${day}일\n오픈 예정`;
+  }
+
+  return '오픈 예정';
 };
 
 
@@ -370,10 +399,11 @@ const normalizeScheduleGame = (game: GameScheduleResponse): NormalizedScheduleGa
     status,
     ticket,
     resell: mapResellStatus(ticket),
-    ticketInfo: ticket === '판매예정' ? computeTicketOpenLabel(date) : undefined,
+    ticketInfo: ticket === '판매예정' ? formatOpenBoundaryLabel(game.ticketingOpenedAt, date) : undefined,
     reselInfo: ticket === '판매예정' ? '정식 예매 오픈\n2시간 후' : undefined,
     isToday: isSameCalendarDate(date, new Date()),
     ticketingOpenedAt: game.ticketingOpenedAt,
+    ticketingEndAt: game.ticketingEndAt,
   };
 };
 
@@ -396,6 +426,8 @@ export const mapGamesToDaySchedules = (games: NormalizedScheduleGame[]): DaySche
       leagueType: game.leagueType,
       queueTokenJti: game.queueTokenJti,
       rawDate: game.date,
+      ticketingOpenedAt: game.ticketingOpenedAt,
+      ticketingEndAt: game.ticketingEndAt,
       time: game.time,
       venue: game.venue,
       away: game.awayTeamName,

--- a/src/entities/resale/model/useResaleGameCounts.ts
+++ b/src/entities/resale/model/useResaleGameCounts.ts
@@ -2,13 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 
 import { fetchResaleListingCountsByGames } from '@/entities/resale/api/resaleApi';
 
-export const useResaleGameCounts = (gameIds: string[]) => {
+export const useResaleGameCounts = (gameIds: string[], enabled = true) => {
    const normalizedGameIds = [...new Set(gameIds.filter(Boolean))].sort();
 
    return useQuery({
       queryKey: ['resales', 'game-counts', normalizedGameIds],
       queryFn: () => fetchResaleListingCountsByGames(normalizedGameIds),
-      enabled: normalizedGameIds.length > 0,
+      enabled: enabled && normalizedGameIds.length > 0,
       placeholderData: previousData => previousData,
    });
 };

--- a/src/entities/resale/model/useResaleListingMarket.ts
+++ b/src/entities/resale/model/useResaleListingMarket.ts
@@ -8,12 +8,12 @@ type ResaleGameMarketSnapshot = {
    maxPrice: number;
 };
 
-export const useResaleListingMarket = (gameIds: string[]) => {
+export const useResaleListingMarket = (gameIds: string[], enabled = true) => {
    const normalizedGameIds = [...new Set(gameIds.filter(Boolean))].sort();
 
    return useQuery({
       queryKey: ['resales', 'listing-market', normalizedGameIds],
-      enabled: normalizedGameIds.length > 0,
+      enabled: enabled && normalizedGameIds.length > 0,
       queryFn: async () => {
          const listings = await fetchResaleListings();
          const gameIdSet = new Set(normalizedGameIds);

--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -64,7 +64,6 @@ type RawSeatResponse = Partial<SeatResponse> & {
 };
 
 const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0;
-
 const toOptionalFiniteNumber = (value: unknown) => {
    if (typeof value === 'number' && Number.isFinite(value)) {
       return value;
@@ -85,7 +84,7 @@ const normalizeSeatResponse = (seat: RawSeatResponse): SeatResponse | null => {
    const rawSeatId = isNonEmptyString(seat.seatId) ? seat.seatId : undefined;
    const rawId = isNonEmptyString(seat.id) ? seat.id : undefined;
    const seatId = rawSeatId ?? rawId;
-   const apiSeatId = rawId ?? rawSeatId;
+   const apiSeatId = rawSeatId ?? rawId;
    const sectionId = isNonEmptyString(seat.sectionId) ? seat.sectionId : undefined;
    const rowName = isNonEmptyString(seat.rowName) ? seat.rowName : isNonEmptyString(seat.row) ? seat.row : undefined;
    const seatNum = toOptionalFiniteNumber(seat.seatNum) ?? toOptionalFiniteNumber(seat.seatNumber);

--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { fetchResaleListingCountsBySections } from '@/entities/resale/api/resaleApi';
+import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
+import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 
 import {
    fetchSeatGrades,
@@ -14,11 +16,13 @@ import {
 import { getBookingTeamConfig, getZoneDisplayOrder, getBookingZones } from '@/pages/books/model/zoneData';
 import type { ZoneItem } from '@/pages/books/model/types';
 import { getBookingFlowMode } from '@/shared/lib/booking-flow';
+import { useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
 import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 
 import BookingCaptchaGate from './components/BookingCaptchaGate';
 import BookingZoneDesktopLayout from './components/BookingZoneDesktopLayout';
 import BookingZoneMobileLayout from './components/BookingZoneMobileLayout';
+import BooksExitDialog from '@/shared/widgets/layout/books/BooksExitDialog';
 
 const CAPTCHA_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
 
@@ -37,6 +41,10 @@ const BooksPage = () => {
    const bookingEntryState = routeBookingEntryState ?? storedBookingEntryState;
    const setBookingEntry = useBookingEntryStore((state) => state.setEntry);
    const patchBookingEntry = useBookingEntryStore((state) => state.patchEntry);
+   const clearBookingEntry = useBookingEntryStore((state) => state.clearEntry);
+   const clearAllSelections = useSeatSelectionStore((state) => state.clearAllSelections);
+   const clearSeatHolds = useSeatHoldStore((state) => state.clearSeatHolds);
+   const clearTimer = useBookingFlowTimerStore((state) => state.clearTimer);
    const bookingTeamConfig = useMemo(() => getBookingTeamConfig(bookingEntryState?.homeTeamId), [bookingEntryState?.homeTeamId]);
    const requiresCaptcha = Boolean(bookingEntryState?.requireCaptcha);
    const localZones = useMemo(
@@ -110,8 +118,18 @@ const BooksPage = () => {
    const [captchaError, setCaptchaError] = useState('');
    const [captchaSeed, setCaptchaSeed] = useState(0);
    const [isZoneDrawerOpen, setIsZoneDrawerOpen] = useState(true);
+   const [isExitDialogOpen, setIsExitDialogOpen] = useState(false);
+   const shouldRestoreHistoryRef = useRef(false);
 
    const captchaCode = useMemo(() => createMockCaptcha(), [captchaSeed]);
+
+   const exitBookingFlow = () => {
+      clearTimer();
+      clearSeatHolds();
+      clearAllSelections();
+      clearBookingEntry();
+      navigate('/', { replace: true });
+   };
 
    useEffect(() => {
       if (routeBookingEntryState) {
@@ -166,6 +184,21 @@ const BooksPage = () => {
       }
    }, [isCaptchaOpen]);
 
+   useEffect(() => {
+      window.history.pushState({ bookingExitGuard: true }, '', window.location.href);
+
+      const handlePopState = () => {
+         shouldRestoreHistoryRef.current = true;
+         setIsExitDialogOpen(true);
+      };
+
+      window.addEventListener('popstate', handlePopState);
+
+      return () => {
+         window.removeEventListener('popstate', handlePopState);
+      };
+   }, []);
+
    const resolvedBookingEntryState = useMemo<BookingEntryState | undefined>(() => {
       if (!bookingEntryState) {
          return undefined;
@@ -213,6 +246,22 @@ const BooksPage = () => {
 
    return (
       <div className="w-full bg-background text-foreground">
+         <BooksExitDialog
+            open={isExitDialogOpen}
+            onOpenChange={(open) => {
+               setIsExitDialogOpen(open);
+
+               if (!open && shouldRestoreHistoryRef.current) {
+                  window.history.pushState({ bookingExitGuard: true }, '', window.location.href);
+                  shouldRestoreHistoryRef.current = false;
+               }
+            }}
+            onConfirm={() => {
+               shouldRestoreHistoryRef.current = false;
+               setIsExitDialogOpen(false);
+               exitBookingFlow();
+            }}
+         />
          <BookingCaptchaGate
             open={isCaptchaOpen}
             captchaCode={captchaCode}

--- a/src/pages/home/ui/game-schedule/ScheduleList.tsx
+++ b/src/pages/home/ui/game-schedule/ScheduleList.tsx
@@ -25,15 +25,49 @@ const toVenueRegionLabel = (venue: string) => {
    return VENUE_REGION_LABELS[venue] ?? venue;
 };
 
+const parseScheduleDateTime = (value?: string) => {
+   if (!value?.trim()) {
+      return null;
+   }
+
+   const normalized = value.includes('T') ? value : value.replace(' ', 'T');
+   const parsedDate = new Date(normalized);
+
+   return Number.isNaN(parsedDate.getTime()) ? null : parsedDate;
+};
+
 const getEffectiveSaleStatuses = (game: GameRow) => {
    const now = new Date();
-   const saleOpenTime = game.rawDate ? new Date(`${game.rawDate}T11:00:00`) : null;
+   const saleOpenTime = parseScheduleDateTime(game.ticketingOpenedAt);
+   const saleEndTime = parseScheduleDateTime(game.ticketingEndAt);
    const resellOpenTime = game.rawDate ? new Date(`${game.rawDate}T13:00:00`) : null;
-   const saleNowOpen = saleOpenTime !== null && now >= saleOpenTime;
+   const saleBeforeOpen = saleOpenTime !== null && now < saleOpenTime;
+   const saleClosed = saleEndTime !== null && now > saleEndTime;
+   const saleNowOpen = (saleOpenTime === null || now >= saleOpenTime) && (saleEndTime === null || now <= saleEndTime);
    const resellNowOpen = resellOpenTime !== null && now >= resellOpenTime;
 
+   const effectiveTicket = (() => {
+      if (game.ticket === '매진') {
+         return game.ticket;
+      }
+
+      if (saleBeforeOpen) {
+         return '판매예정';
+      }
+
+      if (saleClosed) {
+         return '매진';
+      }
+
+      if (saleNowOpen) {
+         return '예매하기';
+      }
+
+      return game.ticket;
+   })();
+
    return {
-      effectiveTicket: game.ticket === '판매예정' && saleNowOpen ? '예매하기' : game.ticket,
+      effectiveTicket,
       effectiveResell: game.resell === '리셀예정' && resellNowOpen ? '리셀예매' : game.resell,
    };
 };

--- a/src/pages/home/ui/game-schedule/types.ts
+++ b/src/pages/home/ui/game-schedule/types.ts
@@ -11,6 +11,8 @@ export type GameRow = {
    leagueType?: import('@/shared/types/game').ApiLeagueType;
    queueTokenJti?: string;
    rawDate?: string; // YYYY-MM-DD — 시간 기반 상태 전환용
+   ticketingOpenedAt?: string;
+   ticketingEndAt?: string;
    time: string;
    venue: string;
    away: string;

--- a/src/pages/tickets/ui/TicketsPage.tsx
+++ b/src/pages/tickets/ui/TicketsPage.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useQueries } from '@tanstack/react-query';
 import { RefreshCw, SlidersHorizontal } from 'lucide-react';
 
 import { useGameSchedules } from '@/entities/game/model/schedule';
 import { useResaleGameCounts } from '@/entities/resale/model/useResaleGameCounts';
 import { useResaleListingMarket } from '@/entities/resale/model/useResaleListingMarket';
-import { fetchSeatGrades } from '@/pages/books/api/bookingApi';
 import { useBookingEntryFlow } from '@/shared/lib/use-booking-entry-flow';
 import { Button } from '@/shared/ui/button';
 import { FilterSidebar } from './FilterSidebar';
@@ -108,41 +106,7 @@ const TicketsPage = () => {
    );
    const visibleGames = useMemo(() => filteredGames.slice(0, visibleCount), [filteredGames, visibleCount]);
    const hasMoreGames = visibleCount < filteredGames.length;
-
-   const seatGradeQueries = useQueries({
-      queries: visibleGames.map((game) => ({
-         queryKey: ['ticket-remaining-seat-grades', game.id, game.stadiumId],
-         enabled: Boolean(game.id && game.stadiumId),
-         queryFn: async () => {
-            const grades = await fetchSeatGrades(game.id, game.stadiumId!);
-
-            return grades.reduce((total, grade) => total + grade.availableSeatCount, 0);
-         },
-      })),
-   });
-
-   const remainingSeatsByGameId = useMemo(() => {
-      return new Map(
-         visibleGames.flatMap((game, index) => {
-            const remainingSeats = seatGradeQueries[index]?.data;
-
-            if (typeof remainingSeats !== 'number') {
-               return [];
-            }
-
-            return [[game.id, remainingSeats] as const];
-         }),
-      );
-   }, [seatGradeQueries, visibleGames]);
-
-   const gamesToRender = useMemo(
-      () =>
-         visibleGames.map((game) => ({
-            ...game,
-            remainingSeats: remainingSeatsByGameId.get(game.id) ?? game.remainingSeats,
-         })),
-      [remainingSeatsByGameId, visibleGames],
-   );
+   const gamesToRender = visibleGames;
    const appliedSearchQuery = appliedFilters.searchQuery.trim();
 
    useEffect(() => {
@@ -188,9 +152,6 @@ const TicketsPage = () => {
       void scheduleQuery.refetch();
       void resaleCountsQuery.refetch();
       void resaleListingMarketQuery.refetch();
-      seatGradeQueries.forEach((query) => {
-         void query.refetch();
-      });
    };
 
    const handleGameActionClick = (game: GameItem) => {

--- a/src/pages/tickets/ui/TicketsPage.tsx
+++ b/src/pages/tickets/ui/TicketsPage.tsx
@@ -22,7 +22,7 @@ const DEFAULT_FILTERS: FilterState = {
    searchQuery: '',
 };
 
-const PAGE_SIZE = 12;
+const PAGE_SIZE = 8;
 
 function applyFilters(games: GameItem[], filters: FilterState, activeTab: TabType): GameItem[] {
    return games.filter((game) => {
@@ -32,8 +32,8 @@ function applyFilters(games: GameItem[], filters: FilterState, activeTab: TabTyp
       if (!filters.showSoldOut && status === '매진') return false;
       if (filters.dateTime && game.date !== filters.dateTime) return false;
       if (filters.venue && game.venue !== filters.venue) return false;
-      if (filters.minPrice > 0 && game.minPrice < filters.minPrice) return false;
-      if (filters.maxPrice < MAX_PRICE && game.maxPrice > filters.maxPrice) return false;
+      if (filters.minPrice > 0 && game.minPrice > 0 && game.minPrice < filters.minPrice) return false;
+      if (filters.maxPrice < MAX_PRICE && game.maxPrice > 0 && game.maxPrice > filters.maxPrice) return false;
 
       const trimmedQuery = filters.searchQuery.trim();
       if (trimmedQuery.length >= 2) {
@@ -57,26 +57,19 @@ function getResellStatus(resaleCount: number | undefined, fallbackStatus: Resell
 const TicketsPage = () => {
    const { openBookingEntry, openResellEntry, bookingGuideDialog } = useBookingEntryFlow();
    const scheduleQuery = useGameSchedules();
-   const resaleGameIds = useMemo(() => (scheduleQuery.data ?? []).map((game) => game.id), [scheduleQuery.data]);
-   const resaleCountsQuery = useResaleGameCounts(resaleGameIds);
-   const resaleListingMarketQuery = useResaleListingMarket(resaleGameIds);
    const [isFilterOpen, setIsFilterOpen] = useState(false);
    const [appliedFilters, setAppliedFilters] = useState<FilterState>(DEFAULT_FILTERS);
    const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
    const loadMoreTriggerRef = useRef<HTMLDivElement | null>(null);
    const activeTab: TabType = appliedFilters.tab;
+   const isResellTab = activeTab === '리셀';
 
    const baseGames = useMemo<GameItem[]>(() => {
-      const resaleCountByGameId = resaleCountsQuery.data;
-      const resaleMarketByGameId = resaleListingMarketQuery.data;
-
       return (scheduleQuery.data ?? [])
          .filter((game) => game.status === '예정')
          .map((game) => {
             const fallbackResellStatus =
                game.resell === '리셀예매' ? '리셀 가능' : game.resell === '리셀예정' ? '리셀 예정' : '매진';
-            const resaleMarket = resaleMarketByGameId?.get(game.id);
-            const resaleCount = resaleCountByGameId?.get(game.id) ?? resaleMarket?.count;
 
             return {
                id: game.id,
@@ -91,14 +84,14 @@ const TicketsPage = () => {
                dateTime: `${game.date.replace(/-/g, '.')} ${game.time}`,
                venue: game.venue,
                remainingSeats: game.ticket === '매진' ? 0 : 999,
-               resellRemainingSeats: resaleCount ?? (fallbackResellStatus === '리셀 가능' ? 999 : 0),
-               minPrice: resaleMarket?.minPrice ?? 0,
-               maxPrice: resaleMarket?.maxPrice ?? 0,
+               resellRemainingSeats: fallbackResellStatus === '리셀 가능' ? 999 : 0,
+               minPrice: 0,
+               maxPrice: 0,
                bookingStatus: game.ticket === '예매하기' ? '예매 가능' : game.ticket === '판매예정' ? '판매 예정' : '매진',
-               resellStatus: getResellStatus(resaleCount, fallbackResellStatus),
+               resellStatus: fallbackResellStatus,
             };
          });
-   }, [resaleCountsQuery.data, resaleListingMarketQuery.data, scheduleQuery.data]);
+   }, [scheduleQuery.data]);
 
    const filteredGames = useMemo(
       () => applyFilters(baseGames, appliedFilters, activeTab),
@@ -106,7 +99,27 @@ const TicketsPage = () => {
    );
    const visibleGames = useMemo(() => filteredGames.slice(0, visibleCount), [filteredGames, visibleCount]);
    const hasMoreGames = visibleCount < filteredGames.length;
-   const gamesToRender = visibleGames;
+   const visibleGameIds = useMemo(() => visibleGames.map((game) => game.id), [visibleGames]);
+   const resaleCountsQuery = useResaleGameCounts(visibleGameIds, isResellTab);
+   const resaleListingMarketQuery = useResaleListingMarket(visibleGameIds, isResellTab);
+   const gamesToRender = useMemo(
+      () =>
+         visibleGames.map((game) => {
+            const fallbackResellStatus =
+               game.resellStatus === '리셀 가능' ? '리셀 가능' : game.resellStatus === '리셀 예정' ? '리셀 예정' : '매진';
+            const resaleMarket = resaleListingMarketQuery.data?.get(game.id);
+            const resaleCount = resaleCountsQuery.data?.get(game.id) ?? resaleMarket?.count;
+
+            return {
+               ...game,
+               resellRemainingSeats: resaleCount ?? game.resellRemainingSeats,
+               minPrice: resaleMarket?.minPrice ?? game.minPrice,
+               maxPrice: resaleMarket?.maxPrice ?? game.maxPrice,
+               resellStatus: getResellStatus(resaleCount, fallbackResellStatus),
+            };
+         }),
+      [resaleCountsQuery.data, resaleListingMarketQuery.data, visibleGames],
+   );
    const appliedSearchQuery = appliedFilters.searchQuery.trim();
 
    useEffect(() => {
@@ -224,11 +237,11 @@ const TicketsPage = () => {
                      <div className="flex items-center justify-center py-20 bg-surface rounded-[14px] h-full text-body-1-medium text-muted-foreground">
                         경기 일정을 불러오지 못했습니다.
                      </div>
-                  ) : activeTab === '리셀' && resaleCountsQuery.isError ? (
+                  ) : isResellTab && resaleCountsQuery.isError ? (
                      <div className="flex items-center justify-center h-full bg-surface rounded-[14px] text-body-1-medium text-muted-foreground">
                         리셀 경기 정보를 불러오지 못했습니다.
                      </div>
-                  ) : activeTab === '리셀' && resaleListingMarketQuery.isError ? (
+                  ) : isResellTab && resaleListingMarketQuery.isError ? (
                      <div className="flex items-center justify-center h-full bg-surface rounded-[14px] text-body-1-medium text-muted-foreground">
                         리셀 목록 정보를 불러오지 못했습니다.
                      </div>


### PR DESCRIPTION
<!-- 제목 예시: [feat] 작업 내용 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
- #200
- #114
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->

<br/>

 ## 🔎 개요
티켓 목록과 예매 플로우, 경기 일정 상태 처리에서 확인된 정합성 문제를 함께 정리했습니다. 일반 예매 목록의 불필요한 잔여석 실조회 제거, 무한 스크롤 통신 범위 축소, 예매 플로우 직접 진입/이탈 방어, 판매 시간 기준 상태 보정까지 포함합니다.

  <br/>

  ## 📋 작업 내용
  - `src/pages/tickets/ui/TicketsPage.tsx`일반 예매 카드에서 `seat-grades` 실조회를 제거하고 더미 잔여석 UI만 유지하도록 변경했습니다.
  - `src/pages/tickets/ui/TicketsPage.tsx`무한 스크롤 초기 노출 수를 줄이고, 리셀 관련 조회는 현재 화면에 노출된 경기 ID 범위에서만 호출하도록 조정했습니다.
  - `src/entities/resale/model/useResaleGameCounts.ts`리셀 개수 조회 훅에 활성화 제어를 추가해 불필요한 요청을 막았습니다.
  - `src/entities/resale/model/useResaleListingMarket.ts`리셀 시세 조회 훅에 활성화 제어를 추가해 예매 탭 및 비가시 영역 통신을 줄였습니다.
  - `src/app/providers/router/ui/BookingFlowStateGuard.tsx` 예매 진입 정보 없이 `/books`, 결제 페이지에 직접 접근하는 경우 홈으로 리다이렉트하고, 관련 선택/hold/timer 상태를 정리하도록 보완했습니다.
  - `src/pages/books/ui/BooksPage.tsx` 브라우저 뒤로가기 이탈 시 확인 다이얼로그를 띄우고, 이탈 확정 시 예매 관련 상태를 정리하도록 추가했습니다.
  - `src/entities/game/model/schedule.ts`
    `ticketingOpenedAt`, `ticketingEndAt`를 반영해 판매 예정 문구와 일정 데이터의 판매 시각 정보를 정리했습니다.
  - `src/pages/home/ui/game-schedule/types.ts` 경기 일정 row 타입에 판매 시작/종료 시각 필드를 추가했습니다.
  - `src/pages/home/ui/game-schedule/ScheduleList.tsx` 판매 시작/종료 시각 기준으로 예매 상태가 실제 시간과 맞게 전환되도록 보정했습니다.

  <br/>