### PR TITLE
[feat] 결제 완료 후 예매-결제 플로우로 이전버튼 되돌아오기 방어 로직

### DIFF
--- a/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
@@ -8,6 +8,8 @@ import { Button } from '@/shared/ui/button';
 import BooksHeader from '@/shared/widgets/layout/books/BooksHeader';
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
+import { resolveBookingEntrySourcePath } from '@/shared/lib/booking-flow';
+import { useBookingEntryStore } from '@/shared/lib/useBookingEntryStore';
 import { useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
 import { ApiError } from '@/shared/api/client';
 
@@ -122,20 +124,50 @@ const MOCK_ORDER = {
 export default function PaymentCompletePage() {
    const navigate = useNavigate();
    const [searchParams] = useSearchParams();
-   const { state } = useLocation();
+   const location = useLocation();
+   const { state } = location;
    const timeStr = useTimerStr();
    const deliveryMethod = (searchParams.get('delivery') as DeliveryMethod) ?? 'mobile';
    const orderId = searchParams.get('orderId');
    const locationOrder = state as PaymentResponse | null;
+   const clearBookingEntry = useBookingEntryStore(state => state.clearEntry);
+   const clearTimer = useBookingFlowTimerStore(state => state.clearTimer);
+   const [entrySourcePath] = useState(() =>
+      resolveBookingEntrySourcePath(useBookingEntryStore.getState().entry?.entrySourcePath),
+   );
    const [order, setOrder] = useState<PaymentResponse>(() => {
       return locationOrder ?? readStoredPaymentCompleteState(orderId) ?? (MOCK_ORDER as PaymentResponse);
    });
    const [paymentReloadError, setPaymentReloadError] = useState<string | null>(null);
 
+   const navigateToEntrySource = () => {
+      clearTimer();
+      clearBookingEntry();
+      navigate(entrySourcePath, { replace: true });
+   };
+
    useEffect(() => {
       useSeatHoldStore.getState().clearSeatHolds();
       useSeatSelectionStore.getState().clearAllSelections();
-   }, []);
+      clearTimer();
+      clearBookingEntry();
+   }, [clearBookingEntry, clearTimer]);
+
+   useEffect(() => {
+      window.history.pushState({ paymentCompleteExitGuard: true }, '', window.location.href);
+
+      const handlePopState = () => {
+         clearTimer();
+         clearBookingEntry();
+         navigate(entrySourcePath, { replace: true });
+      };
+
+      window.addEventListener('popstate', handlePopState);
+
+      return () => {
+         window.removeEventListener('popstate', handlePopState);
+      };
+   }, [clearBookingEntry, clearTimer, entrySourcePath, navigate]);
 
    useEffect(() => {
       if (locationOrder?.orderId) {
@@ -224,7 +256,7 @@ export default function PaymentCompletePage() {
             <div className="relative flex items-center justify-between pl-3 pr-5 py-2">
                <button
                   type="button"
-                  onClick={() => navigate(-1)}
+                  onClick={navigateToEntrySource}
                   className="p-1 flex items-center justify-center shrink-0"
                   aria-label="뒤로가기"
                >
@@ -373,8 +405,8 @@ export default function PaymentCompletePage() {
 
                {/* 하단 버튼 */}
                <div className="flex gap-4 justify-center w-full">
-                  <Button variant="secondary" className="flex-1 max-w-[360px] py-3" onClick={() => navigate('/')}>
-                     홈으로
+                  <Button variant="secondary" className="flex-1 max-w-[360px] py-3" onClick={navigateToEntrySource}>
+                     시작 화면으로
                   </Button>
                   <Button variant="primary" className="flex-1 max-w-[360px] py-3" onClick={actionButton.onClick}>
                      {actionButton.label}

--- a/src/shared/lib/booking-flow.ts
+++ b/src/shared/lib/booking-flow.ts
@@ -1,6 +1,7 @@
 export type BookingFlowMode = 'standard' | 'resell';
 
 const BOOKING_FLOW_QUERY_KEY = 'mode';
+export const DEFAULT_BOOKING_ENTRY_SOURCE_PATH = '/';
 
 export function getBookingFlowMode(search: string): BookingFlowMode {
    const params = new URLSearchParams(search);
@@ -18,4 +19,24 @@ export function createBookingFlowSearch(mode: BookingFlowMode): string {
    });
 
    return `?${params.toString()}`;
+}
+
+export function createBookingEntrySourcePath({
+   pathname,
+   search,
+   hash,
+}: {
+   pathname: string;
+   search?: string;
+   hash?: string;
+}) {
+   return `${pathname}${search ?? ''}${hash ?? ''}`;
+}
+
+export function resolveBookingEntrySourcePath(path?: string) {
+   if (!path?.startsWith('/')) {
+      return DEFAULT_BOOKING_ENTRY_SOURCE_PATH;
+   }
+
+   return path;
 }

--- a/src/shared/lib/use-booking-entry-flow.tsx
+++ b/src/shared/lib/use-booking-entry-flow.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
-import { createBookingFlowSearch, type BookingFlowMode } from '@/shared/lib/booking-flow';
+import {
+  createBookingEntrySourcePath,
+  createBookingFlowSearch,
+  type BookingFlowMode,
+} from '@/shared/lib/booking-flow';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import { resolveUserIdFromJwt } from '@/shared/lib/jwt';
@@ -9,6 +13,7 @@ import type { ApiLeagueType } from '@/shared/types/game';
 import BookingGuideDialog from '@/shared/ui/booking-guide-dialog';
 
 export type OpenBookingEntryOptions = {
+  entrySourcePath?: string;
   homeTeamId?: string;
   serverHomeTeamId?: string;
   gameId?: string;
@@ -26,6 +31,7 @@ const createBookingEntryState = (options?: OpenBookingEntryOptions): BookingEntr
   return {
     requireCaptcha: true,
     forceNewSession: true,
+    entrySourcePath: options?.entrySourcePath,
     homeTeamId: options?.homeTeamId,
     serverHomeTeamId: options?.serverHomeTeamId,
     gameId: options?.gameId,
@@ -50,6 +56,7 @@ type PendingEntry = {
  */
 export function useBookingEntryFlow() {
   const navigate = useNavigate();
+  const location = useLocation();
   const hasResolvedSession = useAuthStore(state => state.hasResolvedSession);
   const accessToken = useAuthStore(state => state.accessToken);
   const currentUserId = useAuthStore(state => state.currentUserId);
@@ -61,6 +68,7 @@ export function useBookingEntryFlow() {
     const nextEntryState = createBookingEntryState({
       ...options,
       userId: options?.userId ?? currentUserId ?? resolveUserIdFromJwt(accessToken) ?? undefined,
+      entrySourcePath: createBookingEntrySourcePath(location),
     });
 
     setBookingEntry(nextEntryState);

--- a/src/shared/lib/useBookingEntryStore.ts
+++ b/src/shared/lib/useBookingEntryStore.ts
@@ -7,6 +7,7 @@ import type { ApiLeagueType } from '@/shared/types/game';
 export type BookingEntryState = {
    requireCaptcha?: boolean;
    forceNewSession?: boolean;
+   entrySourcePath?: string;
    homeTeamId?: string;
    serverHomeTeamId?: string;
    gameId?: string;


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #237

<br/>

## 🔎 개요
결제 완료 후 브라우저 뒤로가기 방지로 예매-결제 플로우로 이전버튼 되돌아오기 방어 로직 구현

<br/>

## 📋 작업 내용
- 출발 경로 저장
- 완료 화면 뒤로가기 가드
- 결제 완료 화면에서 뒤로가기 시도 시 출발 경로 복귀

<br/>
