### PR TITLE
[bug] 티켓 상세조회 실패시 안내 팝업 추가

### DIFF
--- a/src/entities/payment/api/paymentApi.ts
+++ b/src/entities/payment/api/paymentApi.ts
@@ -1,0 +1,38 @@
+import apiClient from '@/shared/api/client';
+import type { ApiEnvelope } from '@/features/auth/api/types';
+
+export type OrderPaymentMethod = 'CARD' | 'ACCOUNT_TRANSFER';
+export type OrderPaymentStatus = 'PENDING' | 'SUCCESS' | 'FAILED' | 'CANCELED';
+export type OrderPaymentType = 'PAYMENT' | 'REFUND';
+
+export interface OrderPaymentDetail {
+   paymentId: string;
+   orderId: string;
+   paymentType: OrderPaymentType;
+   paymentMethod: OrderPaymentMethod;
+   paymentAmount: number;
+   pgProvider: string;
+   pgTid: string;
+   paymentStatus: OrderPaymentStatus;
+   paidAt?: string;
+   failedReason?: string | null;
+}
+
+export const fetchOrderPaymentDetail = async (orderId: string): Promise<OrderPaymentDetail> => {
+   const response = await apiClient.get<ApiEnvelope<OrderPaymentDetail>>(
+      `/api/v1/payments/orders/${encodeURIComponent(orderId)}`,
+   );
+
+   return response.data.data;
+};
+
+export const formatOrderPaymentMethod = (paymentMethod?: string): string => {
+   switch (paymentMethod) {
+      case 'CARD':
+         return '카드 결제';
+      case 'ACCOUNT_TRANSFER':
+         return '무통장 입금';
+      default:
+         return paymentMethod ?? '-';
+   }
+};

--- a/src/entities/ticket/api/ticketApi.ts
+++ b/src/entities/ticket/api/ticketApi.ts
@@ -45,8 +45,14 @@ export const fetchTicketDetail = async (ticketId: string): Promise<TicketDetail>
    return response.data.data;
 };
 
