### PR TITLE
[refactor] 예매 시각 지난 경우 매진으로 표시

### DIFF
--- a/src/pages/home/ui/game-schedule/utils.ts
+++ b/src/pages/home/ui/game-schedule/utils.ts
@@ -137,6 +137,10 @@ export const getEffectiveSaleStatuses = (game: GameRow, now = new Date()): Effec
          return '예매하기';
       }
 
+      if (saleOpenTime !== null && now >= saleOpenTime) {
+         return '매진';
+      }
+
       return game.ticket;
    })();
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #118
<br/>

## 🔎 개요
예매 시각이 지난 경우 `ScheduleList`에서 매진으로 표시

<br/>

## 📋 작업 내용
예매 시각이 지난 경우 `ScheduleList`에서 매진으로 표시되도록 조건문 추가

<br/>
