### PR TITLE
[bug] 실제 seatId를 갖기 전에 hold 요청이 시작되어 seatId 타입 오류 발생 방지 로직 추가

### DIFF
--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -219,24 +219,37 @@ export const fetchSeatGrades = async (gameId: string, stadiumId: string) => {
    return response.data.data;
 };
 
-export const fetchSeatSections = async (stadiumId: string) => {
-   const response = await apiClient.get<ApiEnvelope<SeatSectionResponse[]>>(`/api/v1/stadium-seats/stadiums/${stadiumId}/seat-sections`);
+export const fetchSeatSections = async ({
+   stadiumId,
+   gameId,
+}: {
+   stadiumId: string;
+   gameId?: string;
+}) => {
+   const response = await apiClient.get<ApiEnvelope<SeatSectionResponse[]>>(`/api/v1/stadium-seats/stadiums/${stadiumId}/seat-sections`, {
+      params: gameId ? { gameId } : undefined,
+   });
 
    return response.data.data;
 };
 
 export const resolveSeatSectionByCode = async ({
    stadiumId,
+   gameId,
    sectionCode,
 }: {
    stadiumId?: string;
+   gameId?: string;
    sectionCode: string;
 }) => {
    if (!stadiumId) {
       return null;
    }
 
-   const sections = await fetchSeatSections(stadiumId);
+   const sections = await fetchSeatSections({
+      stadiumId,
+      gameId,
+   });
    const normalizedTargetSectionCode = normalizeSectionCode(sectionCode);
 
    return sections.find((section) => normalizeSectionCode(section.sectionCode) === normalizedTargetSectionCode) ?? null;

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -230,11 +230,18 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
                   stadiumId,
                   gameId,
                   sectionCode: zone.sectionCode,
-               })) ??
-               ({
-                  sectionId: zone.id,
-                  sectionCode: zone.sectionCode,
-               } satisfies Pick<ApiSeatSectionBundle, 'sectionId' | 'sectionCode'>);
+               }));
+
+            if (!resolvedSection) {
+               console.error('[SeatMapDebug] 좌석 구역 매핑 실패', {
+                  gameId,
+                  stadiumId,
+                  zoneId: zone.id,
+                  zoneSectionCode: zone.sectionCode,
+               });
+
+               return null;
+            }
             const [seats, statuses] = await Promise.all([
                fetchSeats(resolvedSection.sectionId),
                fetchSeatStatuses(gameId, resolvedSection.sectionId),

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -181,7 +181,10 @@ const fetchAggregatedSeatSections = async ({
    stadiumId,
    zone,
 }: Required<Pick<SeatMapDataParams, 'gameId' | 'stadiumId'>> & { zone: ZoneItem }) => {
-   const sections = await fetchSeatSections(stadiumId);
+   const sections = await fetchSeatSections({
+      stadiumId,
+      gameId,
+   });
    const targetSections = sections
       .filter((section) => matchesSectionExpression(zone.sectionCode, section.sectionCode))
       .sort((left, right) =>
@@ -225,6 +228,7 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
             const resolvedSection =
                (await resolveSeatSectionByCode({
                   stadiumId,
+                  gameId,
                   sectionCode: zone.sectionCode,
                })) ??
                ({

--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -76,7 +76,10 @@ const BooksPage = () => {
       queryFn: async () => {
          const [grades, sections, pricingPolicy] = await Promise.all([
             fetchSeatGrades(bookingEntryState!.gameId!, bookingEntryState!.stadiumId!),
-            fetchSeatSections(bookingEntryState!.stadiumId!),
+            fetchSeatSections({
+               stadiumId: bookingEntryState!.stadiumId!,
+               gameId: bookingEntryState!.gameId!,
+            }),
             fetchTicketPricingPolicy(bookingEntryState!.serverHomeTeamId!).catch(() => undefined),
          ]);
          const remainingBySectionId =

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -169,7 +169,7 @@ function SeatsPage() {
    );
 
    const selectedPrice = selectedSeats.reduce((total, item) => total + item.price, 0);
-   const isSeatInteractionLocked = isSeatMapLoading && !hasApiSeatMap && Boolean(bookingEntryState?.gameId);
+   const isSeatInteractionLocked = Boolean(bookingEntryState?.gameId) && (!hasApiSeatMap || isSeatMapLoading);
    const resellInsightsQuery = useResellZoneInsights({
       enabled: isResellMode,
       gameId: bookingEntryState?.gameId,


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #200

<br/>

## 🔎 개요
mock seatId가 쓰이지 않도록 방어 로직 추가

<br/>

## 📋 작업 내용
- 예매좌석 구역 조회 실패 시 mock 데이터 반영 제외 및 gameId 파라미터 반영
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

<br/>
