### PR TITLE
[bug] 좌석 등급 조회 경로 및 호출 순서 백엔드 API 스펙 반영

### DIFF
--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -241,15 +241,13 @@ export const getPricingDayType = (gameDate: string) => {
 
 export const fetchSeatGrades = async ({
    gameId,
-   stadiumId,
    forceNewSession,
 }: {
    gameId: string;
-   stadiumId: string;
    forceNewSession?: boolean;
 }) => {
    const response = await apiClient.get<ApiEnvelope<SeatGradeSearchResultResponse>>(
-      `/api/v1/stadium-seats/stadiums/${stadiumId}/games/${gameId}/seat-grades`,
+      `/api/v1/stadium-seats/games/${gameId}/seat-grades`,
       {
          params: forceNewSession ? { forceNewSession: true } : undefined,
       },

--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -78,13 +78,12 @@ const BooksPage = () => {
       ),
       queryFn: async () => {
          const shouldForceNewSession = shouldForceNewSessionRef.current;
+         const grades = await fetchSeatGrades({
+            gameId: bookingEntryState!.gameId!,
+            forceNewSession: shouldForceNewSession,
+         });
 
-         const [grades, sections, pricingPolicy] = await Promise.all([
-            fetchSeatGrades({
-               gameId: bookingEntryState!.gameId!,
-               stadiumId: bookingEntryState!.stadiumId!,
-               forceNewSession: shouldForceNewSession,
-            }),
+         const [sections, pricingPolicy] = await Promise.all([
             fetchSeatSections({
                stadiumId: bookingEntryState!.stadiumId!,
                gameId: bookingEntryState!.gameId!,

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -551,6 +551,35 @@ function SeatsPage() {
       sectionBounds,
    ]);
 
+   const getDefaultSeatMapView = () => {
+      if (!sectionBounds || mapViewportSize.width === 0 || mapViewportSize.height === 0) {
+         return {
+            scale: 1,
+            offset: { x: 0, y: 0 },
+         };
+      }
+
+      const contentWidth = sectionBounds.right - sectionBounds.left;
+      const contentHeight = sectionBounds.bottom - sectionBounds.top;
+      const availableWidth = Math.max(1, mapViewportSize.width - DEFAULT_SEAT_MAP_LEFT_PADDING * 2);
+      const availableHeight = Math.max(1, mapViewportSize.height - 56 - DEFAULT_SEAT_MAP_TOP_PADDING * 2);
+      const scale = Math.min(
+         MAX_SCALE,
+         Math.max(MIN_SCALE, Math.min(availableWidth / contentWidth, availableHeight / contentHeight)),
+      );
+      const contentCenterX = (sectionBounds.left + sectionBounds.right) / 2;
+      const contentCenterY = (sectionBounds.top + sectionBounds.bottom) / 2;
+      const targetCenterY = 56 + DEFAULT_SEAT_MAP_TOP_PADDING + availableHeight / 2;
+
+      return {
+         scale: Number(scale.toFixed(2)),
+         offset: {
+            x: (STAGE_WIDTH / 2 - contentCenterX) * scale,
+            y: targetCenterY - 56 - contentCenterY * scale,
+         },
+      };
+   };
+
    const updateSeatMapScale = (nextScale: number) => {
       setSeatMapScale(Math.min(MAX_SCALE, Math.max(MIN_SCALE, Number(nextScale.toFixed(2)))));
    };
@@ -567,7 +596,7 @@ function SeatsPage() {
 
       setSeatMapScale(nextView.scale);
       setSeatMapOffset(nextView.offset);
-   }, [mapViewportSize.height, mapViewportSize.width, stageContentBounds, zone.id]);
+   }, [mapViewportSize.height, mapViewportSize.width, sectionBounds, zone.id]);
 
    const toggleSeat = (seat: SeatItem) => {
       if (isSeatInteractionLocked) {

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -862,10 +862,14 @@ export const paymentHandlers = [
       });
    }),
 
-   http.get('/api/v1/stadium-seats/stadiums/:stadiumId/games/:gameId/seat-grades', async ({ params }) => {
-      const seatGrades = seatGradesByStadium[String(params.stadiumId)] ?? [];
+   http.get('/api/v1/stadium-seats/games/:gameId/seat-grades', async ({ params, request }) => {
+      const requestUrl = new URL(request.url);
+      const forceNewSession = requestUrl.searchParams.get('forceNewSession');
+      const gameId = String(params.gameId);
+      const stadiumId = mockGameSchedules.find((game) => game.gameId === gameId)?.stadiumId;
+      const seatGrades = stadiumId ? seatGradesByStadium[stadiumId] ?? [] : [];
       const seatGradeResult: SeatGradeSearchResult = {
-         sessionId: `seat-session-${String(params.gameId)}`,
+         sessionId: forceNewSession === 'true' ? `seat-session-new-${gameId}` : `seat-session-${gameId}`,
          sessionExpiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
          seatGrades,
       };

--- a/src/shared/types/game.ts
+++ b/src/shared/types/game.ts
@@ -44,7 +44,7 @@ export interface GetGameSchedulesParams {
    today?: boolean;
 }
 
-// GET /api/v1/stadium-seats/stadiums/{stadiumId}/games/{gameId}/seat-grades 응답 타입
+// GET /api/v1/stadium-seats/games/{gameId}/seat-grades 응답 타입
 export interface SeatGradeResponse {
    seatGradeId: string;
    stadiumId: string;


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #114
- #72

<br/>

## 🔎 개요
좌석 등급 조회 경로 수정 및 호출 순서 좌석 등급조회 이후 좌석 구역조회가 되도록 순서 고정 반영

<br/>

## 📋 작업 내용
- 좌석 등급 조회 경로 수정
- 좌석등급, 좌석 구역 조회로 순서
- 좌석선택 맵 초기화 로직 누락 복원

<br/>
