### PR TITLE
[feat] 예매 API 세션 시작 query 추가

### DIFF
--- a/src/app/providers/router/ui/BookingFlowStateGuard.tsx
+++ b/src/app/providers/router/ui/BookingFlowStateGuard.tsx
@@ -43,15 +43,17 @@ const BookingFlowStateGuard = () => {
       }
 
       if (!isCurrentBookingFlow) {
-         console.info('[BookingFlowStateGuard] booking flow exited, clearing seat selections and timer');
+         console.info('[BookingFlowStateGuard] booking flow exited, clearing booking state');
          useSeatHoldStore.getState().clearSeatHolds();
          useSeatSelectionStore.getState().clearAllSelections();
          useBookingFlowTimerStore.getState().clearTimer();
+         useBookingEntryStore.getState().clearEntry();
       } else if (previousPathname && isBookingFlowPath(previousPathname) && !isCurrentBookingFlow) {
-         console.info('[BookingFlowStateGuard] moved out of booking flow, clearing seat selections and timer');
+         console.info('[BookingFlowStateGuard] moved out of booking flow, clearing booking state');
          useSeatHoldStore.getState().clearSeatHolds();
          useSeatSelectionStore.getState().clearAllSelections();
          useBookingFlowTimerStore.getState().clearTimer();
+         useBookingEntryStore.getState().clearEntry();
       }
 
       previousPathnameRef.current = pathname;

--- a/src/app/providers/router/ui/BookingFlowStateGuard.tsx
+++ b/src/app/providers/router/ui/BookingFlowStateGuard.tsx
@@ -18,6 +18,9 @@ const BookingFlowStateGuard = () => {
    useEffect(() => {
       const previousPathname = previousPathnameRef.current;
       const isCurrentBookingFlow = isBookingFlowPath(pathname);
+      const didExitBookingFlow = Boolean(
+         previousPathname && isBookingFlowPath(previousPathname) && !isCurrentBookingFlow,
+      );
       const requiresEntry = requiresBookingEntry(pathname);
       const selectedSeatCount = Object.values(useSeatSelectionStore.getState().zones).reduce(
          (count, zone) => count + zone.selectedSeatIds.length,
@@ -42,13 +45,7 @@ const BookingFlowStateGuard = () => {
          return;
       }
 
-      if (!isCurrentBookingFlow) {
-         console.info('[BookingFlowStateGuard] booking flow exited, clearing booking state');
-         useSeatHoldStore.getState().clearSeatHolds();
-         useSeatSelectionStore.getState().clearAllSelections();
-         useBookingFlowTimerStore.getState().clearTimer();
-         useBookingEntryStore.getState().clearEntry();
-      } else if (previousPathname && isBookingFlowPath(previousPathname) && !isCurrentBookingFlow) {
+      if (didExitBookingFlow) {
          console.info('[BookingFlowStateGuard] moved out of booking flow, clearing booking state');
          useSeatHoldStore.getState().clearSeatHolds();
          useSeatSelectionStore.getState().clearAllSelections();

--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -217,9 +217,20 @@ export const getPricingDayType = (gameDate: string) => {
    return dayOfWeek === 0 || dayOfWeek === 6 ? 'WEEKEND' : 'WEEKDAY';
 };
 
-export const fetchSeatGrades = async (gameId: string, stadiumId: string) => {
+export const fetchSeatGrades = async ({
+   gameId,
+   stadiumId,
+   forceNewSession,
+}: {
+   gameId: string;
+   stadiumId: string;
+   forceNewSession?: boolean;
+}) => {
    const response = await apiClient.get<ApiEnvelope<SeatGradeSearchResultResponse>>(
       `/api/v1/stadium-seats/stadiums/${stadiumId}/games/${gameId}/seat-grades`,
+      {
+         params: forceNewSession ? { forceNewSession: true } : undefined,
+      },
    );
 
    return response.data.data?.seatGrades ?? [];

--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -45,6 +45,7 @@ const BooksPage = () => {
    const clearAllSelections = useSeatSelectionStore((state) => state.clearAllSelections);
    const clearSeatHolds = useSeatHoldStore((state) => state.clearSeatHolds);
    const clearTimer = useBookingFlowTimerStore((state) => state.clearTimer);
+   const shouldForceNewSession = Boolean(storedBookingEntryState?.forceNewSession);
    const bookingTeamConfig = useMemo(() => getBookingTeamConfig(bookingEntryState?.homeTeamId), [bookingEntryState?.homeTeamId]);
    const requiresCaptcha = Boolean(bookingEntryState?.requireCaptcha);
    const localZones = useMemo(
@@ -62,6 +63,7 @@ const BooksPage = () => {
          bookingFlowMode,
          bookingEntryState?.stadiumId,
          bookingEntryState?.gameId,
+         shouldForceNewSession,
          bookingEntryState?.serverHomeTeamId,
          bookingEntryState?.leagueType,
          bookingEntryState?.gameDate,
@@ -75,7 +77,11 @@ const BooksPage = () => {
       ),
       queryFn: async () => {
          const [grades, sections, pricingPolicy] = await Promise.all([
-            fetchSeatGrades(bookingEntryState!.gameId!, bookingEntryState!.stadiumId!),
+            fetchSeatGrades({
+               gameId: bookingEntryState!.gameId!,
+               stadiumId: bookingEntryState!.stadiumId!,
+               forceNewSession: shouldForceNewSession,
+            }),
             fetchSeatSections({
                stadiumId: bookingEntryState!.stadiumId!,
                gameId: bookingEntryState!.gameId!,
@@ -139,6 +145,16 @@ const BooksPage = () => {
          setBookingEntry(routeBookingEntryState);
       }
    }, [routeBookingEntryState, setBookingEntry]);
+
+   useEffect(() => {
+      if (!shouldForceNewSession) {
+         return;
+      }
+
+      patchBookingEntry({
+         forceNewSession: false,
+      });
+   }, [patchBookingEntry, shouldForceNewSession]);
 
    useEffect(() => {
       setSelectedZoneId(zones[0]?.id ?? '');
@@ -210,6 +226,7 @@ const BooksPage = () => {
       return {
          ...bookingEntryState,
          requireCaptcha: undefined,
+         forceNewSession: undefined,
          bookingZones: zones,
       } satisfies BookingEntryState;
    }, [bookingEntryState, zones]);

--- a/src/shared/lib/use-booking-entry-flow.tsx
+++ b/src/shared/lib/use-booking-entry-flow.tsx
@@ -24,6 +24,7 @@ export type OpenBookingEntryOptions = {
 const createBookingEntryState = (options?: OpenBookingEntryOptions): BookingEntryState => {
   return {
     requireCaptcha: true,
+    forceNewSession: true,
     homeTeamId: options?.homeTeamId,
     serverHomeTeamId: options?.serverHomeTeamId,
     gameId: options?.gameId,

--- a/src/shared/lib/useBookingEntryStore.ts
+++ b/src/shared/lib/useBookingEntryStore.ts
@@ -6,6 +6,7 @@ import type { ApiLeagueType } from '@/shared/types/game';
 
 export type BookingEntryState = {
    requireCaptcha?: boolean;
+   forceNewSession?: boolean;
    homeTeamId?: string;
    serverHomeTeamId?: string;
    gameId?: string;


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #114

<br/>

## 🔎 개요
예매 섹션이 시작됨을 알리는 query를 좌석등급 조회 로직에 추가

<br/>

## 📋 작업 내용
- 예매 플로우 이탈 시 프론트 세션 초기화
- 좌석등급 조회 API에 대해서 백엔드 최신 API 스펙에 맞춰 query추가

<br/>
