### PR TITLE
[bug] 경기 일정 조회 시 예매 시각이 아님에도 열리던 버그 해결

### DIFF
--- a/src/entities/game/api/scheduleApi.ts
+++ b/src/entities/game/api/scheduleApi.ts
@@ -1,39 +1,8 @@
 import apiClient from '@/shared/api/client';
 import type { ApiEnvelope } from '@/features/auth/api/types';
+import type { GameScheduleResponse, GetGameSchedulesParams } from '@/shared/types/game';
 
-export type FetchGameSchedulesParams = {
-  teamId?: string;
-  year?: number;
-  month?: number;
-  week?: number;
-  today?: boolean;
-};
-
-export type GameScheduleResponse = {
-  gameId: string;
-  startAt: string;
-  leagueType: string;
-  homeTeamId: string;
-  awayTeamId: string;
-  stadiumId: string;
-  gameStatus: string;
-  homeTeamScore: number;
-  awayTeamScore: number;
-  gameResult: string;
-  ticketingStatus: string;
-  ticketingOpenedAt?: string;
-  ticketingEndAt?: string;
-  // 실서버 응답 필드
-  homeTeamDisplayName?: string;
-  awayTeamDisplayName?: string;
-  stadiumLocation?: string;
-  // MSW 모의 응답 호환 필드 (실서버에는 없음)
-  homeTeamCode?: string;
-  awayTeamCode?: string;
-  homeTeamName?: string;
-  awayTeamName?: string;
-  stadiumName?: string;
-};
+export type FetchGameSchedulesParams = GetGameSchedulesParams;
 
 export type BaseballTeamDetailResponse = {
   id: string;

--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -309,6 +309,7 @@ const mapTicketStatus = (value: string): TicketStatus => {
     case 'ENDED':
     case 'EXHAUSTED':
     case 'TERMINATED':
+    case 'CANCELED':
       return '매진';
     case 'PAUSED':
       return '판매예정';

--- a/src/pages/home/ui/game-schedule/utils.ts
+++ b/src/pages/home/ui/game-schedule/utils.ts
@@ -117,7 +117,7 @@ export const getEffectiveSaleStatuses = (game: GameRow, now = new Date()): Effec
    const resellOpenTime = game.rawDate ? new Date(`${game.rawDate}T13:00:00`) : null;
    const saleBeforeOpen = saleOpenTime !== null && now < saleOpenTime;
    const saleClosed = saleEndTime !== null && now > saleEndTime;
-   const saleNowOpen = (saleOpenTime === null || now >= saleOpenTime) && (saleEndTime === null || now <= saleEndTime);
+   const saleWithinWindow = (saleOpenTime === null || now >= saleOpenTime) && (saleEndTime === null || now <= saleEndTime);
    const resellNowOpen = resellOpenTime !== null && now >= resellOpenTime;
 
    const effectiveTicket: TicketStatus = (() => {
@@ -133,7 +133,7 @@ export const getEffectiveSaleStatuses = (game: GameRow, now = new Date()): Effec
          return '매진';
       }
 
-      if (saleNowOpen) {
+      if (game.ticket === '예매하기' && saleWithinWindow) {
          return '예매하기';
       }
 

--- a/src/pages/teams/api/useGameSchedules.ts
+++ b/src/pages/teams/api/useGameSchedules.ts
@@ -35,7 +35,10 @@ function toTicketStatus(status: ApiTicketingStatus): TicketStatus {
       case 'AVAILABLE':
          return '예매하기';
       case 'EXHAUSTED':
+      case 'TERMINATED':
+      case 'CANCELED':
          return '매진';
+      case 'PAUSED':
       default:
          return '판매예정';
    }
@@ -46,7 +49,10 @@ function toResellStatus(status: ApiTicketingStatus): ReselStatus {
       case 'AVAILABLE':
          return '리셀예매';
       case 'EXHAUSTED':
+      case 'TERMINATED':
+      case 'CANCELED':
          return '리셀매진';
+      case 'PAUSED':
       default:
          return '리셀예정';
    }

--- a/src/shared/api/mocks/handlers/game.ts
+++ b/src/shared/api/mocks/handlers/game.ts
@@ -11,9 +11,14 @@ type MockGameSchedule = {
   gameStatus: 'SCHEDULED' | 'FINISHED' | 'IN_PROGRESS';
   homeTeamScore: number;
   awayTeamScore: number;
-  gameResult: 'HOME_WIN' | 'AWAY_WIN' | 'DRAW';
-  ticketingStatus: 'AVAILABLE' | 'SCHEDULED' | 'CLOSED';
+  gameResult: 'WIN' | 'LOSE' | 'DRAW';
+  ticketingStatus: 'AVAILABLE' | 'SCHEDULED' | 'TERMINATED';
   ticketingOpenedAt: string;
+  ticketingEndAt: string;
+  remainingSeatCount: number;
+  homeTeamDisplayName: string;
+  awayTeamDisplayName: string;
+  stadiumLocation: string;
 };
 
 const formatLocalDate = (value: Date) => {
@@ -45,9 +50,14 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameStatus: 'FINISHED',
     homeTeamScore: 6,
     awayTeamScore: 2,
-    gameResult: 'HOME_WIN',
-    ticketingStatus: 'CLOSED',
+    gameResult: 'WIN',
+    ticketingStatus: 'TERMINATED',
     ticketingOpenedAt: '2026-03-11 11:00',
+    ticketingEndAt: '2026-03-18 14:30',
+    remainingSeatCount: 0,
+    homeTeamDisplayName: 'KIA',
+    awayTeamDisplayName: 'LG',
+    stadiumLocation: '광주',
   },
   {
     gameId: 'game-samsung-home-today',
@@ -62,6 +72,11 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameResult: 'DRAW',
     ticketingStatus: 'AVAILABLE',
     ticketingOpenedAt: formatLocalDateTime(-7, 11, 0),
+    ticketingEndAt: formatLocalDateTime(0, 14, 30),
+    remainingSeatCount: 12543,
+    homeTeamDisplayName: '삼성',
+    awayTeamDisplayName: 'NC',
+    stadiumLocation: '대구',
   },
   {
     gameId: 'game-kia-home-tomorrow',
@@ -76,6 +91,11 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameResult: 'DRAW',
     ticketingStatus: 'AVAILABLE',
     ticketingOpenedAt: formatLocalDateTime(-6, 11, 0),
+    ticketingEndAt: formatLocalDateTime(1, 14, 30),
+    remainingSeatCount: 9632,
+    homeTeamDisplayName: 'KIA',
+    awayTeamDisplayName: 'SSG',
+    stadiumLocation: '광주',
   },
   {
     gameId: 'game-samsung-home-this-weekend',
@@ -90,6 +110,11 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameResult: 'DRAW',
     ticketingStatus: 'AVAILABLE',
     ticketingOpenedAt: formatLocalDateTime(-4, 11, 0),
+    ticketingEndAt: formatLocalDateTime(3, 10, 0),
+    remainingSeatCount: 10124,
+    homeTeamDisplayName: '삼성',
+    awayTeamDisplayName: '키움',
+    stadiumLocation: '대구',
   },
   {
     gameId: 'game-kia-home-next-week',
@@ -104,6 +129,11 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameResult: 'DRAW',
     ticketingStatus: 'AVAILABLE',
     ticketingOpenedAt: formatLocalDateTime(1, 11, 0),
+    ticketingEndAt: formatLocalDateTime(8, 14, 30),
+    remainingSeatCount: 8740,
+    homeTeamDisplayName: 'KIA',
+    awayTeamDisplayName: 'NC',
+    stadiumLocation: '광주',
   },
   {
     gameId: 'game-samsung-home-next-weekend',
@@ -118,6 +148,11 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameResult: 'DRAW',
     ticketingStatus: 'SCHEDULED',
     ticketingOpenedAt: formatLocalDateTime(5, 11, 0),
+    ticketingEndAt: formatLocalDateTime(9, 13, 0),
+    remainingSeatCount: 11032,
+    homeTeamDisplayName: '삼성',
+    awayTeamDisplayName: 'LG',
+    stadiumLocation: '대구',
   },
   {
     gameId: 'game-kia-home-two-weeks',
@@ -132,6 +167,11 @@ export const mockGameSchedules: MockGameSchedule[] = [
     gameResult: 'DRAW',
     ticketingStatus: 'AVAILABLE',
     ticketingOpenedAt: formatLocalDateTime(8, 11, 0),
+    ticketingEndAt: formatLocalDateTime(14, 14, 30),
+    remainingSeatCount: 11876,
+    homeTeamDisplayName: 'KIA',
+    awayTeamDisplayName: '두산',
+    stadiumLocation: '광주',
   },
 ];
 
@@ -145,13 +185,13 @@ const resolveGameStatus = (game: MockGameSchedule): Pick<MockGameSchedule, 'game
   const TICKETING_CLOSE_MS = 4 * 60 * 60 * 1000; // 경기 시작 4시간 전 티켓팅 마감
 
   if (now >= startMs + GAME_DURATION_MS) {
-    return { gameStatus: 'FINISHED', ticketingStatus: 'CLOSED' };
+    return { gameStatus: 'FINISHED', ticketingStatus: 'TERMINATED' };
   }
   if (now >= startMs) {
-    return { gameStatus: 'IN_PROGRESS', ticketingStatus: 'CLOSED' };
+    return { gameStatus: 'IN_PROGRESS', ticketingStatus: 'TERMINATED' };
   }
   if (now >= startMs - TICKETING_CLOSE_MS) {
-    return { gameStatus: 'SCHEDULED', ticketingStatus: 'CLOSED' };
+    return { gameStatus: 'SCHEDULED', ticketingStatus: 'TERMINATED' };
   }
   return { gameStatus: game.gameStatus, ticketingStatus: game.ticketingStatus };
 };

--- a/src/shared/types/game.ts
+++ b/src/shared/types/game.ts
@@ -17,13 +17,20 @@ export type ApiTicketingStatus =
    | 'CANCELED'
    | 'PAUSED';
 
-export type ApiGameResult = 'NONE' | 'HOME_WIN' | 'AWAY_WIN' | 'DRAW' | 'CANCELLED';
+export type ApiGameResult =
+   | 'NONE'
+   | 'HOME_WIN'
+   | 'AWAY_WIN'
+   | 'WIN'
+   | 'LOSE'
+   | 'DRAW'
+   | 'CANCELLED';
 
 export type ApiLeagueType = 'EXHIBITION' | 'REGULAR' | 'POST_SEASON';
 
 export interface GameScheduleResponse {
    gameId: string;
-   startAt: string; // ISO 8601 date-time
+   startAt: string;
    leagueType: ApiLeagueType;
    homeTeamId: string;
    awayTeamId: string;
@@ -33,7 +40,17 @@ export interface GameScheduleResponse {
    awayTeamScore: number;
    gameResult: ApiGameResult;
    ticketingStatus: ApiTicketingStatus;
-   ticketingOpenedAt: string;
+   ticketingOpenedAt?: string;
+   ticketingEndAt?: string;
+   remainingSeatCount?: number;
+   homeTeamDisplayName?: string;
+   awayTeamDisplayName?: string;
+   stadiumLocation?: string;
+   homeTeamCode?: string;
+   awayTeamCode?: string;
+   homeTeamName?: string;
+   awayTeamName?: string;
+   stadiumName?: string;
 }
 
 export interface GetGameSchedulesParams {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #118

<br/>

## 🔎 개요
경기 일정 조회 시 예매 시각이 아님에도 `ScheduleList` 컴포넌트에서 예매하기 버튼이 활성화되는 버그 수정

<br/>

## 📋 작업 내용
- TicketingStatus와 예매시각 or 계산을 and 계산으로 변경

<br/>
