### PR TITLE
[bug] 결제완료 헤더 뒤로가기 복귀 처리

### DIFF
--- a/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
@@ -247,6 +247,7 @@ export default function PaymentCompletePage() {
                confirmBeforeExit={false}
                showTimer={false}
                currentStepIndex={3}
+               onBack={navigateToEntrySource}
             />
          </div>
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #237

<br/>

## 🔎 개요
- 결제 완료 페이지 헤더 이전 버튼 아이콘 클릭 시 결제 진행 페이지로 이동하는 버그 수정

<br/>

## 📋 작업 내용
- 결제 완료 페이지 헤더 뒤로가기시 예매 플로우 진입점으로 이동

<br/>
