### PR TITLE
[bug] api 중복 호출 로직 삭제

### DIFF
--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -45,7 +45,7 @@ const BooksPage = () => {
    const clearAllSelections = useSeatSelectionStore((state) => state.clearAllSelections);
    const clearSeatHolds = useSeatHoldStore((state) => state.clearSeatHolds);
    const clearTimer = useBookingFlowTimerStore((state) => state.clearTimer);
-   const shouldForceNewSession = Boolean(storedBookingEntryState?.forceNewSession);
+   const shouldForceNewSessionRef = useRef(Boolean(bookingEntryState?.forceNewSession));
    const bookingTeamConfig = useMemo(() => getBookingTeamConfig(bookingEntryState?.homeTeamId), [bookingEntryState?.homeTeamId]);
    const requiresCaptcha = Boolean(bookingEntryState?.requireCaptcha);
    const localZones = useMemo(
@@ -63,7 +63,6 @@ const BooksPage = () => {
          bookingFlowMode,
          bookingEntryState?.stadiumId,
          bookingEntryState?.gameId,
-         shouldForceNewSession,
          bookingEntryState?.serverHomeTeamId,
          bookingEntryState?.leagueType,
          bookingEntryState?.gameDate,
@@ -76,6 +75,8 @@ const BooksPage = () => {
             bookingEntryState?.gameDate,
       ),
       queryFn: async () => {
+         const shouldForceNewSession = shouldForceNewSessionRef.current;
+
          const [grades, sections, pricingPolicy] = await Promise.all([
             fetchSeatGrades({
                gameId: bookingEntryState!.gameId!,
@@ -88,6 +89,14 @@ const BooksPage = () => {
             }),
             fetchTicketPricingPolicy(bookingEntryState!.serverHomeTeamId!).catch(() => undefined),
          ]);
+
+         if (shouldForceNewSession) {
+            shouldForceNewSessionRef.current = false;
+            patchBookingEntry({
+               forceNewSession: false,
+            });
+         }
+
          const remainingBySectionId =
             bookingFlowMode === 'resell'
                ? await fetchResaleListingCountsBySections(
@@ -145,16 +154,6 @@ const BooksPage = () => {
          setBookingEntry(routeBookingEntryState);
       }
    }, [routeBookingEntryState, setBookingEntry]);
-
-   useEffect(() => {
-      if (!shouldForceNewSession) {
-         return;
-      }
-
-      patchBookingEntry({
-         forceNewSession: false,
-      });
-   }, [patchBookingEntry, shouldForceNewSession]);
 
    useEffect(() => {
       setSelectedZoneId(zones[0]?.id ?? '');


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #114

<br/>

## 🔎 개요
forceNewSession에서 query의 key로 넣어 두번 동일한 api 조회

<br/>

## 📋 작업 내용
- api 중복 호출 로직 삭제

<br/>