-export const fetchOrderTickets = async (orderId: string): Promise<OrderTicket[]> => {
-   const response = await apiClient.get<ApiEnvelope<OrderTicket[]>>(`/api/v1/orders/${orderId}/tickets`);
+interface FetchOrderTicketsOptions {
+   mockScenario?: string;
+}
+
+export const fetchOrderTickets = async (orderId: string, options?: FetchOrderTicketsOptions): Promise<OrderTicket[]> => {
+   const response = await apiClient.get<ApiEnvelope<OrderTicket[]>>(`/api/v1/orders/${orderId}/tickets`, {
+      params: options?.mockScenario ? { mockScenario: options.mockScenario } : undefined,
+   });
    return response.data.data;
 };
 

--- a/src/pages/mypage/ui/ActionStatusDialog.tsx
+++ b/src/pages/mypage/ui/ActionStatusDialog.tsx
@@ -1,0 +1,58 @@
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { Button } from '@/shared/ui/button';
+
+interface Props {
+   open: boolean;
+   title: string;
+   message: string;
+   onClose: () => void;
+   retryLabel?: string;
+   onRetry?: () => void;
+}
+
+export default function ActionStatusDialog({
+   open,
+   title,
+   message,
+   onClose,
+   retryLabel,
+   onRetry,
+}: Props) {
+   if (!open) return null;
+
+   return createPortal(
+      <div className="fixed inset-0 z-50 flex items-end lg:items-center justify-center bg-black/50" onClick={onClose}>
+         <div
+            className="bg-background rounded-t-xl lg:rounded-xl w-full lg:w-147 max-h-[90vh] lg:max-h-190 flex flex-col shadow-xl overflow-hidden"
+            onClick={e => e.stopPropagation()}
+         >
+            <div className="relative flex items-center gap-2 p-5 shrink-0">
+               <p className="flex-1 text-[18px] font-bold text-[#161d24] leading-[1.55] text-center">{title}</p>
+               <button
+                  type="button"
+                  onClick={onClose}
+                  className="absolute right-5 top-1/2 -translate-y-1/2 text-[#161d24] hover:text-muted-foreground transition-colors"
+                  aria-label="닫기"
+               >
+                  <X size={24} />
+               </button>
+            </div>
+            <div className="flex flex-col items-center gap-4 px-5 pb-8 pt-2">
+               <p className="text-center text-[16px] text-[#374553]">{message}</p>
+               <div className="flex w-full max-w-80 gap-2">
+                  <Button type="button" variant={onRetry ? 'tertiary' : 'primary'} className="flex-1" onClick={onClose}>
+                     닫기
+                  </Button>
+                  {onRetry && (
+                     <Button type="button" className="flex-1" onClick={onRetry}>
+                        {retryLabel ?? '다시 시도'}
+                     </Button>
+                  )}
+               </div>
+            </div>
+         </div>
+      </div>,
+      document.body,
+   );
+}

--- a/src/pages/mypage/ui/CancelBookingDialog.tsx
+++ b/src/pages/mypage/ui/CancelBookingDialog.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/shared/ui/button';
 import CancelConfirmDialog from './CancelConfirmDialog';
 import { useQuery } from '@tanstack/react-query';
 import { fetchOrderTickets } from '@/entities/ticket/api/ticketApi';
+import { MYPAGE_ACTION_TICKET_INFO_ERROR_SCENARIO } from '@/shared/api/mockScenarios';
 
 export interface CancelTicketItem {
    orderId: string;
@@ -28,6 +29,7 @@ interface Props {
    isBankTransfer?: boolean;
    /** 무통장 입금이 아닐 때 결제 수단 표시용 */
    paymentMethod?: string;
+   mockTicketInfoError?: boolean;
 }
 
 // ─── Mock: 등록된 계좌 (없으면 null) ──────────────────────────────
@@ -74,6 +76,7 @@ export default function CancelBookingDialog({
    seats: _seats,
    isBankTransfer = false,
    paymentMethod,
+   mockTicketInfoError = false,
 }: Props) {
    const [checkedSeats, setCheckedSeats] = useState<Set<number>>(new Set());
    const [confirmOpen, setConfirmOpen] = useState(false);
@@ -87,8 +90,11 @@ export default function CancelBookingDialog({
    }, [open]);
 
    const orderTicketsQuery = useQuery({
-      queryKey: ['cancelOrderTickets', orderId],
-      queryFn: () => fetchOrderTickets(orderId),
+      queryKey: ['cancelOrderTickets', orderId, mockTicketInfoError],
+      queryFn: () =>
+         fetchOrderTickets(orderId, {
+            mockScenario: mockTicketInfoError ? MYPAGE_ACTION_TICKET_INFO_ERROR_SCENARIO : undefined,
+         }),
       enabled: open && Boolean(orderId),
       staleTime: 0,
    });

--- a/src/pages/mypage/ui/HistoryCard.tsx
+++ b/src/pages/mypage/ui/HistoryCard.tsx
@@ -176,17 +176,20 @@ export default function HistoryCard(props: HistoryCardProps) {
             />
          )}
          {isPurchase && qrOpen && (
-            actionTicketsQuery.isLoading ? null : actionTickets.length > 0 ? (
-               <QrViewDialog
-                  open={qrOpen}
-                  onClose={() => setQrOpen(false)}
-                  seats={actionTickets.map((ticket) => ({
-                     ticketId: ticket.ticketId,
-                     section: ticket.seatInfo.split(' ')[0] ?? '',
-                     seatDetail: ticket.seatInfo,
-                  }))}
-               />
-            ) : null
+            <QrViewDialog
+               open={qrOpen}
+               onClose={() => setQrOpen(false)}
+               seats={actionTickets.map((ticket) => ({
+                  ticketId: ticket.ticketId,
+                  section: ticket.seatInfo.split(' ')[0] ?? '',
+                  seatDetail: ticket.seatInfo,
+               }))}
+               isTicketInfoLoading={actionTicketsQuery.isLoading}
+               isTicketInfoError={actionTicketsQuery.isError}
+               onRetryTicketInfo={() => {
+                  void actionTicketsQuery.refetch();
+               }}
+            />
          )}
 
          <div

--- a/src/pages/mypage/ui/HistoryCard.tsx
+++ b/src/pages/mypage/ui/HistoryCard.tsx
@@ -12,6 +12,7 @@ import ResellRegisterDialog from './ResellRegisterDialog';
 import QrViewDialog from './QrViewDialog';
 import CancelBookingDialog from './CancelBookingDialog';
 import NoAccountDialog from './NoAccountDialog';
+import ActionStatusDialog from './ActionStatusDialog';
 import { fetchOrderTickets } from '@/entities/ticket/api/ticketApi';
 import { MYPAGE_ACTION_TICKET_INFO_ERROR_SCENARIO } from '@/shared/api/mockScenarios';
 
@@ -149,7 +150,24 @@ export default function HistoryCard(props: HistoryCardProps) {
       <>
          {/* 구매 전용 다이얼로그 */}
          {isPurchase && resellOpen && purchaseItem && (
-            actionTicketsQuery.isLoading ? null : actionTickets.length > 0 ? (
+            actionTicketsQuery.isLoading ? (
+               <ActionStatusDialog
+                  open={resellOpen}
+                  title="리셀 판매 등록"
+                  message="판매 가능한 티켓 정보를 불러오는 중입니다."
+                  onClose={() => setResellOpen(false)}
+               />
+            ) : actionTicketsQuery.isError ? (
+               <ActionStatusDialog
+                  open={resellOpen}
+                  title="리셀 판매 등록"
+                  message="판매 가능한 티켓 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요."
+                  onClose={() => setResellOpen(false)}
+                  onRetry={() => {
+                     void actionTicketsQuery.refetch();
+                  }}
+               />
+            ) : actionTickets.length > 0 ? (
                <ResellRegisterDialog
                   open={resellOpen}
                   onClose={() => setResellOpen(false)}
@@ -159,7 +177,14 @@ export default function HistoryCard(props: HistoryCardProps) {
                      ticketIds: actionTickets.map((ticket) => ticket.ticketId),
                   }}
                />
-            ) : null
+            ) : (
+               <ActionStatusDialog
+                  open={resellOpen}
+                  title="리셀 판매 등록"
+                  message="판매 가능한 티켓이 없습니다."
+                  onClose={() => setResellOpen(false)}
+               />
+            )
          )}
          {isPurchase && noAccountOpen && (
             <NoAccountDialog open={noAccountOpen} onClose={() => setNoAccountOpen(false)} />

--- a/src/pages/mypage/ui/HistoryCard.tsx
+++ b/src/pages/mypage/ui/HistoryCard.tsx
@@ -13,6 +13,7 @@ import QrViewDialog from './QrViewDialog';
 import CancelBookingDialog from './CancelBookingDialog';
 import NoAccountDialog from './NoAccountDialog';
 import { fetchOrderTickets } from '@/entities/ticket/api/ticketApi';
+import { MYPAGE_ACTION_TICKET_INFO_ERROR_SCENARIO } from '@/shared/api/mockScenarios';
 
 // ── 타입 ────────────────────────────────────────────────────────────
 
@@ -63,6 +64,7 @@ export interface SaleHistoryItem {
 
 type HistoryCardProps = ({ mode: 'purchase'; item: PurchaseHistoryItem } | { mode: 'sale'; item: SaleHistoryItem }) & {
    onResellCompleteConfirm?: () => void;
+   mockTicketInfoError?: boolean;
 };
 
 // ── 유틸 ─────────────────────────────────────────────────────────────
@@ -99,12 +101,16 @@ export default function HistoryCard(props: HistoryCardProps) {
    const [qrOpen, setQrOpen] = useState(false);
 
    const { mode, item } = props;
+   const mockTicketInfoError = props.mockTicketInfoError ?? false;
    const isPurchase = mode === 'purchase';
    const purchaseItem = isPurchase ? (item as PurchaseHistoryItem) : null;
    const purchaseOrderId = purchaseItem?.rawOrderId;
    const actionTicketsQuery = useQuery({
-      queryKey: ['historyCardOrderTickets', purchaseOrderId],
-      queryFn: () => fetchOrderTickets(purchaseOrderId!),
+      queryKey: ['historyCardOrderTickets', purchaseOrderId, mockTicketInfoError],
+      queryFn: () =>
+         fetchOrderTickets(purchaseOrderId!, {
+            mockScenario: mockTicketInfoError ? MYPAGE_ACTION_TICKET_INFO_ERROR_SCENARIO : undefined,
+         }),
       enabled: isPurchase && Boolean(purchaseOrderId) && (qrOpen || resellOpen),
       staleTime: 0,
    });
@@ -164,6 +170,7 @@ export default function HistoryCard(props: HistoryCardProps) {
                onClose={() => setCancelOpen(false)}
                orderId={purchaseItem.rawOrderId ?? purchaseItem.id}
                game={{ teams: item.game.teams, datetime: item.game.datetime }}
+               mockTicketInfoError={mockTicketInfoError}
                seats={item.game.seats.map(seat => ({
                   orderId: item.orderId,
                   section: item.game.section,

--- a/src/pages/mypage/ui/MypagePage.tsx
+++ b/src/pages/mypage/ui/MypagePage.tsx
@@ -7,6 +7,9 @@ import HistoryCard from './HistoryCard';
 import { Button } from '@/shared/ui/button';
 import { DatePicker } from '@/shared/ui/date-picker';
 import { useMyProfileData, useMyOrdersData, useMyResaleListData } from '../model/useMypageData';
+import { isMswEnabled } from '@/shared/config/runtime';
+
+const MYPAGE_MSW_TICKET_INFO_ERROR_KEY = '__mypage_msw_ticket_info_error__';
 
 type HistoryTab = 'purchase' | 'sale';
 type PurchaseStatusFilter = '전체' | '입금 대기' | '예매 완료' | '부분 처리' | '관람 완료' | '취소/환불';
@@ -77,6 +80,7 @@ export default function MypagePage() {
    const [searchQuery, setSearchQuery] = useState('');
    const [appliedSearchQuery, setAppliedSearchQuery] = useState('');
    const [searchError, setSearchError] = useState('');
+   const [mockTicketInfoError, setMockTicketInfoError] = useState(false);
 
    useEffect(() => {
       const handleClickOutside = (e: MouseEvent) => {
@@ -89,6 +93,11 @@ export default function MypagePage() {
       };
       document.addEventListener('mousedown', handleClickOutside);
       return () => document.removeEventListener('mousedown', handleClickOutside);
+   }, []);
+
+   useEffect(() => {
+      if (!isMswEnabled || typeof window === 'undefined') return;
+      setMockTicketInfoError(window.localStorage.getItem(MYPAGE_MSW_TICKET_INFO_ERROR_KEY) === 'true');
    }, []);
 
    const [appliedStartDate, setAppliedStartDate] = useState('');
@@ -194,6 +203,32 @@ export default function MypagePage() {
          <div className="flex-1 bg-background px-4">
             <div className="mx-auto max-w-300 pt-7.5 lg:pt-12.5 pb-30">
                <h1 className="text-[30px] font-bold text-foreground mb-8">MY고티</h1>
+
+               {isMswEnabled && (
+                  <div className="mb-4 rounded-[14px] border border-[#d0d6db] bg-[#f7f8f9] p-4">
+                     <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                        <div className="flex flex-col gap-1">
+                           <p className="text-body-1-bold text-foreground">MSW 테스트</p>
+                           <p className="text-caption-1-regular text-muted-foreground">
+                              켜두면 구매 내역의 QR 확인, 예매 취소에서 티켓 정보 조회를 실패시켜 팝업 예외 상태를 확인할 수 있습니다.
+                           </p>
+                        </div>
+                        <label className="flex items-center gap-2 text-body-2-medium text-foreground">
+                           <input
+                              type="checkbox"
+                              checked={mockTicketInfoError}
+                              onChange={(e) => {
+                                 const nextValue = e.target.checked;
+                                 setMockTicketInfoError(nextValue);
+                                 window.localStorage.setItem(MYPAGE_MSW_TICKET_INFO_ERROR_KEY, String(nextValue));
+                              }}
+                              className="size-4 rounded border border-[#acb4bb]"
+                           />
+                           티켓 정보 조회 실패
+                        </label>
+                     </div>
+                  </div>
+               )}
 
                <div className="flex flex-col gap-4">
                   {/* 유저 정보 카드 */}
@@ -518,7 +553,12 @@ export default function MypagePage() {
                                     {pageItems.length > 0 ? (
                                        activeTab === 'purchase' ? (
                                           (pageItems as typeof filteredPurchaseItems).map(item => (
-                                             <HistoryCard key={item.id} mode="purchase" item={item} />
+                                             <HistoryCard
+                                                key={item.id}
+                                                mode="purchase"
+                                                item={item}
+                                                mockTicketInfoError={mockTicketInfoError}
+                                             />
                                           ))
                                        ) : (
                                           (pageItems as typeof filteredSaleItems).map(item => (

--- a/src/pages/mypage/ui/PurchaseDetailPage.tsx
+++ b/src/pages/mypage/ui/PurchaseDetailPage.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/shared/ui/button';
 import { useQuery } from '@tanstack/react-query';
 import { fetchTicketDetail, fetchOrderTickets } from '@/entities/ticket/api/ticketApi';
 import type { OrderTicket } from '@/entities/ticket/api/ticketApi';
+import { fetchOrderPaymentDetail, formatOrderPaymentMethod } from '@/entities/payment/api/paymentApi';
 import StatusBadge from './StatusBadge';
 import type { BadgeVariant } from './StatusBadge';
 import TicketItem from './TicketItem';
@@ -143,6 +144,13 @@ export default function PurchaseDetailPage() {
       retry: false,
    });
 
+   const orderPaymentQuery = useQuery({
+      queryKey: ['orderPaymentDetail', orderId],
+      queryFn: () => fetchOrderPaymentDetail(orderId!),
+      enabled: Boolean(orderId),
+      retry: false,
+   });
+
    const apiDetail = ticketDetailQuery.data;
    const isLoading = orderTicketsQuery.isLoading || (Boolean(primaryTicketId) && ticketDetailQuery.isLoading);
    const isError =
@@ -180,8 +188,11 @@ export default function PurchaseDetailPage() {
       const ticketAmount = seatItems.reduce((sum, s) => sum + s.price, 0);
       const fee = orderTickets.reduce((sum, t) => sum + (t.serviceFee ?? 0), 0);
       const total = ticketAmount + fee;
-
-      const paymentMethodDisplay = apiDetail.paymentMethodDisplay ?? apiDetail.paymentMethod ?? '-';
+      const paymentMethodDisplay = orderPaymentQuery.data?.paymentMethod
+         ? formatOrderPaymentMethod(orderPaymentQuery.data.paymentMethod)
+         : (apiDetail.paymentMethodDisplay ?? apiDetail.paymentMethod ?? '-');
+      const paidAt = orderPaymentQuery.data?.paidAt ?? apiDetail.issuedAt;
+      const paymentAmount = orderPaymentQuery.data?.paymentAmount ?? total;
 
       return {
          id: apiDetail.ticketId,
@@ -204,14 +215,15 @@ export default function PurchaseDetailPage() {
          seatInfo: apiDetail.seatInfo,
          ticketPrice: apiDetail.ticketPrice,
          paymentMethodDisplay,
+         paidAt,
          seatItems,
          paymentSummary: {
             status: isInvalid ? '결제 완료' : '결제 완료',
             ticketCount,
             ticketAmount,
             fee,
-            total,
-            date: apiDetail.issuedAt,
+            total: paymentAmount,
+            date: paidAt,
             bankAccount: undefined as string | undefined,
             bankDeadline: undefined as string | undefined,
          },
@@ -222,7 +234,7 @@ export default function PurchaseDetailPage() {
                  cancelFee: 0,
                  refundTotal: ticketAmount,
                  method: paymentMethodDisplay,
-                 date: apiDetail.issuedAt,
+                 date: paidAt,
               }
             : undefined,
          canCancel: apiDetail.ticketStatus === 'ISSUED',
@@ -233,7 +245,7 @@ export default function PurchaseDetailPage() {
          deliveryCarrier: undefined as string | undefined,
          deliveryTrackingNumber: undefined as string | undefined,
       };
-   }, [apiDetail, orderTickets]);
+   }, [apiDetail, orderPaymentQuery.data, orderTickets]);
 
    if (isLoading) return <div className="py-24 text-center text-body-1-regular">정보를 불러오는 중입니다...</div>;
    if (isError || !detail) {
@@ -399,7 +411,7 @@ export default function PurchaseDetailPage() {
                      {/* 결제 수단/일시 */}
                      <div className="flex flex-col gap-3">
                         <InfoRow label="결제 수단" value={detail.paymentMethodDisplay} />
-                        <InfoRow label="결제 일시" value={detail.issuedAt ? formatDateTime(detail.issuedAt) : '-'} />
+                        <InfoRow label="결제 일시" value={detail.paidAt ? formatDateTime(detail.paidAt) : '-'} />
                      </div>
                   </SectionCard>
                )}
@@ -423,7 +435,7 @@ export default function PurchaseDetailPage() {
                      {/* 환불 수단/일시 */}
                      <div className="flex flex-col gap-3">
                         <InfoRow label="환불 수단" value={detail.paymentMethodDisplay} />
-                        <InfoRow label="취소 일시" value={detail.issuedAt ? formatDateTime(detail.issuedAt) : '-'} />
+                        <InfoRow label="취소 일시" value={detail.paidAt ? formatDateTime(detail.paidAt) : '-'} />
                      </div>
                      {/* 안내 문구 */}
                      <div className="bg-[#f7f8f9] rounded-xl p-5">

--- a/src/pages/mypage/ui/QrViewDialog.tsx
+++ b/src/pages/mypage/ui/QrViewDialog.tsx
@@ -20,6 +20,9 @@ interface QrViewDialogProps {
    open: boolean;
    onClose: () => void;
    seats: QrSeat[];
+   isTicketInfoLoading?: boolean;
+   isTicketInfoError?: boolean;
+   onRetryTicketInfo?: () => void;
 }
 
 function formatTime(seconds: number): string {
@@ -35,7 +38,14 @@ function getRemainingSeconds(expiresAt?: string): number {
    return Math.max(diffSeconds, 0);
 }
 
-export default function QrViewDialog({ open, onClose, seats }: QrViewDialogProps) {
+export default function QrViewDialog({
+   open,
+   onClose,
+   seats,
+   isTicketInfoLoading = false,
+   isTicketInfoError = false,
+   onRetryTicketInfo,
+}: QrViewDialogProps) {
    const [currentIndex, setCurrentIndex] = useState(0);
    const [timeLeft, setTimeLeft] = useState(QR_DURATION);
 
@@ -84,7 +94,68 @@ export default function QrViewDialog({ open, onClose, seats }: QrViewDialogProps
       setTimeLeft(QR_DURATION);
    }, [currentTicketId, qrQuery]);
 
-   if (!currentSeat) return null;
+   const renderStatusContent = () => {
+      switch (true) {
+         case isTicketInfoLoading:
+            return (
+               <div className="flex flex-col items-center gap-4 px-5 pt-[30px] pb-5 text-center">
+                  <p className="text-[18px] font-bold text-[#161d24] leading-[1.55]">QR 확인</p>
+                  <p className="text-[16px] text-[#374553]">티켓 정보를 불러오는 중입니다.</p>
+                  <Button variant="primary" className="w-full py-1.5" onClick={onClose}>
+                     닫기
+                  </Button>
+               </div>
+            );
+         case isTicketInfoError:
+            return (
+               <div className="flex flex-col items-center gap-4 px-5 pt-[30px] pb-5 text-center">
+                  <p className="text-[18px] font-bold text-[#161d24] leading-[1.55]">QR 확인</p>
+                  <p className="text-[16px] text-[#374553]">
+                     티켓 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+                  </p>
+                  <div className="flex w-full gap-2">
+                     <Button variant="tertiary" className="flex-1 py-1.5" onClick={onClose}>
+                        닫기
+                     </Button>
+                     <Button variant="primary" className="flex-1 py-1.5" onClick={onRetryTicketInfo}>
+                        다시 시도
+                     </Button>
+                  </div>
+               </div>
+            );
+         case !currentSeat:
+            return (
+               <div className="flex flex-col items-center gap-4 px-5 pt-[30px] pb-5 text-center">
+                  <p className="text-[18px] font-bold text-[#161d24] leading-[1.55]">QR 확인</p>
+                  <p className="text-[16px] text-[#374553]">표시할 티켓이 없습니다.</p>
+                  <Button variant="primary" className="w-full py-1.5" onClick={onClose}>
+                     닫기
+                  </Button>
+               </div>
+            );
+         case qrQuery.isError:
+            return (
+               <div className="flex flex-col items-center gap-4 px-5 pt-[30px] pb-5 text-center">
+                  <p className="text-[18px] font-bold text-[#161d24] leading-[1.55]">QR 확인</p>
+                  <p className="text-[16px] text-[#374553]">
+                     QR 코드를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+                  </p>
+                  <div className="flex w-full gap-2">
+                     <Button variant="tertiary" className="flex-1 py-1.5" onClick={onClose}>
+                        닫기
+                     </Button>
+                     <Button variant="primary" className="flex-1 py-1.5" onClick={handleRefresh}>
+                        다시 시도
+                     </Button>
+                  </div>
+               </div>
+            );
+         default:
+            return null;
+      }
+   };
+
+   const statusContent = renderStatusContent();
 
    return (
       <Dialog open={open} onOpenChange={isOpen => { if (!isOpen) onClose(); }}>
@@ -92,95 +163,96 @@ export default function QrViewDialog({ open, onClose, seats }: QrViewDialogProps
             showCloseButton={false}
             className="p-0 w-[340px] max-w-[340px] rounded-[16px] border-0 bg-white overflow-hidden"
          >
-            <div className="flex flex-col items-center gap-6 px-5 pt-[30px] pb-5">
+            {statusContent ?? (
+               <div className="flex flex-col items-center gap-6 px-5 pt-[30px] pb-5">
 
-               {/* 좌석 정보 */}
-               <div className="flex flex-col items-center">
-                  <p className="text-[18px] font-bold text-[#161d24] leading-[1.55]">{currentSeat.section}</p>
-                  <p className="text-[14px] font-medium text-[#646f7c] leading-[1.5]">{currentSeat.seatDetail}</p>
-               </div>
+                  {/* 좌석 정보 */}
+                  <div className="flex flex-col items-center">
+                     <p className="text-[18px] font-bold text-[#161d24] leading-[1.55]">{currentSeat.section}</p>
+                     <p className="text-[14px] font-medium text-[#646f7c] leading-[1.5]">{currentSeat.seatDetail}</p>
+                  </div>
 
-               {/* QR + 네비게이션 */}
-               <div className="flex flex-col items-center gap-2">
+                  {/* QR + 네비게이션 */}
+                  <div className="flex flex-col items-center gap-2">
 
-                  {/* 도트 인디케이터 */}
-                  {seats.length > 1 && (
-                     <div className="flex gap-3 h-2">
-                        {seats.map((_, i) => (
-                           <button
-                              key={i}
-                              type="button"
-                              className={`w-2 h-2 rounded-full transition-colors ${
-                                 i === currentIndex ? 'bg-primary' : 'bg-[#d0d6db]'
-                              }`}
-                              onClick={() => setCurrentIndex(i)}
+                     {/* 도트 인디케이터 */}
+                     {seats.length > 1 && (
+                        <div className="flex gap-3 h-2">
+                           {seats.map((_, i) => (
+                              <button
+                                 key={i}
+                                 type="button"
+                                 className={`w-2 h-2 rounded-full transition-colors ${
+                                    i === currentIndex ? 'bg-primary' : 'bg-[#d0d6db]'
+                                 }`}
+                                 onClick={() => setCurrentIndex(i)}
+                              />
+                           ))}
+                        </div>
+                     )}
+
+                     {/* QR 이미지 + 좌우 화살표 */}
+                     <div className="flex items-center gap-5">
+                        <button
+                           type="button"
+                           className="text-[#646f7c] disabled:opacity-30"
+                           onClick={() => setCurrentIndex(prev => Math.max(0, prev - 1))}
+                           disabled={currentIndex === 0}
+                        >
+                           <ChevronLeft size={24} />
+                        </button>
+
+                        <div className="w-[200px] h-[200px] flex items-center justify-center bg-surface rounded-xl overflow-hidden">
+                           <img
+                              src={QR_IMAGE_SRC}
+                              alt="QR 코드"
+                              className="w-full h-full object-contain"
                            />
-                        ))}
-                     </div>
-                  )}
+                        </div>
 
-                  {/* QR 이미지 + 좌우 화살표 */}
-                  <div className="flex items-center gap-5">
-                     <button
-                        type="button"
-                        className="text-[#646f7c] disabled:opacity-30"
-                        onClick={() => setCurrentIndex(prev => Math.max(0, prev - 1))}
-                        disabled={currentIndex === 0}
-                     >
-                        <ChevronLeft size={24} />
-                     </button>
-
-                     <div className="w-[200px] h-[200px] flex items-center justify-center bg-surface rounded-xl overflow-hidden">
-                        <img
-                           src={QR_IMAGE_SRC}
-                           alt="QR 코드"
-                           className="w-full h-full object-contain"
-                        />
+                        <button
+                           type="button"
+                           className="text-[#646f7c] disabled:opacity-30"
+                           onClick={() => setCurrentIndex(prev => Math.min(seats.length - 1, prev + 1))}
+                           disabled={currentIndex === seats.length - 1}
+                        >
+                           <ChevronRight size={24} />
+                        </button>
                      </div>
 
-                     <button
-                        type="button"
-                        className="text-[#646f7c] disabled:opacity-30"
-                        onClick={() => setCurrentIndex(prev => Math.min(seats.length - 1, prev + 1))}
-                        disabled={currentIndex === seats.length - 1}
+                     {/* 타이머 */}
+                     <div className="flex items-center gap-1.5 px-1.5">
+                        <Clock size={16} className="text-destructive" />
+                        <span className="text-[11px] font-medium text-destructive leading-[1.45]">
+                           {formatTime(timeLeft)}
+                        </span>
+                     </div>
+                  </div>
+
+                  {/* 안내 텍스트 */}
+                  <div className="flex flex-col items-center">
+                     <p className="text-[16px] font-semibold text-[#161d24] leading-[1.5]">입장을 위한 QR코드</p>
+                     <p className="text-[14px] text-[#646f7c] leading-[1.5]">생성된 QR코드를 입장시 보여주세요.</p>
+                  </div>
+
+                  {/* 버튼 */}
+                  <div className="flex flex-col gap-1.5 w-full">
+                     <Button
+                        variant="none"
+                        className="w-full border border-border rounded-lg py-1.5 gap-2 hover:bg-surface hover:border-[#b0b8c1] transition-colors"
+                        onClick={handleRefresh}
                      >
-                        <ChevronRight size={24} />
-                     </button>
-                  </div>
-
-                  {/* 타이머 */}
-                  <div className="flex items-center gap-1.5 px-1.5">
-                     <Clock size={16} className="text-destructive" />
-                     <span className="text-[11px] font-medium text-destructive leading-[1.45]">
-                        {formatTime(timeLeft)}
-                     </span>
-                  </div>
-               </div>
-
-               {/* 안내 텍스트 */}
-               <div className="flex flex-col items-center">
-                  <p className="text-[16px] font-semibold text-[#161d24] leading-[1.5]">입장을 위한 QR코드</p>
-                  <p className="text-[14px] text-[#646f7c] leading-[1.5]">생성된 QR코드를 입장시 보여주세요.</p>
-               </div>
-
-               {/* 버튼 */}
-               <div className="flex flex-col gap-1.5 w-full">
-                  <Button
-                     variant="none"
-                     className="w-full border border-border rounded-lg py-1.5 gap-2 hover:bg-surface hover:border-[#b0b8c1] transition-colors"
-                     onClick={handleRefresh}
-                  >
-                     <RefreshCcw size={16} />
-                     <span className="text-[14px] font-medium text-[#374553]">새로고침</span>
-                  </Button>
-                  <DialogClose asChild>
-                     <Button variant="primary" className="w-full py-1.5" onClick={onClose}>
-                        닫기
+                        <RefreshCcw size={16} />
+                        <span className="text-[14px] font-medium text-[#374553]">새로고침</span>
                      </Button>
-                  </DialogClose>
+                     <DialogClose asChild>
+                        <Button variant="primary" className="w-full py-1.5" onClick={onClose}>
+                           닫기
+                        </Button>
+                     </DialogClose>
+                  </div>
                </div>
-
-            </div>
+            )}
          </DialogContent>
       </Dialog>
    );

--- a/src/pages/mypage/ui/ResellRegisterDialog.tsx
+++ b/src/pages/mypage/ui/ResellRegisterDialog.tsx
@@ -9,8 +9,9 @@ import ResellRegisterCompleteDialog from './ResellRegisterCompleteDialog';
 import type { ResellZoneInsights } from '@/pages/books/model/resellData';
 import ResellPriceChart from '@/pages/books/ui/components/ResellPriceChart';
 import { formatPrice } from '@/pages/books/model/zoneData';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { createResaleListing } from '@/entities/resale/api/resaleApi';
+import { getErrorMessage } from '@/shared/lib/error/getErrorMessage';
 
 interface Props {
    open: boolean;
@@ -107,17 +108,18 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
 
    const [isSubmitting, setIsSubmitting] = useState(false);
    const queryClient = useQueryClient();
-   const mutation = useMutation({
-      mutationFn: createResaleListing,
-      onSuccess: () => {
-         queryClient.invalidateQueries({ queryKey: ['myResales'] });
-         setCompleteOpen(true);
-      },
-      onError: (error) => {
-         alert('판매 등록에 실패했습니다. 다시 시도해주세요.');
-         console.error('Resale listing failed:', error);
+
+   const getResaleRegisterAlertMessage = (error: unknown) => {
+      const message = getErrorMessage(error, '판매 등록에 실패했습니다. 다시 시도해주세요.');
+
+      switch (message) {
+         case '이미 등록된 티켓입니다':
+         case '판매가는 35000원 ~ 65000원 이내여야 합니다.':
+            return message;
+         default:
+            return '판매 등록에 실패했습니다. 다시 시도해주세요.';
       }
-   });
+   };
 
    // 열릴 때마다 상태 초기화
    useEffect(() => {
@@ -177,8 +179,8 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
          await Promise.all(requests.map(r => createResaleListing(r)));
          queryClient.invalidateQueries({ queryKey: ['myResales'] });
          setCompleteOpen(true);
-      } catch {
-         alert('판매 등록에 실패했습니다. 다시 시도해주세요.');
+      } catch (error) {
+         alert(getResaleRegisterAlertMessage(error));
       } finally {
          setIsSubmitting(false);
       }

--- a/src/shared/api/mockScenarios.ts
+++ b/src/shared/api/mockScenarios.ts
@@ -1,0 +1,1 @@
+export const MYPAGE_ACTION_TICKET_INFO_ERROR_SCENARIO = 'mypage-action-ticket-info-error';

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -1200,6 +1200,32 @@ export const paymentHandlers = [
       });
    }),
 
+   http.get('/api/v1/payments/orders/:orderId', async ({ params }) => {
+      const orderId = String(params.orderId);
+      const payment = Array.from(ticketPayments.values()).find((item) => item.orderId === orderId);
+
+      if (!payment) {
+         return buildErrorResponse('Payment not found.', 404);
+      }
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            paymentId: payment.paymentId,
+            orderId: payment.orderId,
+            paymentType: 'PAYMENT',
+            paymentMethod: payment.paymentMethod,
+            paymentAmount: payment.paymentAmount,
+            pgProvider: 'MOCK',
+            pgTid: payment.pgTid,
+            paymentStatus: payment.paymentStatus,
+            paidAt: payment.paidAt,
+            failedReason: null,
+         },
+      });
+   }),
+
    http.post('/api/v1/resales/holds', async ({ request }) => {
       const body = (await request.json()) as {
          listingId?: string;

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw';
 import { teams } from '@/entities/team/model/teams';
+import { MYPAGE_ACTION_TICKET_INFO_ERROR_SCENARIO } from '@/shared/api/mockScenarios';
 import { mockGameSchedules } from './game';
 
 // serverTeamId → 팀 단축명 조회 맵
@@ -743,6 +744,78 @@ const isTicketPaymentMethod = (paymentMethod: unknown) => {
       paymentMethod === 'ACCOUNT_TRANSFER'
    );
 };
+
+const ensureMockPurchaseHistorySeed = () => {
+   const seedOrderId = 'mock-order-mypage-actions';
+   if (ticketOrders.has(seedOrderId)) {
+      return;
+   }
+
+   const seedGame = mockGameSchedules.find((game) => game.gameId === 'game-kia-home-tomorrow');
+   if (!seedGame) {
+      return;
+   }
+
+   const seedSeatIds = [
+      'section-stadium-kia-champions-field-104-A-9',
+      'section-stadium-kia-champions-field-104-A-10',
+   ];
+   const seedTicketIds = seedSeatIds.map((_, index) => `mock-ticket-mypage-actions-${index + 1}`);
+   const orderedAt = new Date(new Date(seedGame.startAt.replace(' ', 'T')).getTime() - 2 * 24 * 60 * 60 * 1000).toISOString();
+   const serviceFee = 1000;
+
+   const seatInfos = seedSeatIds.map((seatId) => buildSeatInfoStr(seatId));
+   const ticketPrices = seedSeatIds.map((seatId) => resolveSeatPrice(seedGame.homeTeamId, seatId, seedGame.startAt));
+   const totalAmount = ticketPrices.reduce((sum, price) => sum + price + serviceFee, 0);
+
+   ticketOrders.set(seedOrderId, {
+      orderId: seedOrderId,
+      orderNumber: 'T241231ABC123',
+      gameId: seedGame.gameId,
+      stadiumId: seedGame.stadiumId,
+      orderStatus: 'CONFIRMED',
+      totalQuantity: seedSeatIds.length,
+      totalAmount,
+      holdIds: [],
+      orderedAt,
+      homeTeamName: seedGame.homeTeamDisplayName,
+      awayTeamName: seedGame.awayTeamDisplayName,
+      stadiumName: `${seedGame.stadiumLocation} ${seedGame.homeTeamDisplayName} 홈구장`,
+      gameStartAt: seedGame.startAt,
+      seatGradeName: resolveSeatGradeName(seedSeatIds[0]) ?? '좌석 정보',
+      ticketIds: seedTicketIds,
+      seatInfos,
+      ordererName: '홍길동',
+   });
+
+   seedTicketIds.forEach((ticketId, index) => {
+      ticketRecords.set(ticketId, {
+         ticketId,
+         ticketNumber: `TKT-MOCK-${index + 1}`,
+         orderItemId: `mock-order-item-mypage-actions-${index + 1}`,
+         orderId: seedOrderId,
+         gameId: seedGame.gameId,
+         seatId: seedSeatIds[index],
+         qrToken: `mock-qr-mypage-actions-${index + 1}`,
+         gameTitle: `${seedGame.awayTeamDisplayName} vs ${seedGame.homeTeamDisplayName}`,
+         gameDate: seedGame.startAt,
+         stadiumName: `${seedGame.stadiumLocation} ${seedGame.homeTeamDisplayName} 홈구장`,
+         seatInfo: seatInfos[index],
+         ticketPrice: ticketPrices[index],
+         serviceFee,
+         paymentMethod: 'CARD',
+         paymentMethodDisplay: buildPaymentMethodDisplay('CARD'),
+         ticketStatus: 'ISSUED',
+         resaleEnabledStatus: 'ENABLED',
+         issuedAt: orderedAt,
+         orderedAt,
+         cancelableUntil: new Date(new Date(seedGame.startAt.replace(' ', 'T')).getTime() - 4 * 60 * 60 * 1000).toISOString(),
+         ordererName: '홍길동',
+      });
+   });
+};
+
+ensureMockPurchaseHistorySeed();
 
 const buildPageResponse = <T>(content: T[], page = 0, size = content.length || 10) => {
    const pageSize = size > 0 ? size : content.length || 10;
@@ -1549,7 +1622,12 @@ export const paymentHandlers = [
       });
    }),
 
-   http.get('/api/v1/orders/:orderId/tickets', async ({ params }) => {
+   http.get('/api/v1/orders/:orderId/tickets', async ({ params, request }) => {
+      const requestUrl = new URL(request.url);
+      if (requestUrl.searchParams.get('mockScenario') === MYPAGE_ACTION_TICKET_INFO_ERROR_SCENARIO) {
+         return buildErrorResponse('Mock ticket info error.', 500);
+      }
+
       const orderId = String(params.orderId);
       const tickets = Array.from(ticketRecords.values()).filter((t) => t.orderId === orderId);
       return HttpResponse.json({


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #140 
- #186

<br/>

## 🔎 개요
티켓 상세조회 실패로 인해 판매등록, 예매 취소, qr확인 버튼이 미작동하는 것처럼 보이는 현상을 실패시 안내 팝업이 나오도록 변경 및 리셀 판매 등록 시 단순 서버 오류와 리셀 가격 한도 범위 문제를 안내하도록 변경

<br/>

## 📋 작업 내용
- 리셀 판매 등록 시 서버오류, 가격 오류로 나누어 안내 alert 추가
- 주문 상세 기반 API 호출
- 결제 상세 정보 표시
- QR 확인, 예매취소 시 티켓 정보 조회 실패할 경우 안내 팝업 추가

<br/>
