### PR TITLE
[feat] 티켓/리셀 페이지 예매 가능 잔여석 표시

### DIFF
--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -37,6 +37,7 @@ export type NormalizedScheduleGame = {
   isToday: boolean;
   ticketingOpenedAt?: string;
   ticketingEndAt?: string;
+  remainingSeatCount?: number;
 };
 
 type TeamReference = {
@@ -405,6 +406,7 @@ const normalizeScheduleGame = (game: GameScheduleResponse): NormalizedScheduleGa
     isToday: isSameCalendarDate(date, new Date()),
     ticketingOpenedAt: game.ticketingOpenedAt,
     ticketingEndAt: game.ticketingEndAt,
+    remainingSeatCount: game.remainingSeatCount,
   };
 };
 

--- a/src/pages/tickets/ui/TicketsPage.tsx
+++ b/src/pages/tickets/ui/TicketsPage.tsx
@@ -83,7 +83,12 @@ const TicketsPage = () => {
                date: game.date,
                dateTime: `${game.date.replace(/-/g, '.')} ${game.time}`,
                venue: game.venue,
-               remainingSeats: game.ticket === '매진' ? 0 : 999,
+               remainingSeats:
+                  game.ticket === '판매예정'
+                     ? 25000
+                     : game.ticket === '매진'
+                       ? 0
+                       : (game.remainingSeatCount ?? 0),
                resellRemainingSeats: fallbackResellStatus === '리셀 가능' ? 999 : 0,
                minPrice: 0,
                maxPrice: 0,


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #118

<br/>

## 🔎 개요
티켓 페이지 잔여석 표기 기능 추가

<br/>

## 📋 작업 내용
- 티켓 페이지 잔여석 표기 기능 추가
- 판매예정에 대해서는 25000잔여석 고정
- 매진에 대해서는 0잔여석 고정
- 판매중인 경우 경기 일정 조회 api에 추가된 잔여석 값으로 표시

<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

<br/>
