### PR TITLE
[bug] 결제 완료 이후 예매 플로우 이탈 감지 좌석 자동 hold 해체 모듈 작동 버그

### DIFF
--- a/src/features/seat-booking/ui/SeatHoldLifecycleController.tsx
+++ b/src/features/seat-booking/ui/SeatHoldLifecycleController.tsx
@@ -6,10 +6,12 @@ import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 
 const isSeatHoldManagedPath = (pathname: string) =>
-   pathname.startsWith('/books') || pathname.startsWith('/tickets/payment');
+   pathname.startsWith('/books') || pathname === '/tickets/payment' || pathname === '/tickets/payment/processing';
+
+const getSeatHolds = () => Object.values(useSeatHoldStore.getState().holdsBySeatId);
 
 const releaseAllSeatHolds = async () => {
-   const seatHolds = Object.values(useSeatHoldStore.getState().holdsBySeatId);
+   const seatHolds = getSeatHolds();
 
    if (seatHolds.length === 0) {
       return;
@@ -32,7 +34,7 @@ const releaseAllSeatHolds = async () => {
 };
 
 const releaseAllSeatHoldsKeepalive = () => {
-   const seatHolds = Object.values(useSeatHoldStore.getState().holdsBySeatId);
+   const seatHolds = getSeatHolds();
 
    if (seatHolds.length === 0) {
       return;
@@ -53,7 +55,7 @@ const SeatHoldLifecycleController = () => {
    useEffect(() => {
       const previousPathname = previousPathnameRef.current;
 
-      if (isSeatHoldManagedPath(previousPathname) && !isSeatHoldManagedPath(pathname)) {
+      if (getSeatHolds().length > 0 && isSeatHoldManagedPath(previousPathname) && !isSeatHoldManagedPath(pathname)) {
          void releaseAllSeatHolds();
       }
 
@@ -62,7 +64,7 @@ const SeatHoldLifecycleController = () => {
 
    useEffect(() => {
       const handlePageHide = () => {
-         if (!isSeatHoldManagedPath(window.location.pathname)) {
+         if (!isSeatHoldManagedPath(window.location.pathname) || getSeatHolds().length === 0) {
             return;
          }
 

--- a/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
@@ -6,6 +6,8 @@ import { getOrderPayment, type PaymentResponse } from '@/pages/tickets/api/payme
 import { Calendar, CheckCircle, ChevronLeft, MapPin } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import BooksHeader from '@/shared/widgets/layout/books/BooksHeader';
+import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
+import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 import { useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
 import { ApiError } from '@/shared/api/client';
 
@@ -129,6 +131,11 @@ export default function PaymentCompletePage() {
       return locationOrder ?? readStoredPaymentCompleteState(orderId) ?? (MOCK_ORDER as PaymentResponse);
    });
    const [paymentReloadError, setPaymentReloadError] = useState<string | null>(null);
+
+   useEffect(() => {
+      useSeatHoldStore.getState().clearSeatHolds();
+      useSeatSelectionStore.getState().clearAllSelections();
+   }, []);
 
    useEffect(() => {
       if (locationOrder?.orderId) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #115


<br/>

## 🔎 개요
결제 완료 이후 예매/결제 플로우 무단 이탈로 감지한 좌석 관리 모듈이 좌석 hold 자동 해제를 시도하여 오류가 발생하는 버그 수정
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>

## 📋 작업 내용
- 결제 완료 이후 예매/결제 플로우 무단 이탈로 감지한 좌석 관리 모듈이 좌석 hold 자동 해제를 시도하여 오류가 발생하는 버그 수정

<br/>
