### PR TITLE
[bug] 백엔드 API 스펙 최신화 동기화

### DIFF
--- a/src/entities/ticket/api/ticketApi.ts
+++ b/src/entities/ticket/api/ticketApi.ts
@@ -19,6 +19,8 @@ export interface TicketDetail {
    resalePrice?: number;
    ticketStatus: 'ISSUED' | 'USED' | 'INVALID' | 'RESALE_ISSUED';
    resaleEnabledStatus: 'ENABLED' | 'DISABLED';
+   frozen?: boolean;
+   frozenUntil?: string;
    issuedAt: string;
    usedAt?: string;
    orderedAt?: string;

--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -11,6 +11,12 @@ export type SeatGradeResponse = {
    availableSeatCount: number;
 };
 
+export type SeatGradeSearchResultResponse = {
+   sessionId: string;
+   sessionExpiresAt: string;
+   seatGrades: SeatGradeResponse[];
+};
+
 export type SeatSectionResponse = {
    sectionId: string;
    gradeId: string;
@@ -212,11 +218,11 @@ export const getPricingDayType = (gameDate: string) => {
 };
 
 export const fetchSeatGrades = async (gameId: string, stadiumId: string) => {
-   const response = await apiClient.get<ApiEnvelope<SeatGradeResponse[]>>(
+   const response = await apiClient.get<ApiEnvelope<SeatGradeSearchResultResponse>>(
       `/api/v1/stadium-seats/stadiums/${stadiumId}/games/${gameId}/seat-grades`,
    );
 
-   return response.data.data;
+   return response.data.data?.seatGrades ?? [];
 };
 
 export const fetchSeatSections = async ({
@@ -255,8 +261,16 @@ export const resolveSeatSectionByCode = async ({
    return sections.find((section) => normalizeSectionCode(section.sectionCode) === normalizedTargetSectionCode) ?? null;
 };
 
-export const fetchSeats = async (sectionId: string) => {
-   const response = await apiClient.get<ApiEnvelope<RawSeatResponse[]>>(`/api/v1/seats/seat-sections/${sectionId}/seats`);
+export const fetchSeats = async ({
+   sectionId,
+   gameId,
+}: {
+   sectionId: string;
+   gameId: string;
+}) => {
+   const response = await apiClient.get<ApiEnvelope<RawSeatResponse[]>>(`/api/v1/seats/seat-sections/${sectionId}/seats`, {
+      params: { gameId },
+   });
 
    return (response.data.data ?? []).flatMap((seat) => {
       const normalizedSeat = normalizeSeatResponse(seat);
@@ -267,6 +281,7 @@ export const fetchSeats = async (sectionId: string) => {
 
       console.error('[bookingApi] 좌석 응답 정규화 실패', {
          sectionId,
+         gameId,
          seat,
       });
 

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -14,9 +14,12 @@ import {
 } from '@/pages/books/api/bookingApi';
 import { getSeatBlocks } from '@/pages/books/model/seatData';
 import type { SeatBlock, SeatItem, ZoneItem } from '@/pages/books/model/types';
+import { getErrorMessage } from '@/shared/lib/error/getErrorMessage';
 
 const AGGREGATED_SECTION_CODE_PATTERN = /[~,/]/;
 const API_SEAT_SPACING = 20;
+const DEFAULT_SEAT_MAP_ERROR_MESSAGE = '현재 좌석 정보를 불러올 수 없습니다. 잠시 후 다시 시도해 주세요.';
+const MEANINGFUL_SEAT_MAP_ERROR_PATTERNS = [/예매 가능/i, /권한/i, /로그인/i];
 
 type SeatMapDataParams = {
    gameId?: string;
@@ -52,6 +55,14 @@ const sortSectionBundles = (left: ApiSeatSectionBundle, right: ApiSeatSectionBun
       numeric: true,
       sensitivity: 'base',
    });
+
+const toSeatMapErrorMessage = (error: unknown) => {
+   const message = getErrorMessage(error, DEFAULT_SEAT_MAP_ERROR_MESSAGE);
+
+   return MEANINGFUL_SEAT_MAP_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+      ? message
+      : DEFAULT_SEAT_MAP_ERROR_MESSAGE;
+};
 
 const getSectionSeatLayoutMeta = (seats: SeatResponse[]) => {
    const rowNames = Array.from(new Set(seats.map((seat) => seat.rowName))).sort(sortRowNames);
@@ -216,7 +227,7 @@ const fetchAggregatedSeatSections = async ({
 export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) => {
    const defaultSeatBlocks = useMemo(() => getSeatBlocks(zone), [zone]);
 
-   const { data, isFetching, isLoading, refetch } = useQuery({
+   const { data, error, isError, isFetching, isLoading, refetch } = useQuery({
       queryKey: ['booking-seat-map', gameId, stadiumId, zone.id, zone.sectionCode],
       enabled: Boolean(gameId && zone.id && zone.sectionCode),
       queryFn: async (): Promise<SeatMapApiSnapshot | null> => {
@@ -240,7 +251,7 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
                   zoneSectionCode: zone.sectionCode,
                });
 
-               return null;
+               throw new Error(DEFAULT_SEAT_MAP_ERROR_MESSAGE);
             }
             const [seats, statuses] = await Promise.all([
                fetchSeats(resolvedSection.sectionId),
@@ -261,10 +272,10 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
                statusSeatIdsPreview: statuses.slice(0, 10).map((seatStatus) => seatStatus.seatId),
             });
 
-            const [seatBlock] = buildSeatBlockFromApiSeats(zone.sectionCode, seats);
+           const [seatBlock] = buildSeatBlockFromApiSeats(zone.sectionCode, seats);
 
             if (!seatBlock) {
-               return null;
+               throw new Error(DEFAULT_SEAT_MAP_ERROR_MESSAGE);
             }
 
             return {
@@ -293,7 +304,7 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
          });
 
          if (sectionBundles.length === 0) {
-            return null;
+            throw new Error(DEFAULT_SEAT_MAP_ERROR_MESSAGE);
          }
 
          return buildAggregatedSeatMapSnapshot({
@@ -308,6 +319,8 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
       seatBlocks: data?.seatBlocks ?? defaultSeatBlocks,
       apiSeatItems: data?.seatItems ?? [],
       hasApiSeatMap: Boolean(data),
+      isSeatMapError: isError,
+      seatMapErrorMessage: isError ? toSeatMapErrorMessage(error) : '',
       isSeatMapLoading: isLoading || isFetching,
       refetchSeatMap: refetch,
    };

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -208,7 +208,10 @@ const fetchAggregatedSeatSections = async ({
    const sectionBundles = await Promise.all(
       targetSections.map(async (section) => {
          const [seats, statuses] = await Promise.all([
-            fetchSeats(section.sectionId),
+            fetchSeats({
+               sectionId: section.sectionId,
+               gameId,
+            }),
             fetchSeatStatuses(gameId, section.sectionId),
          ]);
 
@@ -254,7 +257,10 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
                throw new Error(DEFAULT_SEAT_MAP_ERROR_MESSAGE);
             }
             const [seats, statuses] = await Promise.all([
-               fetchSeats(resolvedSection.sectionId),
+               fetchSeats({
+                  sectionId: resolvedSection.sectionId,
+                  gameId,
+               }),
                fetchSeatStatuses(gameId, resolvedSection.sectionId),
             ]);
 

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -27,6 +27,7 @@ const STAGE_WIDTH = 1240;
 const STAGE_HEIGHT = 620;
 const BLOCK_SEAT_SIZE = 18;
 const BLOCK_SEAT_GAP = 2;
+const BLOCK_CARD_COLUMN_GAP = 48;
 const MINIMAP_WIDTH = 215;
 const MINIMAP_HEIGHT = 140;
 const MINIMAP_PADDING_X = 24;
@@ -58,7 +59,13 @@ function SeatsPage() {
    const stadiumName = useMemo(() => getStadiumName(bookingEntryState?.homeTeamId), [bookingEntryState?.homeTeamId]);
 
    const initialSeats = useMemo(() => createSeatsForZone(zone), [zone]);
-   const { apiSeatItems, seatBlocks, hasApiSeatMap, isSeatMapLoading, refetchSeatMap } = useSeatMapData({
+   const {
+      apiSeatItems,
+      seatBlocks,
+      hasApiSeatMap,
+      isSeatMapLoading,
+      refetchSeatMap,
+   } = useSeatMapData({
       gameId: bookingEntryState?.gameId,
       stadiumId: bookingEntryState?.stadiumId,
       zone,
@@ -259,27 +266,44 @@ function SeatsPage() {
          return null;
       }
 
-      const blockMetrics = seatBlocks.map(block => {
+      const blockMetrics = seatBlocks.map((block, index) => {
          const width = block.cols * (BLOCK_SEAT_SIZE + BLOCK_SEAT_GAP) - BLOCK_SEAT_GAP;
          const height = block.rows * (BLOCK_SEAT_SIZE + BLOCK_SEAT_GAP) - BLOCK_SEAT_GAP;
+         const renderedOffsetX = block.offsetX + index * BLOCK_CARD_COLUMN_GAP;
 
          return {
             ...block,
             width,
             height,
-            right: block.offsetX + width,
+            renderedOffsetX,
+            right: renderedOffsetX + width,
             bottom: block.offsetY + height,
          };
       });
 
       return {
-         left: Math.min(...blockMetrics.map(block => block.offsetX)),
+         left: Math.min(...blockMetrics.map(block => block.renderedOffsetX)),
          top: Math.min(...blockMetrics.map(block => block.offsetY)),
          right: Math.max(...blockMetrics.map(block => block.right)),
          bottom: Math.max(...blockMetrics.map(block => block.bottom)),
          blocks: blockMetrics,
       };
    }, [seatBlocks]);
+
+   const directionBadgePosition = useMemo(() => {
+      if (!sectionBounds) {
+         return null;
+      }
+
+      const badgeHeight = 48;
+      const sectionHeight = sectionBounds.bottom - sectionBounds.top;
+      const badgeOffset = Math.max(156, Math.min(260, Math.round(sectionHeight * 0.44)));
+
+      return {
+         left: (sectionBounds.left + sectionBounds.right) / 2,
+         top: Math.max(-160, sectionBounds.top - badgeHeight - badgeOffset),
+      };
+   }, [sectionBounds]);
 
    const minimapLayout = useMemo(() => {
       if (!sectionBounds) {
@@ -302,7 +326,7 @@ function SeatsPage() {
          offsetY,
          blocks: sectionBounds.blocks.map(block => ({
             id: block.id,
-            x: offsetX + (block.offsetX - sectionBounds.left) * scale,
+            x: offsetX + (block.renderedOffsetX - sectionBounds.left) * scale,
             y: offsetY + (block.offsetY - sectionBounds.top) * scale,
             width: block.width * scale,
             height: block.height * scale,
@@ -321,15 +345,15 @@ function SeatsPage() {
 
       const stageLeft = (mapViewportSize.width - STAGE_WIDTH * seatMapScale) / 2 + seatMapOffset.x;
       const stageTop = 56 + seatMapOffset.y;
-      const visibleX = Math.max(0, (0 - stageLeft) / seatMapScale);
-      const visibleY = Math.max(0, (0 - stageTop) / seatMapScale);
-      const visibleWidth = Math.min(STAGE_WIDTH - visibleX, mapViewportSize.width / seatMapScale);
-      const visibleHeight = Math.min(STAGE_HEIGHT - visibleY, mapViewportSize.height / seatMapScale);
+      const visibleLeft = (0 - stageLeft) / seatMapScale;
+      const visibleTop = (0 - stageTop) / seatMapScale;
+      const visibleRight = (mapViewportSize.width - stageLeft) / seatMapScale;
+      const visibleBottom = (mapViewportSize.height - stageTop) / seatMapScale;
 
-      const intersectLeft = Math.max(sectionBounds.left, visibleX);
-      const intersectTop = Math.max(sectionBounds.top, visibleY);
-      const intersectRight = Math.min(sectionBounds.right, visibleX + visibleWidth);
-      const intersectBottom = Math.min(sectionBounds.bottom, visibleY + visibleHeight);
+      const intersectLeft = Math.max(sectionBounds.left, visibleLeft);
+      const intersectTop = Math.max(sectionBounds.top, visibleTop);
+      const intersectRight = Math.min(sectionBounds.right, visibleRight);
+      const intersectBottom = Math.min(sectionBounds.bottom, visibleBottom);
 
       if (intersectRight <= intersectLeft || intersectBottom <= intersectTop || !minimapLayout) {
          return null;
@@ -491,6 +515,7 @@ function SeatsPage() {
 
                <div className="relative flex-1 overflow-hidden px-0 pb-[144px] lg:px-8 lg:pb-6 xl:pb-6">
                   <SeatMapStage
+                     directionBadgePosition={directionBadgePosition}
                      isSeatMapDragging={isSeatMapDragging}
                      mapViewportRef={mapViewportRef}
                      minimapLayout={minimapLayout}

--- a/src/pages/books/ui/components/BookingCaptchaGate.tsx
+++ b/src/pages/books/ui/components/BookingCaptchaGate.tsx
@@ -29,6 +29,7 @@ function BookingCaptchaGate({
       <Dialog open={open} onOpenChange={onOpenChange}>
          <DialogContent
             className="w-[calc(100%-40px)] max-w-[426px] gap-0 overflow-hidden rounded-[12px] border-0 bg-(--background-elevated) p-0"
+            closeOnlyWithButton
             showCloseButton={false}
          >
             <DialogHeader className="px-5 pb-5 pt-5">

--- a/src/pages/books/ui/components/SeatMapStage.tsx
+++ b/src/pages/books/ui/components/SeatMapStage.tsx
@@ -34,6 +34,10 @@ type MinimapViewport = {
 } | null;
 
 type SeatMapStageProps = {
+   directionBadgePosition: {
+      left: number;
+      top: number;
+   } | null;
    isSeatMapDragging: boolean;
    mapViewportRef: RefObject<HTMLDivElement | null>;
    minimapLayout: MinimapLayout;
@@ -57,6 +61,7 @@ type SeatMapStageProps = {
 };
 
 function SeatMapStage({
+   directionBadgePosition,
    isSeatMapDragging,
    mapViewportRef,
    minimapLayout,
@@ -110,16 +115,18 @@ function SeatMapStage({
                onPointerUp={onMapPointerUp}
                onPointerCancel={onMapPointerUp}
             >
-               <div
-                  className="absolute rounded-[10px] bg-[rgba(233,235,238,0.72)] px-8 py-3 text-body-1-bold text-muted-foreground shadow-[0_8px_24px_rgba(15,23,42,0.06)] backdrop-blur lg:rounded-xl lg:bg-white/70 lg:text-body-2-semibold"
-                  style={{
-                     left: '50%',
-                     top: '24px',
-                     transform: 'translateX(-50%)',
-                  }}
-               >
-                  경기장 방향
-               </div>
+               {directionBadgePosition ? (
+                  <div
+                     className="pointer-events-none absolute z-10 whitespace-nowrap rounded-[10px] bg-[rgba(233,235,238,0.72)] px-8 py-3 text-body-1-bold text-muted-foreground shadow-[0_8px_24px_rgba(15,23,42,0.06)] backdrop-blur lg:rounded-xl lg:bg-white/70 lg:text-body-2-semibold"
+                     style={{
+                        left: `${directionBadgePosition.left}px`,
+                        top: `${directionBadgePosition.top}px`,
+                        transform: 'translateX(-50%)',
+                     }}
+                  >
+                     경기장 방향
+                  </div>
+               ) : null}
 
                {seatBlocks.map((block, index) => (
                   <SeatBlockGrid

--- a/src/pages/home/ui/game-schedule/ScheduleList.tsx
+++ b/src/pages/home/ui/game-schedule/ScheduleList.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/shared/lib/utils';
 import { Badge } from '@/shared/ui/badge';
 import { TAB_TODAY, TEAM_IDS, statusColor, teamLogos } from './constants';
 import type { DaySchedule, GameRow } from './types';
-import { getGameResultTexts } from './utils';
+import { getEffectiveSaleStatuses, getGameResultTexts } from './utils';
 
 const VENUE_REGION_LABELS: Record<string, string> = {
    '기아 챔피언스필드': '광주',
@@ -23,53 +23,6 @@ const VENUE_REGION_LABELS: Record<string, string> = {
 
 const toVenueRegionLabel = (venue: string) => {
    return VENUE_REGION_LABELS[venue] ?? venue;
-};
-
-const parseScheduleDateTime = (value?: string) => {
-   if (!value?.trim()) {
-      return null;
-   }
-
-   const normalized = value.includes('T') ? value : value.replace(' ', 'T');
-   const parsedDate = new Date(normalized);
-
-   return Number.isNaN(parsedDate.getTime()) ? null : parsedDate;
-};
-
-const getEffectiveSaleStatuses = (game: GameRow) => {
-   const now = new Date();
-   const saleOpenTime = parseScheduleDateTime(game.ticketingOpenedAt);
-   const saleEndTime = parseScheduleDateTime(game.ticketingEndAt);
-   const resellOpenTime = game.rawDate ? new Date(`${game.rawDate}T13:00:00`) : null;
-   const saleBeforeOpen = saleOpenTime !== null && now < saleOpenTime;
-   const saleClosed = saleEndTime !== null && now > saleEndTime;
-   const saleNowOpen = (saleOpenTime === null || now >= saleOpenTime) && (saleEndTime === null || now <= saleEndTime);
-   const resellNowOpen = resellOpenTime !== null && now >= resellOpenTime;
-
-   const effectiveTicket = (() => {
-      if (game.ticket === '매진') {
-         return game.ticket;
-      }
-
-      if (saleBeforeOpen) {
-         return '판매예정';
-      }
-
-      if (saleClosed) {
-         return '매진';
-      }
-
-      if (saleNowOpen) {
-         return '예매하기';
-      }
-
-      return game.ticket;
-   })();
-
-   return {
-      effectiveTicket,
-      effectiveResell: game.resell === '리셀예정' && resellNowOpen ? '리셀예매' : game.resell,
-   };
 };
 
 function ScoreDisplay({ game }: { game: GameRow }) {
@@ -220,7 +173,7 @@ function ActionButtons({
    onOpenBookingFlow: (game: GameRow) => void;
    onOpenResellFlow: (game: GameRow) => void;
 }) {
-   const { effectiveTicket, effectiveResell } = getEffectiveSaleStatuses(game);
+   const { effectiveTicket, effectiveResell, ticketInfo, reselInfo } = getEffectiveSaleStatuses(game);
 
    const canBook = effectiveTicket === '예매하기';
    const canResellBook = effectiveResell === '리셀예매';
@@ -228,8 +181,8 @@ function ActionButtons({
    const isResellScheduled = effectiveResell === '리셀예정';
 
    // 서브텍스트 두 줄 분리
-   const [ticketInfoLine1, ticketInfoLine2] = (game.ticketInfo ?? '').split('\n');
-   const [reselInfoLine1, reselInfoLine2] = (game.reselInfo ?? '').split('\n');
+   const [ticketInfoLine1, ticketInfoLine2] = (ticketInfo ?? '').split('\n');
+   const [reselInfoLine1, reselInfoLine2] = (reselInfo ?? '').split('\n');
 
    return (
       <>

--- a/src/pages/home/ui/game-schedule/utils.ts
+++ b/src/pages/home/ui/game-schedule/utils.ts
@@ -3,7 +3,7 @@ import {
    TAB_TODAY,
    TAB_WEEK,
 } from './constants';
-import type { DaySchedule } from './types';
+import type { DaySchedule, GameRow, ReselStatus, TicketStatus } from './types';
 
 type FilterParams = {
    activeTab: number;
@@ -69,3 +69,84 @@ export function getGameResultTexts(score: string | null, isEnded: boolean): { aw
       home: homeScore > awayScore ? '승' : '패',
    };
 }
+
+const parseScheduleDateTime = (value?: string) => {
+   if (!value?.trim()) {
+      return null;
+   }
+
+   const normalized = value.includes('T') ? value : value.replace(' ', 'T');
+   const parsedDate = new Date(normalized);
+
+   return Number.isNaN(parsedDate.getTime()) ? null : parsedDate;
+};
+
+const formatOpenBoundaryLabel = (value?: string, fallbackDate?: string) => {
+   const parsedDate = parseScheduleDateTime(value);
+
+   if (parsedDate) {
+      const month = parsedDate.getMonth() + 1;
+      const day = parsedDate.getDate();
+      const hours = parsedDate.getHours();
+      const minutes = parsedDate.getMinutes();
+      const meridiem = hours < 12 ? '오전' : '오후';
+      const displayHour = hours % 12 || 12;
+      const minuteLabel = minutes === 0 ? '' : ` ${minutes}분`;
+
+      return `${month}월 ${day}일\n${meridiem} ${displayHour}시${minuteLabel} 오픈`;
+   }
+
+   if (fallbackDate) {
+      const [, month, day] = fallbackDate.split('-').map(Number);
+      return `${month}월 ${day}일\n오픈 예정`;
+   }
+
+   return '오픈 예정';
+};
+
+type EffectiveSaleStatus = {
+   effectiveTicket: TicketStatus;
+   effectiveResell: ReselStatus;
+   ticketInfo?: string;
+   reselInfo?: string;
+};
+
+export const getEffectiveSaleStatuses = (game: GameRow, now = new Date()): EffectiveSaleStatus => {
+   const saleOpenTime = parseScheduleDateTime(game.ticketingOpenedAt);
+   const saleEndTime = parseScheduleDateTime(game.ticketingEndAt);
+   const resellOpenTime = game.rawDate ? new Date(`${game.rawDate}T13:00:00`) : null;
+   const saleBeforeOpen = saleOpenTime !== null && now < saleOpenTime;
+   const saleClosed = saleEndTime !== null && now > saleEndTime;
+   const saleNowOpen = (saleOpenTime === null || now >= saleOpenTime) && (saleEndTime === null || now <= saleEndTime);
+   const resellNowOpen = resellOpenTime !== null && now >= resellOpenTime;
+
+   const effectiveTicket: TicketStatus = (() => {
+      if (game.ticket === '매진') {
+         return game.ticket;
+      }
+
+      if (saleBeforeOpen) {
+         return '판매예정';
+      }
+
+      if (saleClosed) {
+         return '매진';
+      }
+
+      if (saleNowOpen) {
+         return '예매하기';
+      }
+
+      return game.ticket;
+   })();
+
+   const effectiveResell: ReselStatus =
+      game.resell === '리셀예정' && resellNowOpen ? '리셀예매' : game.resell;
+
+   return {
+      effectiveTicket,
+      effectiveResell,
+      ticketInfo: effectiveTicket === '판매예정' ? formatOpenBoundaryLabel(game.ticketingOpenedAt, game.rawDate) : undefined,
+      reselInfo: effectiveResell === '리셀예정' ? '정식 예매 오픈\n2시간 후' : undefined,
+   };
+};

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -15,6 +15,12 @@ type SeatGrade = {
    availableSeatCount: number;
 };
 
+type SeatGradeSearchResult = {
+   sessionId: string;
+   sessionExpiresAt: string;
+   seatGrades: SeatGrade[];
+};
+
 type SeatSection = {
    sectionId: string;
    gradeId: string;
@@ -849,10 +855,17 @@ export const paymentHandlers = [
    }),
 
    http.get('/api/v1/stadium-seats/stadiums/:stadiumId/games/:gameId/seat-grades', async ({ params }) => {
+      const seatGrades = seatGradesByStadium[String(params.stadiumId)] ?? [];
+      const seatGradeResult: SeatGradeSearchResult = {
+         sessionId: `seat-session-${String(params.gameId)}`,
+         sessionExpiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+         seatGrades,
+      };
+
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',
-         data: seatGradesByStadium[String(params.stadiumId)] ?? [],
+         data: seatGradeResult,
       });
    }),
 
@@ -864,7 +877,21 @@ export const paymentHandlers = [
       });
    }),
 
-   http.get('/api/v1/seats/seat-sections/:sectionId/seats', async ({ params }) => {
+   http.get('/api/v1/seats/seat-sections/:sectionId/seats', async ({ params, request }) => {
+      const requestUrl = new URL(request.url);
+      const gameId = requestUrl.searchParams.get('gameId');
+
+      if (!gameId) {
+         return HttpResponse.json(
+            {
+               code: 'VALIDATION_ERROR',
+               message: 'gameId query parameter is required',
+               data: null,
+            },
+            { status: 400 },
+         );
+      }
+
       return HttpResponse.json({
          code: 'SUCCESS',
          message: 'ok',

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -112,6 +112,8 @@ type TicketRecord = {
    paymentMethodDisplay?: string;
    ticketStatus: 'ISSUED' | 'USED' | 'INVALID';
    resaleEnabledStatus: 'ENABLED' | 'DISABLED';
+   frozen?: boolean;
+   frozenUntil?: string;
    issuedAt: string;
    orderedAt: string;
    cancelableUntil?: string;
@@ -1416,6 +1418,8 @@ export const paymentHandlers = [
             serviceFee: ticket.serviceFee ?? 1000,
             ticketStatus: ticket.ticketStatus,
             resaleEnabledStatus: ticket.resaleEnabledStatus,
+            frozen: ticket.frozen ?? false,
+            frozenUntil: ticket.frozenUntil,
             issuedAt: ticket.issuedAt,
             orderedAt: ticket.orderedAt,
             cancelableUntil: ticket.cancelableUntil,

--- a/src/shared/types/game.ts
+++ b/src/shared/types/game.ts
@@ -53,6 +53,12 @@ export interface SeatGradeResponse {
    availableSeatCount: number;
 }
 
+export interface SeatGradeSearchResultResponse {
+   sessionId: string;
+   sessionExpiresAt: string;
+   seatGrades: SeatGradeResponse[];
+}
+
 // GET /api/v1/stadium-seats/stadiums/{stadiumId}/seat-sections 응답 타입
 export interface SeatSectionResponse {
    sectionId: string;


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #200 
  <br/>

  ## 🔎 개요

  오늘자 Ticketing Service Swagger 스펙에 맞춰 예매 좌석 API 응답 구조와 티켓 상세 응답 필드를 정합성 있게 반영했습니다. 예매 플로우에서 `seat-grades`, `seat-sections`, `seats` 호출 스펙 차이로 생길 수 있는 실서버 연동 문제를 수정했고, 티켓 상세 응답의 동결 상태 필드도 타입과 mock에 맞췄습니다.

  <br/>

  ## 📋 작업 내용

  - `GET /api/v1/stadium-seats/stadiums/{stadiumId}/games/{gameId}/seat-grades` 응답을 `data.seatGrades[]` 구조로 파싱하도록 수정
  - 좌석 등급 조회 응답 타입에 `sessionId`, `sessionExpiresAt`, `seatGrades` 구조 반영
  - `GET /api/v1/seats/seat-sections/{sectionId}/seats` 호출 시 `gameId` query parameter를 전달하도록 수정
  - 예매 좌석 맵 데이터 조회 흐름에서 `fetchSeats` 호출부 전체를 최신 시그니처에 맞게 수정
  - MSW mock에서 `seat-grades` 응답을 세션 정보를 포함한 객체 구조로 수정
  - MSW mock에서 `seats` 조회 시 `gameId` query parameter 누락 시 400을 반환하도록 수정
  - 티켓 상세 API 타입에 `frozen`, `frozenUntil` 필드 추가
  - 티켓 상세 mock 응답에도 `frozen`, `frozenUntil` 필드 반영