### PR TITLE
[feat] 마이페이지 계정 정보, 판매요약, 구매/판매 상세, 리셀 등록 등 api 재연결

### DIFF
--- a/src/entities/payment/api/paymentApi.ts
+++ b/src/entities/payment/api/paymentApi.ts
@@ -18,11 +18,20 @@ export interface OrderPaymentDetail {
    failedReason?: string | null;
 }
 
+export interface ResaleUnsettledAmountResponse {
+   unsettledAmount: number;
+}
+
 export const fetchOrderPaymentDetail = async (orderId: string): Promise<OrderPaymentDetail> => {
    const response = await apiClient.get<ApiEnvelope<OrderPaymentDetail>>(
       `/api/v1/payments/orders/${encodeURIComponent(orderId)}`,
    );
 
+   return response.data.data;
+};
+
+export const fetchResaleUnsettledAmount = async (): Promise<ResaleUnsettledAmountResponse> => {
+   const response = await apiClient.get<ApiEnvelope<ResaleUnsettledAmountResponse>>('/api/v1/payments/resales/unsettled');
    return response.data.data;
 };
 

--- a/src/entities/resale/api/resaleApi.ts
+++ b/src/entities/resale/api/resaleApi.ts
@@ -89,7 +89,11 @@ export interface CreateResaleListingRequest {
    listingPrice: number;
 }
 
-export const createResaleListing = async (body: CreateResaleListingRequest): Promise<void> => {
+export interface CreateResaleListingsRequest {
+   listings: CreateResaleListingRequest[];
+}
+
+export const createResaleListings = async (body: CreateResaleListingsRequest): Promise<void> => {
    await apiClient.post('/api/v1/resales/listings', body);
 };
 
@@ -118,6 +122,11 @@ export const cancelResaleListing = async (listingId: string): Promise<void> => {
 
 export interface ResaleGameListingCountResponse {
    count: number;
+}
+
+export interface MyResaleListingSummaryResponse {
+   listingCount: number;
+   soldCount: number;
 }
 
 export interface ResaleHistoryPointResponse {
@@ -177,6 +186,11 @@ export const fetchResaleListingCountsBySections = async (
 
 export const fetchResaleListings = async (): Promise<ResaleListingItem[]> => {
    const response = await apiClient.get<ApiEnvelope<ResaleListingItem[]>>('/api/v1/resales/listings');
+   return response.data.data;
+};
+
+export const fetchMyResaleListingSummary = async (): Promise<MyResaleListingSummaryResponse> => {
+   const response = await apiClient.get<ApiEnvelope<MyResaleListingSummaryResponse>>('/api/v1/resales/listings/count/listing');
    return response.data.data;
 };
 

--- a/src/entities/user/api/memberApi.ts
+++ b/src/entities/user/api/memberApi.ts
@@ -11,7 +11,43 @@ export interface MemberProfile {
    birthDate?: string;
 }
 
+export interface MemberAccountRequest {
+   accountNumber: string;
+   bankName: string;
+   accountHolder: string;
+}
+
+export interface MemberAccount {
+   accountId: string;
+   accountNumber: string;
+   bankName: string;
+   accountHolder: string;
+}
+
+export interface MemberAddressRequest {
+   zipCode: string;
+   baseAddress: string;
+   detailAddress: string;
+}
+
+export interface MemberAddress {
+   addressId: string;
+   zipCode: string;
+   baseAddress: string;
+   detailAddress: string;
+}
+
 export const fetchMyProfile = async (): Promise<MemberProfile> => {
    const response = await apiClient.get<ApiEnvelope<MemberProfile>>('/api/v1/members/me');
+   return response.data.data;
+};
+
+export const createMemberAccount = async (body: MemberAccountRequest): Promise<MemberAccount> => {
+   const response = await apiClient.post<ApiEnvelope<MemberAccount>>('/api/v1/members/accounts', body);
+   return response.data.data;
+};
+
+export const createMemberAddress = async (body: MemberAddressRequest): Promise<MemberAddress> => {
+   const response = await apiClient.post<ApiEnvelope<MemberAddress>>('/api/v1/members/addresses', body);
    return response.data.data;
 };

--- a/src/entities/user/model/useMyProfile.ts
+++ b/src/entities/user/model/useMyProfile.ts
@@ -2,31 +2,22 @@
 
 import { useMemo } from 'react';
 import { useAuthStore } from '@/entities/auth/model/authStore';
+import { resolveProfileFromJwt } from '@/shared/lib/jwt';
 import type { MemberProfile } from '../api/memberApi';
-
-/** JWT payload를 base64url 디코딩해서 반환 */
-const decodeJwt = (token: string): Record<string, unknown> | null => {
-   try {
-      const part = token.split('.')[1];
-      if (!part) return null;
-      const base64 = part.replace(/-/g, '+').replace(/_/g, '/');
-      return JSON.parse(atob(base64)) as Record<string, unknown>;
-   } catch {
-      return null;
-   }
-};
 
 export const useMyProfile = (): { data: MemberProfile | undefined } => {
    const accessToken = useAuthStore(s => s.accessToken);
 
    const data = useMemo<MemberProfile | undefined>(() => {
       if (!accessToken) return undefined;
-      const payload = decodeJwt(accessToken);
-      if (!payload) return undefined;
-      return {
-         name: typeof payload.name === 'string' ? payload.name : undefined,
-         mobile: typeof payload.mobile === 'string' ? payload.mobile : undefined,
-      } as MemberProfile;
+
+      const profile = resolveProfileFromJwt(accessToken);
+
+      if (!profile) {
+         return undefined;
+      }
+
+      return profile;
    }, [accessToken]);
 
    return { data };

--- a/src/pages/mypage/model/useMypageData.ts
+++ b/src/pages/mypage/model/useMypageData.ts
@@ -1,15 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useAuthStore } from '@/entities/auth/model/authStore';
-import { fetchMyProfile, type MemberProfile } from '@/entities/user/api/memberApi';
+import { fetchMyProfile } from '@/entities/user/api/memberApi';
 import { fetchMyOrders, type OrderListItem } from '@/entities/order/api/orderApi';
-import { fetchMyResaleListings, type ResaleListingItem } from '@/entities/resale/api/resaleApi';
-import { decodeJwtPayload } from '@/shared/lib/jwt';
-import { readStoredPaymentCompleteItems } from '@/shared/lib/paymentCompleteStorage';
+import {
+   fetchMyResaleListingSummary,
+   fetchMyResaleListings,
+   type MyResaleListingSummaryResponse,
+   type ResaleListingItem,
+} from '@/entities/resale/api/resaleApi';
+import { fetchResaleUnsettledAmount, type ResaleUnsettledAmountResponse } from '@/entities/payment/api/paymentApi';
 import { teams } from '@/entities/team/model/teams';
+import { resolveProfileFromJwt } from '@/shared/lib/jwt';
 import type { PurchaseHistoryItem, SaleHistoryItem, PurchaseStatus, SaleStatus } from '../ui/HistoryCard';
 import type { TicketType } from '../ui/TicketTypeBadge';
-import type { PaymentResponse } from '@/pages/tickets/api/paymentApi';
 import { formatTicketNumber } from './ticketNumber';
 
 const teamStadiumMap = Object.fromEntries(teams.map((t) => [t.serverTeamId, t.stadiumName]));
@@ -81,81 +85,32 @@ const mapSaleStatus = (status: ResaleListingItem['listingStatus']): SaleStatus =
    }
 };
 
-const mapStoredPaymentToPurchaseHistory = (payment: PaymentResponse): PurchaseHistoryItem => {
-   const primarySeat = payment.seats[0] ?? '좌석 정보';
-   const section = parseGradeName(primarySeat);
-   const seatDetail = parseSeatDetail(primarySeat);
-
-   return {
-      id: payment.ticketId ?? payment.orderId ?? payment.orderNumber,
-      rawOrderId: payment.orderId,
-      orderId: formatTicketNumber(payment.orderNumber, payment.orderType === 'resale' ? 'resale' : 'ticket'),
-      orderDate: formatDate(payment.paidAt ?? payment.orderedAt),
-      type: payment.orderType === 'resale' ? '리셀' : '티켓',
-      game: {
-         teams: payment.gameTitle,
-         venue: payment.gameVenue,
-         datetime: payment.gameDate,
-         quantity: payment.quantity,
-         section,
-         seats: seatDetail ? [seatDetail] : payment.seats,
-      },
-      price: payment.amount,
-      paymentStatus: '예매 완료',
-      deliveryType: '모바일 티켓',
-      canSell: payment.orderType !== 'resale',
-   };
-};
-
 export const useMyProfileData = () => {
    const accessToken = useAuthStore(s => s.accessToken);
-   
-   const tokenInfo = useMemo(() => {
-      if (!accessToken) return null;
-      const payload = decodeJwtPayload(accessToken);
-      // 토큰에 담긴 실제 로그인 정보를 추출
-      return {
-         name: payload?.name || '사용자',
-         mobile: payload?.mobile || '010-0000-0000',
-         email: payload?.email || payload?.sub || 'goti1234@google.com',
-      } as MemberProfile;
-   }, [accessToken]);
+   const tokenProfile = useMemo(() => resolveProfileFromJwt(accessToken), [accessToken]);
 
    return useQuery({
       queryKey: ['myProfile', accessToken],
       queryFn: fetchMyProfile,
-      placeholderData: tokenInfo || undefined,
       enabled: !!accessToken,
+      select: (profile) => ({
+         ...profile,
+         name: profile.name ?? tokenProfile?.name,
+         email: profile.email ?? tokenProfile?.email,
+         mobile: profile.mobile ?? tokenProfile?.mobile,
+      }),
+      placeholderData: tokenProfile ?? undefined,
    });
 };
 
 export const useMyOrdersData = () => {
-   const [storageVersion, setStorageVersion] = useState(0);
-
-   useEffect(() => {
-      const refreshStoredPayments = () => {
-         setStorageVersion((previous) => previous + 1);
-      };
-
-      window.addEventListener('focus', refreshStoredPayments);
-      window.addEventListener('pageshow', refreshStoredPayments);
-
-      return () => {
-         window.removeEventListener('focus', refreshStoredPayments);
-         window.removeEventListener('pageshow', refreshStoredPayments);
-      };
-   }, []);
-
    const query = useQuery({
       queryKey: ['myOrders'],
       queryFn: fetchMyOrders,
-      placeholderData: (previousData) => previousData,
    });
 
    const data = useMemo((): PurchaseHistoryItem[] => {
-      void storageVersion;
-
-      const apiItems = (query.data ?? []).map((order) => {
+      return (query.data ?? []).map((order) => {
          const stadiumName = order.stadiumName || teamStadiumMap[order.stadiumId] || '야구장';
          const gameTitle = order.homeTeamName && order.awayTeamName
             ? `${order.awayTeamName} vs ${order.homeTeamName}`
@@ -169,9 +124,11 @@ export const useMyOrdersData = () => {
         return {
             id: order.ticketId ?? order.orderId,
             rawOrderId: order.orderId,
+            gameId: order.gameId,
             orderId: formatTicketNumber(order.orderNumber, 'ticket'),
             orderDate: formatDate(order.orderedAt),
             type: '티켓' as TicketType,
+            seatGradeName: sectionLabel,
             game: {
                teams: gameTitle,
                venue: stadiumName,
@@ -187,23 +144,17 @@ export const useMyOrdersData = () => {
             ticketIds: order.ticketIds?.length ? order.ticketIds : (order.ticketId ? [order.ticketId] : undefined),
          };
       });
+   }, [query.data]);
 
-      const storedItems = readStoredPaymentCompleteItems()
-         .filter((payment) => {
-            const paymentIdentity = payment.orderId ?? payment.orderNumber;
-
-            return !apiItems.some((item) => item.id === paymentIdentity || item.orderId === payment.orderNumber);
-         })
-         .map(mapStoredPaymentToPurchaseHistory);
-
-      return [...storedItems, ...apiItems].sort((left, right) => {
+   const sortedData = useMemo(() => {
+      return [...data].sort((left, right) => {
          return toISODate(right.orderDate).localeCompare(toISODate(left.orderDate));
       });
-   }, [query.data, storageVersion]);
+   }, [data]);
 
    return {
       ...query,
-      data,
+      data: sortedData,
    };
 };
 
@@ -216,6 +167,8 @@ export const useMyResaleListData = () => {
             id: listing.listingId,
             orderId: listing.listingId.replace(/^listing-/i, '').slice(0, 8).toUpperCase(),
             orderDate: formatDate(listing.listedAt),
+            soldAt: listing.soldAt ? formatDateTime(listing.soldAt) : undefined,
+            canceledAt: listing.canceledAt ? formatDateTime(listing.canceledAt) : undefined,
             type: '리셀' as TicketType,
             game: {
                teams: listing.gameTitle || 'KBO 리그 경기',
@@ -231,5 +184,19 @@ export const useMyResaleListData = () => {
             canCancel: listing.listingStatus === 'LISTING' || listing.listingStatus === 'CANCEL_REQUESTED',
          }));
       },
+   });
+};
+
+export const useMyResaleSummaryData = () => {
+   return useQuery<MyResaleListingSummaryResponse>({
+      queryKey: ['myResaleSummary'],
+      queryFn: fetchMyResaleListingSummary,
+   });
+};
+
+export const useMyResaleUnsettledAmountData = () => {
+   return useQuery<ResaleUnsettledAmountResponse>({
+      queryKey: ['myResaleUnsettledAmount'],
+      queryFn: fetchResaleUnsettledAmount,
    });
 };

--- a/src/pages/mypage/ui/AccountPage.tsx
+++ b/src/pages/mypage/ui/AccountPage.tsx
@@ -2,15 +2,23 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import { ChevronLeft, ChevronRight, Check } from 'lucide-react';
+import { createMemberAccount, createMemberAddress, type MemberAccount, type MemberAddress } from '@/entities/user/api/memberApi';
 import { Checkbox } from '@/shared/ui/checkbox';
 import { Input } from '@/shared/ui/input';
+import { getErrorMessage } from '@/shared/lib/error/getErrorMessage';
 import { AccountModals } from './AccountModals';
 import type { ModalType } from './AccountModals';
 import { AccountTermsDialogs } from './AccountTermsDialogs';
 import type { TermsType } from './AccountTermsDialogs';
-import { useMyProfileData, useMyOrdersData, useMyResaleListData } from '../model/useMypageData';
+import {
+   useMyProfileData,
+   useMyOrdersData,
+   useMyResaleListData,
+   useMyResaleUnsettledAmountData,
+} from '../model/useMypageData';
 
 const BANKS = [
    '국민은행',
@@ -75,12 +83,17 @@ function loadDaumPostcodeAndOpen(onComplete: (zipCode: string, address: string) 
 export default function AccountPage() {
    const navigate = useNavigate();
    const location = useLocation();
-   const { data: profile } = useMyProfileData();
-   const { data: purchaseItems = [] } = useMyOrdersData();
-   const { data: saleItems = [] } = useMyResaleListData();
+   const queryClient = useQueryClient();
+   const profileQuery = useMyProfileData();
+   const ordersQuery = useMyOrdersData();
+   const resaleListQuery = useMyResaleListData();
+   const unsettledAmountQuery = useMyResaleUnsettledAmountData();
+   const profile = profileQuery.data;
+   const purchaseItems = ordersQuery.data ?? [];
+   const saleItems = resaleListQuery.data ?? [];
 
    // 미정산 금액 존재 여부: 판매 완료 후 정산 대기 중인 항목
-   const hasUnpaidAmount = saleItems.some(i => i.saleStatus === '정산 대기');
+   const hasUnpaidAmount = (unsettledAmountQuery.data?.unsettledAmount ?? 0) > 0;
    // 예매 완료 또는 판매 중인 티켓 존재 여부
    const hasActiveTickets =
       purchaseItems.some(i => i.paymentStatus === '예매 완료') ||
@@ -94,20 +107,7 @@ export default function AccountPage() {
    const [termsDialog, setTermsDialog] = useState<TermsType>(null);
 
    // ── 간편 로그인 연결 ──
-   const [googleConnected, setGoogleConnected] = useState(true);
-   const [kakaoConnected, setKakaoConnected] = useState(true);
-   const [naverConnected, setNaverConnected] = useState(false);
-
-   const connectedCount = [googleConnected, kakaoConnected, naverConnected].filter(Boolean).length;
-
-   /** 토글 클릭: 1개만 남은 경우 해지 불가 팝업 */
-   const handleSocialToggle = (isConnected: boolean, setter: (v: boolean) => void) => {
-      if (isConnected && connectedCount <= 1) {
-         setModal('cannotDisconnect');
-         return;
-      }
-      setter(!isConnected);
-   };
+   const socialConnectionApiAvailable = false;
 
    // ── 계좌 정보 ──
    const [bank, setBank] = useState('');
@@ -117,14 +117,16 @@ export default function AccountPage() {
    const accountCardRef = useRef<HTMLDivElement>(null);
    const [accountNumber, setAccountNumber] = useState('');
    const [depositor, setDepositor] = useState('');
+   const [savedAccount, setSavedAccount] = useState<MemberAccount | null>(null);
+   const [savedAddress, setSavedAddress] = useState<MemberAddress | null>(null);
    const [agreeAll, setAgreeAll] = useState(false);
    const [agreeOpen, setAgreeOpen] = useState(false);
    const [agreeThird, setAgreeThird] = useState(false);
    const [agreePersonal, setAgreePersonal] = useState(false);
 
    // ── 주소 수정 ──
-   const [zipCode, setZipCode] = useState('12345');
-   const [address, setAddress] = useState('서울특별시 강남구 테헤란로 123');
+   const [zipCode, setZipCode] = useState('');
+   const [address, setAddress] = useState('');
    const [addressDetail, setAddressDetail] = useState('');
 
    // 은행 드롭다운 외부 클릭 닫기
@@ -158,7 +160,47 @@ export default function AccountPage() {
    };
 
    const isAccountSaveEnabled = !!(bank && accountNumber && depositor && agreeOpen && agreeThird && agreePersonal);
+   const isAddressSaveEnabled = Boolean(zipCode && address && addressDetail.trim());
    const clearAuth = useAuthStore(state => state.clearAuth);
+   const isPageLoading =
+      profileQuery.isLoading || ordersQuery.isLoading || resaleListQuery.isLoading || unsettledAmountQuery.isLoading;
+   const isPageError =
+      profileQuery.isError || ordersQuery.isError || resaleListQuery.isError || unsettledAmountQuery.isError;
+
+   const { mutate: saveAccount, isPending: isSavingAccount } = useMutation({
+      mutationFn: () =>
+         createMemberAccount({
+            accountNumber,
+            bankName: bank,
+            accountHolder: depositor,
+         }),
+      onSuccess: (registeredAccount) => {
+         setSavedAccount(registeredAccount);
+         alert('계좌 정보가 저장되었습니다.');
+      },
+      onError: (error) => {
+         alert(getErrorMessage(error, '계좌 정보 저장에 실패했습니다. 다시 시도해주세요.'));
+      },
+   });
+
+   const { mutate: saveAddress, isPending: isSavingAddress } = useMutation({
+      mutationFn: () =>
+         createMemberAddress({
+            zipCode,
+            baseAddress: address,
+            detailAddress: addressDetail.trim(),
+         }),
+      onSuccess: (registeredAddress) => {
+         setSavedAddress(registeredAddress);
+         setZipCode(registeredAddress.zipCode);
+         setAddress(registeredAddress.baseAddress);
+         setAddressDetail(registeredAddress.detailAddress);
+         alert('주소 정보가 저장되었습니다.');
+      },
+      onError: (error) => {
+         alert(getErrorMessage(error, '주소 정보 저장에 실패했습니다. 다시 시도해주세요.'));
+      },
+   });
 
    /** 계좌 정보 변경 버튼: 계좌 정보 카드로 스크롤 후 은행 드롭다운 오픈 */
    const handleAccountChange = () => {
@@ -202,6 +244,32 @@ export default function AccountPage() {
       closeModal();
       navigate('/');
    };
+
+   if (isPageLoading) {
+      return <div className="py-24 text-center text-body-1-regular text-muted-foreground">계정 정보를 불러오는 중입니다.</div>;
+   }
+
+   if (isPageError) {
+      return (
+         <div className="flex flex-col items-center justify-center gap-4 py-24">
+            <p className="text-body-1-regular text-muted-foreground">
+               계정 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+            </p>
+            <button
+               type="button"
+               onClick={() => {
+                  void queryClient.invalidateQueries({ queryKey: ['myProfile'] });
+                  void queryClient.invalidateQueries({ queryKey: ['myOrders'] });
+                  void queryClient.invalidateQueries({ queryKey: ['myResales'] });
+                  void queryClient.invalidateQueries({ queryKey: ['myResaleUnsettledAmount'] });
+               }}
+               className="rounded-lg border border-border px-6 py-3 text-body-1-bold text-muted-foreground hover:bg-surface transition-colors"
+            >
+               다시 시도
+            </button>
+         </div>
+      );
+   }
 
    return (
       <div className="flex-1 bg-background">
@@ -262,8 +330,8 @@ export default function AccountPage() {
                      <div className="flex items-center justify-between">
                         <p className="text-body-1-bold text-(--text-tertiary)">계좌 정보</p>
                         <div className="flex items-center gap-2">
-                           <p className="text-body-1-regular text-foreground">카카오뱅크</p>
-                           <p className="text-body-1-regular text-foreground">3333-67-8765445</p>
+                           <p className="text-body-1-regular text-foreground">{savedAccount?.bankName ?? '미등록'}</p>
+                           <p className="text-body-1-regular text-foreground">{savedAccount?.accountNumber ?? '-'}</p>
                            <button
                               type="button"
                               onClick={handleAccountChange}
@@ -279,6 +347,9 @@ export default function AccountPage() {
                {/* ── 간편 로그인 연결 카드 ── */}
                <div className="bg-background border border-[rgba(0,0,0,0.1)] rounded-[14px] p-6.25 flex flex-col gap-7.5">
                   <p className="text-heading-3-bold text-foreground">간편 로그인 연결</p>
+                  <p className="text-body-2-regular text-muted-foreground">
+                     현재 문서 기준으로 연결 계정 조회/변경 API가 정의되지 않아 상태 표시는 제공하지 않습니다.
+                  </p>
                   <div className="flex flex-col gap-4">
                      {/* Google */}
                      <div className="flex items-center justify-between px-1">
@@ -293,10 +364,7 @@ export default function AccountPage() {
                               회원가입 계정
                            </span>
                         </div>
-                        <Toggle
-                           checked={googleConnected}
-                           onChange={() => handleSocialToggle(googleConnected, setGoogleConnected)}
-                        />
+                        <Toggle checked={false} onChange={() => {}} disabled={!socialConnectionApiAvailable} />
                      </div>
                      {/* Kakao */}
                      <div className="border-t border-border pt-4 flex items-center justify-between px-1">
@@ -306,10 +374,7 @@ export default function AccountPage() {
                            </div>
                            <p className="text-body-2-medium text-muted-foreground">카카오 계정 연결</p>
                         </div>
-                        <Toggle
-                           checked={kakaoConnected}
-                           onChange={() => handleSocialToggle(kakaoConnected, setKakaoConnected)}
-                        />
+                        <Toggle checked={false} onChange={() => {}} disabled={!socialConnectionApiAvailable} />
                      </div>
                      {/* Naver */}
                      <div className="border-t border-border pt-4 flex items-center justify-between px-1">
@@ -319,10 +384,7 @@ export default function AccountPage() {
                            </div>
                            <p className="text-body-2-medium text-muted-foreground">네이버 계정 연결</p>
                         </div>
-                        <Toggle
-                           checked={naverConnected}
-                           onChange={() => handleSocialToggle(naverConnected, setNaverConnected)}
-                        />
+                        <Toggle checked={false} onChange={() => {}} disabled={!socialConnectionApiAvailable} />
                      </div>
                   </div>
                </div>
@@ -336,6 +398,9 @@ export default function AccountPage() {
                   <div className="flex flex-col gap-6">
                      <p className="text-caption-1-regular text-(--text-tertiary)">
                         계좌 미등록 시 리셀 및 취소/환불 기능이 제한됩니다.
+                     </p>
+                     <p className="text-caption-1-regular text-muted-foreground">
+                        계좌 조회 API가 없어 현재 세션에서 저장에 성공한 계좌만 화면에 반영됩니다.
                      </p>
 
                      {/* 은행 + 계좌번호 */}
@@ -455,14 +520,16 @@ export default function AccountPage() {
                      </div>
 
                      <button
-                        disabled={!isAccountSaveEnabled}
+                        type="button"
+                        disabled={!isAccountSaveEnabled || isSavingAccount}
+                        onClick={() => saveAccount()}
                         className={`border border-border rounded-lg py-3 text-body-1-bold w-full transition-colors ${
-                           isAccountSaveEnabled
+                           isAccountSaveEnabled && !isSavingAccount
                               ? 'text-muted-foreground hover:bg-surface'
                               : 'text-(--text-disabled) cursor-not-allowed'
                         }`}
                      >
-                        저장
+                        {isSavingAccount ? '저장 중...' : '저장'}
                      </button>
                   </div>
                </div>
@@ -473,6 +540,11 @@ export default function AccountPage() {
                   <div className="flex gap-5">
                      <p className="text-body-2-medium text-foreground whitespace-nowrap">주소정보</p>
                      <div className="flex flex-col gap-7.5 flex-1">
+                        {savedAddress && (
+                           <div className="rounded-lg bg-surface px-4 py-3 text-body-2-regular text-muted-foreground">
+                              최근 저장 주소: ({savedAddress.zipCode}) {savedAddress.baseAddress} {savedAddress.detailAddress}
+                           </div>
+                        )}
                         <div className="flex flex-col gap-4">
                            <div className="flex items-end gap-2.5">
                               <Input className="flex-1" label="우편번호" required value={zipCode} disabled readOnly />
@@ -493,8 +565,17 @@ export default function AccountPage() {
                               onChange={e => setAddressDetail(e.target.value)}
                            />
                         </div>
-                        <button className="border border-border rounded-lg py-3 text-body-1-bold text-muted-foreground w-full hover:bg-surface transition-colors">
-                           저장
+                        <button
+                           type="button"
+                           disabled={!isAddressSaveEnabled || isSavingAddress}
+                           onClick={() => saveAddress()}
+                           className={`border border-border rounded-lg py-3 text-body-1-bold w-full transition-colors ${
+                              isAddressSaveEnabled && !isSavingAddress
+                                 ? 'text-muted-foreground hover:bg-surface'
+                                 : 'text-(--text-disabled) cursor-not-allowed'
+                           }`}
+                        >
+                           {isSavingAddress ? '저장 중...' : '저장'}
                         </button>
                      </div>
                   </div>
@@ -542,14 +623,18 @@ export default function AccountPage() {
 interface ToggleProps {
    checked: boolean;
    onChange: () => void;
+   disabled?: boolean;
 }
-function Toggle({ checked, onChange }: ToggleProps) {
+function Toggle({ checked, onChange, disabled = false }: ToggleProps) {
    return (
       <button
+         type="button"
          role="switch"
          aria-checked={checked}
+         aria-disabled={disabled}
          onClick={onChange}
-         className={`relative w-10 h-6 rounded-full transition-colors shrink-0 ${checked ? 'bg-primary' : 'bg-border'}`}
+         disabled={disabled}
+         className={`relative w-10 h-6 rounded-full transition-colors shrink-0 ${checked ? 'bg-primary' : 'bg-border'} ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
       >
          <span
             className={`absolute top-0.5 left-0.5 size-5 bg-white rounded-full shadow transition-transform ${checked ? 'translate-x-4' : 'translate-x-0'}`}

--- a/src/pages/mypage/ui/CancelBookingDialog.tsx
+++ b/src/pages/mypage/ui/CancelBookingDialog.tsx
@@ -32,13 +32,6 @@ interface Props {
    mockTicketInfoError?: boolean;
 }
 
-// ─── Mock: 등록된 계좌 (없으면 null) ──────────────────────────────
-const MOCK_REGISTERED_ACCOUNT: { bank: string; number: string; holder: string } | null = {
-   bank: '카카오뱅크',
-   number: '3333-67-8765445',
-   holder: '홍길동',
-};
-
 // ─── Mock: 취소 수수료 (실제로는 API에서 수신) ────────────────────
 const MOCK_CANCEL_FEE = 0;
 
@@ -231,10 +224,6 @@ export default function CancelBookingDialog({
             onBack={() => setConfirmOpen(false)}
             orderId={orderId}
             isBankTransfer={isBankTransfer}
-            account={isBankTransfer && MOCK_REGISTERED_ACCOUNT
-               ? { bank: MOCK_REGISTERED_ACCOUNT.bank, number: MOCK_REGISTERED_ACCOUNT.number }
-               : undefined
-            }
             paymentMethod={paymentMethod}
             ticketAmount={totalPrice}
             ticketCount={selectedSeats.length}

--- a/src/pages/mypage/ui/CancelConfirmDialog.tsx
+++ b/src/pages/mypage/ui/CancelConfirmDialog.tsx
@@ -116,6 +116,12 @@ export default function CancelConfirmDialog({
                            계좌변경
                         </button>
                      </>
+                  ) : isBankTransfer ? (
+                     <p className="text-[14px] text-[#374553] leading-normal w-[260px] whitespace-pre-wrap">
+                        등록된 환불 계좌로 환불되며, 은행 영업일 기준 1~3일 정도 소요됩니다.
+                        {'\n\n'}
+                        현재 마이페이지에서는 환불 계좌 조회 API가 없어 상세 계좌번호를 표시하지 않습니다.
+                     </p>
                   ) : (
                      <p className="text-[14px] text-[#374553] leading-normal w-[260px]">
                         기존 결제 수단{paymentMethod && <span className="font-bold">({paymentMethod})</span>}으로 환불되며,{' '}

--- a/src/pages/mypage/ui/HistoryCard.tsx
+++ b/src/pages/mypage/ui/HistoryCard.tsx
@@ -24,9 +24,11 @@ export type SaleStatus = '판매 중' | '판매 완료' | '정산 대기' | '판
 export interface PurchaseHistoryItem {
    id: string;
    rawOrderId?: string;
+   gameId?: string;
    orderId: string;
    orderDate: string;
    type: TicketType;
+   seatGradeName?: string;
    game: {
       teams: string;
       venue: string;
@@ -47,6 +49,8 @@ export interface SaleHistoryItem {
    id: string;
    orderId: string;
    orderDate: string;
+   soldAt?: string;
+   canceledAt?: string;
    type: TicketType;
    game: {
       teams: string;

--- a/src/pages/mypage/ui/MypagePage.tsx
+++ b/src/pages/mypage/ui/MypagePage.tsx
@@ -3,10 +3,17 @@
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { ChevronDown, ChevronLeft, ChevronRight, Settings, Check, Search, X } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
 import HistoryCard from './HistoryCard';
 import { Button } from '@/shared/ui/button';
 import { DatePicker } from '@/shared/ui/date-picker';
-import { useMyProfileData, useMyOrdersData, useMyResaleListData } from '../model/useMypageData';
+import {
+   useMyProfileData,
+   useMyOrdersData,
+   useMyResaleListData,
+   useMyResaleSummaryData,
+   useMyResaleUnsettledAmountData,
+} from '../model/useMypageData';
 import { isMswEnabled } from '@/shared/config/runtime';
 
 const MYPAGE_MSW_TICKET_INFO_ERROR_KEY = '__mypage_msw_ticket_info_error__';
@@ -47,13 +54,20 @@ const calcPeriodDates = (period: PeriodFilter, dataMinDate?: string) => {
 export default function MypagePage() {
    const navigate = useNavigate();
    const location = useLocation();
+   const queryClient = useQueryClient();
    const [activeTab, setActiveTab] = useState<HistoryTab>(
       (location.state as { activeTab?: HistoryTab } | null)?.activeTab || 'purchase',
    );
 
-   const { data: profile } = useMyProfileData();
-   const { data: purchaseItems = [] } = useMyOrdersData();
-   const { data: saleItems = [] } = useMyResaleListData();
+   const profileQuery = useMyProfileData();
+   const ordersQuery = useMyOrdersData();
+   const resaleListQuery = useMyResaleListData();
+   const resaleSummaryQuery = useMyResaleSummaryData();
+   const unsettledAmountQuery = useMyResaleUnsettledAmountData();
+
+   const profile = profileQuery.data;
+   const purchaseItems = ordersQuery.data ?? [];
+   const saleItems = resaleListQuery.data ?? [];
 
    // 전체 내역 기간의 시작일: 데이터 중 가장 이른 날짜
    const DATA_MIN_DATE = useMemo(() => {
@@ -198,6 +212,33 @@ export default function MypagePage() {
       [saleItems, saleStatus, appliedSaleType, appliedStartDate, appliedEndDate, appliedSearchQuery],
    );
 
+   const isPageLoading = profileQuery.isLoading || ordersQuery.isLoading || resaleListQuery.isLoading;
+   const isPageError = profileQuery.isError || ordersQuery.isError || resaleListQuery.isError;
+
+   if (isPageLoading) {
+      return <div className="py-24 text-center text-body-1-regular text-muted-foreground">마이페이지 정보를 불러오는 중입니다.</div>;
+   }
+
+   if (isPageError) {
+      return (
+         <div className="flex flex-col items-center justify-center gap-4 py-24">
+            <p className="text-body-1-regular text-muted-foreground">
+               마이페이지 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+            </p>
+            <Button
+               variant="tertiary"
+               onClick={() => {
+                  void queryClient.invalidateQueries({ queryKey: ['myProfile'] });
+                  void queryClient.invalidateQueries({ queryKey: ['myOrders'] });
+                  void queryClient.invalidateQueries({ queryKey: ['myResales'] });
+               }}
+            >
+               다시 시도
+            </Button>
+         </div>
+      );
+   }
+
    return (
       <>
          <div className="flex-1 bg-background px-4">
@@ -263,11 +304,11 @@ export default function MypagePage() {
                   {/* 티켓 현황 카드 */}
                   {(() => {
                      const totalHeld = purchaseItems.filter(i => i.paymentStatus === '예매 완료').length;
-                     const onSale = saleItems.filter(i => i.saleStatus === '판매 중').length;
-                     const soldCount = saleItems.filter(i => i.saleStatus === '판매 완료').length;
-                     const unsettledAmount = saleItems
-                        .filter(i => i.saleStatus === '정산 대기')
-                        .reduce((sum, i) => sum + i.salePrice, 0);
+                     const onSale = resaleSummaryQuery.data?.listingCount ?? 0;
+                     const soldCount = resaleSummaryQuery.data?.soldCount ?? 0;
+                     const unsettledAmount = unsettledAmountQuery.data?.unsettledAmount ?? 0;
+                     const isSummaryError = resaleSummaryQuery.isError || unsettledAmountQuery.isError;
+                     const isSummaryLoading = resaleSummaryQuery.isLoading || unsettledAmountQuery.isLoading;
                      const stats = [
                         { icon: '/Icon/Line/ticket.svg', label: '전체 소지', value: String(totalHeld) },
                         { icon: '/Icon/Line/increase.svg', label: '판매 중', value: String(onSale) },
@@ -281,20 +322,42 @@ export default function MypagePage() {
                      return (
                         <div className="bg-background border border-[rgba(0,0,0,0.1)] rounded-[14px] p-6">
                            <p className="text-heading-3-bold text-foreground mb-7.5">티켓 현황</p>
-                           <div className="grid grid-cols-2 lg:flex lg:items-start gap-y-4 lg:gap-y-0">
-                              {stats.map(stat => (
-                                 <div
-                                    key={stat.label}
-                                    className="flex flex-1 flex-col items-center gap-1.5 px-4 py-1 rounded-[10px]"
+                           {isSummaryLoading ? (
+                              <div className="rounded-[10px] bg-surface px-4 py-8 text-center text-body-2-regular text-muted-foreground">
+                                 판매 요약 정보를 불러오는 중입니다.
+                              </div>
+                           ) : isSummaryError ? (
+                              <div className="rounded-[10px] bg-surface px-4 py-8 text-center">
+                                 <p className="text-body-2-regular text-muted-foreground">
+                                    판매 요약 정보를 불러오지 못했습니다.
+                                 </p>
+                                 <Button
+                                    variant="tertiary"
+                                    className="mt-3"
+                                    onClick={() => {
+                                       void resaleSummaryQuery.refetch();
+                                       void unsettledAmountQuery.refetch();
+                                    }}
                                  >
-                                    <img src={stat.icon} alt={stat.label} className="size-8 text-primary" />
-                                    <p className="text-body-1-regular text-muted-foreground text-center">
-                                       {stat.label}
-                                    </p>
-                                    <p className="text-heading-1-bold text-primary text-center">{stat.value}</p>
-                                 </div>
-                              ))}
-                           </div>
+                                    다시 시도
+                                 </Button>
+                              </div>
+                           ) : (
+                              <div className="grid grid-cols-2 lg:flex lg:items-start gap-y-4 lg:gap-y-0">
+                                 {stats.map(stat => (
+                                    <div
+                                       key={stat.label}
+                                       className="flex flex-1 flex-col items-center gap-1.5 px-4 py-1 rounded-[10px]"
+                                    >
+                                       <img src={stat.icon} alt={stat.label} className="size-8 text-primary" />
+                                       <p className="text-body-1-regular text-muted-foreground text-center">
+                                          {stat.label}
+                                       </p>
+                                       <p className="text-heading-1-bold text-primary text-center">{stat.value}</p>
+                                    </div>
+                                 ))}
+                              </div>
+                           )}
                         </div>
                      );
                   })()}

--- a/src/pages/mypage/ui/PurchaseDetailPage.tsx
+++ b/src/pages/mypage/ui/PurchaseDetailPage.tsx
@@ -190,8 +190,8 @@ export default function PurchaseDetailPage() {
       const total = ticketAmount + fee;
       const paymentMethodDisplay = orderPaymentQuery.data?.paymentMethod
          ? formatOrderPaymentMethod(orderPaymentQuery.data.paymentMethod)
-         : (apiDetail.paymentMethodDisplay ?? apiDetail.paymentMethod ?? '-');
-      const paidAt = orderPaymentQuery.data?.paidAt ?? apiDetail.issuedAt;
+         : undefined;
+      const paidAt = orderPaymentQuery.data?.paidAt;
       const paymentAmount = orderPaymentQuery.data?.paymentAmount ?? total;
 
       return {
@@ -228,12 +228,12 @@ export default function PurchaseDetailPage() {
             bankDeadline: undefined as string | undefined,
          },
          paymentEvents: [{ type: '결제 완료' as const, method: paymentMethodDisplay }],
-         refundInfo: isInvalid
+         refundInfo: isInvalid && orderPaymentQuery.data
             ? {
                  ticketAmount,
                  cancelFee: 0,
                  refundTotal: ticketAmount,
-                 method: paymentMethodDisplay,
+                 method: paymentMethodDisplay ?? '정보 없음',
                  date: paidAt,
               }
             : undefined,
@@ -281,6 +281,8 @@ export default function PurchaseDetailPage() {
                onClose={() => setCancelOpen(false)}
                orderId={orderId!}
                game={{ teams: detail.game.teams, datetime: detail.game.datetime }}
+               isBankTransfer={orderPaymentQuery.data?.paymentMethod === 'ACCOUNT_TRANSFER'}
+               paymentMethod={detail.paymentMethodDisplay}
                seats={seatTickets.map((ticket) => ({
                   orderId: formatTicketNumber(
                      ticket.ticketNumber,
@@ -394,26 +396,36 @@ export default function PurchaseDetailPage() {
 
                {/* 결제 정보 — 취소/환불 상태에서는 숨김 */}
                {detail.ticketStatus !== 'INVALID' && (
-                  <SectionCard>
-                     <div className="flex items-start justify-between text-[20px] font-bold">
+               <SectionCard>
+                  <div className="flex items-start justify-between text-[20px] font-bold">
                         <span className="text-[#161d24] leading-normal">결제 정보</span>
                         <span className="text-primary leading-normal">결제 완료</span>
+                  </div>
+                  {orderPaymentQuery.isLoading ? (
+                     <div className="rounded-xl bg-[#f7f8f9] px-5 py-6 text-center text-[14px] text-[#646f7c]">
+                        결제 정보를 불러오는 중입니다.
                      </div>
-                     {/* 금액 요약 */}
-                     <div className="bg-[#f7f8f9] rounded-xl p-5 flex flex-col gap-3">
-                        <InfoRow label={`티켓 금액 (${totalQuantity}매)`} value={formatPrice(totalTicketPrice)} />
-                        <InfoRow label="수수료" value={formatPrice(serviceFee)} />
-                        <div className="flex items-center justify-between font-bold">
-                           <span className="text-[16px] text-[#374553] leading-normal">총 결제 금액</span>
-                           <span className="text-[20px] text-primary leading-normal">{formatPrice(totalPaid)}</span>
+                  ) : orderPaymentQuery.isError ? (
+                     <div className="rounded-xl bg-[#f7f8f9] px-5 py-6 text-center text-[14px] text-[#646f7c]">
+                        결제 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+                     </div>
+                  ) : (
+                     <>
+                        <div className="bg-[#f7f8f9] rounded-xl p-5 flex flex-col gap-3">
+                           <InfoRow label={`티켓 금액 (${totalQuantity}매)`} value={formatPrice(totalTicketPrice)} />
+                           <InfoRow label="수수료" value={formatPrice(serviceFee)} />
+                           <div className="flex items-center justify-between font-bold">
+                              <span className="text-[16px] text-[#374553] leading-normal">총 결제 금액</span>
+                              <span className="text-[20px] text-primary leading-normal">{formatPrice(totalPaid)}</span>
+                           </div>
                         </div>
-                     </div>
-                     {/* 결제 수단/일시 */}
-                     <div className="flex flex-col gap-3">
-                        <InfoRow label="결제 수단" value={detail.paymentMethodDisplay} />
-                        <InfoRow label="결제 일시" value={detail.paidAt ? formatDateTime(detail.paidAt) : '-'} />
-                     </div>
-                  </SectionCard>
+                        <div className="flex flex-col gap-3">
+                           <InfoRow label="결제 수단" value={detail.paymentMethodDisplay ?? '-'} />
+                           <InfoRow label="결제 일시" value={detail.paidAt ? formatDateTime(detail.paidAt) : '-'} />
+                        </div>
+                     </>
+                  )}
+               </SectionCard>
                )}
 
                {/* 취소/환불 정보 — INVALID 상태일 때만 표시 */}
@@ -433,10 +445,20 @@ export default function PurchaseDetailPage() {
                         </div>
                      </div>
                      {/* 환불 수단/일시 */}
-                     <div className="flex flex-col gap-3">
-                        <InfoRow label="환불 수단" value={detail.paymentMethodDisplay} />
-                        <InfoRow label="취소 일시" value={detail.paidAt ? formatDateTime(detail.paidAt) : '-'} />
-                     </div>
+                     {orderPaymentQuery.isLoading ? (
+                        <div className="rounded-xl bg-[#f7f8f9] px-5 py-6 text-center text-[14px] text-[#646f7c]">
+                           환불 정보를 불러오는 중입니다.
+                        </div>
+                     ) : orderPaymentQuery.isError ? (
+                        <div className="rounded-xl bg-[#f7f8f9] px-5 py-6 text-center text-[14px] text-[#646f7c]">
+                           환불 수단 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+                        </div>
+                     ) : (
+                        <div className="flex flex-col gap-3">
+                           <InfoRow label="환불 수단" value={detail.paymentMethodDisplay ?? '정보 없음'} />
+                           <InfoRow label="취소 일시" value={detail.paidAt ? formatDateTime(detail.paidAt) : '정보 없음'} />
+                        </div>
+                     )}
                      {/* 안내 문구 */}
                      <div className="bg-[#f7f8f9] rounded-xl p-5">
                         <div className="flex flex-col gap-1 text-[13px] font-medium text-[#646f7c] leading-normal">
@@ -448,7 +470,7 @@ export default function PurchaseDetailPage() {
                )}
 
                {/* 취소/환불 정보 (InfoItem) */}
-               {detail.refundInfo && (
+               {detail.refundInfo && !orderPaymentQuery.isError && (
                   <InfoItem
                      type="payment"
                      heading="취소/환불 정보"
@@ -466,7 +488,7 @@ export default function PurchaseDetailPage() {
                      totalColor="text-destructive"
                      infoRows={[
                         { label: '환불 수단', value: detail.refundInfo.method },
-                        { label: '환불 일시', value: detail.refundInfo.date },
+                        { label: '환불 일시', value: detail.refundInfo.date ?? '-' },
                      ]}
                      helperTexts={[
                         '• 판매 취소된 티켓은 예매 내역에서 확인하실 수 있습니다.',

--- a/src/pages/mypage/ui/ResellRegisterDialog.tsx
+++ b/src/pages/mypage/ui/ResellRegisterDialog.tsx
@@ -4,13 +4,14 @@ import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { PurchaseHistoryItem } from './HistoryCard';
 import ResellRegisterCompleteDialog from './ResellRegisterCompleteDialog';
-import type { ResellZoneInsights } from '@/pages/books/model/resellData';
 import ResellPriceChart from '@/pages/books/ui/components/ResellPriceChart';
 import { formatPrice } from '@/pages/books/model/zoneData';
-import { useQueryClient } from '@tanstack/react-query';
-import { createResaleListing } from '@/entities/resale/api/resaleApi';
+import { fetchSeatGrades } from '@/pages/books/api/bookingApi';
+import { buildResellZoneInsightsFromApi } from '@/pages/books/model/resellData';
+import { createResaleListings, fetchResaleHistoryGraph } from '@/entities/resale/api/resaleApi';
 import { getErrorMessage } from '@/shared/lib/error/getErrorMessage';
 
 interface Props {
@@ -20,42 +21,7 @@ interface Props {
    item: PurchaseHistoryItem;
 }
 
-// ─── 정적 mock 데이터 (실제로는 API에서 수신) ──────────────────────
-const MOCK_INSIGHTS: ResellZoneInsights = {
-   changeAmount: 6000,
-   changeRate: 25,
-   previousClose: 15000,
-   recentTrade: 21000,
-   dayLow: 16800,
-   dayHigh: 31200,
-   pricePointsByRange: {
-      minute: [
-         { time: '14:00', price: 13000, occurredAt: '2026-03-20T14:00:00+09:00' },
-         { time: '14:45', price: 15500, occurredAt: '2026-03-20T14:45:00+09:00' },
-         { time: '15:30', price: 18500, occurredAt: '2026-03-20T15:30:00+09:00' },
-         { time: '16:15', price: 21000, occurredAt: '2026-03-20T16:15:00+09:00' },
-         { time: '17:00', price: 19500, occurredAt: '2026-03-20T17:00:00+09:00' },
-         { time: '17:45', price: 23000, occurredAt: '2026-03-20T17:45:00+09:00' },
-         { time: '18:30', price: 22000, occurredAt: '2026-03-20T18:30:00+09:00' },
-      ],
-      day: [
-         { time: '03/14', price: 12000, occurredAt: '2026-03-14T18:00:00+09:00' },
-         { time: '03/15', price: 13500, occurredAt: '2026-03-15T18:00:00+09:00' },
-         { time: '03/16', price: 15500, occurredAt: '2026-03-16T18:00:00+09:00' },
-         { time: '03/17', price: 16500, occurredAt: '2026-03-17T18:00:00+09:00' },
-         { time: '03/18', price: 17800, occurredAt: '2026-03-18T18:00:00+09:00' },
-         { time: '03/19', price: 19200, occurredAt: '2026-03-19T18:00:00+09:00' },
-         { time: '03/20', price: 21000, occurredAt: '2026-03-20T18:00:00+09:00' },
-      ],
-   },
-   tradeHistory: [
-      { id: 't1', price: 52000, seatLabel: '110구역 0열 0번', tradedAt: '40분 전' },
-      { id: 't2', price: 81000, seatLabel: '110구역 10열 11번', tradedAt: '6시간 전' },
-      { id: 't3', price: 1052000, seatLabel: '110구역 27열 9번', tradedAt: '03/07 14:23' },
-      { id: 't4', price: 52000, seatLabel: '110구역 0열 0번', tradedAt: '03/07 14:23' },
-   ],
-   listings: [],
-};
+const normalizeGradeName = (value?: string) => (value ?? '').replace(/\s+/g, '').trim().toLowerCase();
 
 // ─── 체크박스 아이콘 ────────────────────────────────────────────────
 function CheckboxIcon({ checked }: { checked: boolean }) {
@@ -108,6 +74,62 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
 
    const [isSubmitting, setIsSubmitting] = useState(false);
    const queryClient = useQueryClient();
+   const unitPrice = item.game.quantity > 0 ? Math.round(item.price / item.game.quantity) : item.price;
+
+   const resaleInsightsQuery = useQuery({
+      queryKey: ['mypage-resell-register-insights', item.gameId, item.seatGradeName, item.game.section, unitPrice],
+      enabled: open && Boolean(item.gameId),
+      queryFn: async () => {
+         if (!item.gameId) {
+            return { status: 'missing-game-id' as const };
+         }
+
+         const seatGrades = await fetchSeatGrades({ gameId: item.gameId });
+         const normalizedTargetGradeName = normalizeGradeName(item.seatGradeName ?? item.game.section);
+         const matchedGrade = seatGrades.find((seatGrade) => {
+            const normalizedSeatGradeName = normalizeGradeName(seatGrade.name);
+
+            return (
+               normalizedSeatGradeName === normalizedTargetGradeName ||
+               normalizedSeatGradeName.includes(normalizedTargetGradeName) ||
+               normalizedTargetGradeName.includes(normalizedSeatGradeName)
+            );
+         });
+
+         if (!matchedGrade) {
+            return { status: 'missing-grade' as const };
+         }
+
+         const [minuteGraph, dayGraph] = await Promise.all([
+            fetchResaleHistoryGraph(item.gameId, matchedGrade.seatGradeId, 'HOUR'),
+            fetchResaleHistoryGraph(item.gameId, matchedGrade.seatGradeId, 'DAY'),
+         ]);
+
+         if (minuteGraph.length === 0 && dayGraph.length === 0) {
+            return { status: 'empty' as const };
+         }
+
+         return {
+            status: 'success' as const,
+            insights: buildResellZoneInsightsFromApi({
+               zone: {
+                  id: matchedGrade.seatGradeId,
+                  name: matchedGrade.name,
+                  price: unitPrice,
+                  remaining: matchedGrade.availableSeatCount,
+                  color: matchedGrade.displayColorHex,
+                  hotspot: [],
+                  sectionCode: item.game.section,
+                  gradeIds: [matchedGrade.seatGradeId],
+               },
+               listings: [],
+               minuteGraph,
+               dayGraph,
+            }),
+         };
+      },
+      staleTime: 60_000,
+   });
 
    const getResaleRegisterAlertMessage = (error: unknown) => {
       const message = getErrorMessage(error, '판매 등록에 실패했습니다. 다시 시도해주세요.');
@@ -136,7 +158,8 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
 
    const checkedCount = checkedSeats.size;
    const showBulkToggle = checkedCount >= 2;
-   const unitPrice = item.game.quantity > 0 ? Math.round(item.price / item.game.quantity) : item.price;
+   const resaleInsightsState = resaleInsightsQuery.data;
+   const insights = resaleInsightsState?.status === 'success' ? resaleInsightsState.insights : null;
 
    const toggleSeat = (idx: number) => {
       setCheckedSeats(prev => {
@@ -176,8 +199,9 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
 
       setIsSubmitting(true);
       try {
-         await Promise.all(requests.map(r => createResaleListing(r)));
+         await createResaleListings({ listings: requests });
          queryClient.invalidateQueries({ queryKey: ['myResales'] });
+         queryClient.invalidateQueries({ queryKey: ['myResaleSummary'] });
          setCompleteOpen(true);
       } catch (error) {
          alert(getResaleRegisterAlertMessage(error));
@@ -338,29 +362,69 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
                   </div>
 
                   {/* 거래 변동 + 차트 */}
-                  <ResellPriceChart insights={MOCK_INSIGHTS} />
+                  {resaleInsightsQuery.isLoading ? (
+                     <div className="bg-surface rounded-xl px-5 py-10 text-center text-[14px] text-[#646f7c]">
+                        거래 변동 정보를 불러오는 중입니다.
+                     </div>
+                  ) : resaleInsightsQuery.isError ? (
+                     <div className="bg-surface rounded-xl px-5 py-8 flex flex-col items-center gap-3 text-center">
+                        <p className="text-[14px] text-[#374553]">
+                           리셀 그래프 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+                        </p>
+                        <Button
+                           variant="tertiary"
+                           type="button"
+                           className="px-4 py-2"
+                           onClick={() => {
+                              void resaleInsightsQuery.refetch();
+                           }}
+                        >
+                           다시 시도
+                        </Button>
+                     </div>
+                  ) : resaleInsightsState?.status === 'missing-game-id' ? (
+                     <div className="bg-surface rounded-xl px-5 py-10 text-center text-[14px] text-[#646f7c]">
+                        경기 정보가 없어 리셀 그래프를 표시할 수 없습니다.
+                     </div>
+                  ) : resaleInsightsState?.status === 'missing-grade' ? (
+                     <div className="bg-surface rounded-xl px-5 py-10 text-center text-[14px] text-[#646f7c]">
+                        좌석 등급 정보를 찾지 못해 리셀 그래프를 표시할 수 없습니다.
+                     </div>
+                  ) : resaleInsightsState?.status === 'empty' ? (
+                     <div className="bg-surface rounded-xl px-5 py-10 text-center text-[14px] text-[#646f7c]">
+                        아직 해당 좌석 등급의 최근 거래 내역이 없습니다.
+                     </div>
+                  ) : insights ? (
+                     <ResellPriceChart insights={insights} />
+                  ) : null}
 
                   {/* 최근 거래 내역 */}
                   <div className="flex flex-col gap-3">
                      <p className="text-[20px] font-bold text-[#161d24] leading-normal">최근 거래 내역</p>
-                     <ul className="flex flex-col gap-1">
-                        {MOCK_INSIGHTS.tradeHistory.map(trade => (
-                           <li
-                              key={trade.id}
-                              className="grid grid-cols-[max-content_minmax(0,1fr)_66px] items-center gap-x-3"
-                           >
-                              <span className="whitespace-nowrap text-[14px] font-semibold text-[#374553]">
-                                 {formatPrice(trade.price)}
-                              </span>
-                              <span className="min-w-0 truncate text-right text-[14px] text-[#374553]">
-                                 {trade.seatLabel}
-                              </span>
-                              <span className="whitespace-nowrap text-right text-[12px] text-[#646f7c]">
-                                 {trade.tradedAt}
-                              </span>
-                           </li>
-                        ))}
-                     </ul>
+                     {insights ? (
+                        <ul className="flex flex-col gap-1">
+                           {insights.tradeHistory.map(trade => (
+                              <li
+                                 key={trade.id}
+                                 className="grid grid-cols-[max-content_minmax(0,1fr)_66px] items-center gap-x-3"
+                              >
+                                 <span className="whitespace-nowrap text-[14px] font-semibold text-[#374553]">
+                                    {formatPrice(trade.price)}
+                                 </span>
+                                 <span className="min-w-0 truncate text-right text-[14px] text-[#374553]">
+                                    {trade.seatLabel}
+                                 </span>
+                                 <span className="whitespace-nowrap text-right text-[12px] text-[#646f7c]">
+                                    {trade.tradedAt}
+                                 </span>
+                              </li>
+                           ))}
+                        </ul>
+                     ) : (
+                        <div className="rounded-xl bg-surface px-5 py-6 text-center text-[14px] text-[#646f7c]">
+                           최근 거래 내역을 표시할 수 없습니다.
+                        </div>
+                     )}
                   </div>
 
                   {/* 판매 유의사항 */}

--- a/src/pages/mypage/ui/SaleDetailPage.tsx
+++ b/src/pages/mypage/ui/SaleDetailPage.tsx
@@ -4,8 +4,9 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { AlertCircle } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import { Separator } from '@/shared/ui/separator';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchResaleListingDetail, cancelResaleListing } from '@/entities/resale/api/resaleApi';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { cancelResaleListing } from '@/entities/resale/api/resaleApi';
+import { useMyResaleListData } from '../model/useMypageData';
 import StatusBadge from './StatusBadge';
 import type { BadgeVariant } from './StatusBadge';
 import TicketItem from './TicketItem';
@@ -21,18 +22,6 @@ const SALE_BADGE: Record<SaleStatus, BadgeVariant> = {
    '판매 완료': 'success',
    '취소 대기': 'disabled',
    '취소 완료': 'disabled',
-};
-
-const mapSaleStatus = (status: string): SaleStatus => {
-   switch (status) {
-      case 'LISTING': return '판매 중';
-      case 'HOLD':    return '판매 중';
-      case 'SOLD':    return '정산 대기';
-      case 'SETTLED': return '판매 완료';
-      case 'CANCEL_REQUESTED': return '취소 대기';
-      case 'CANCELED': return '취소 완료';
-      default:        return '판매 중';
-   }
 };
 
 const FEE_RATE = 5;
@@ -51,45 +40,45 @@ export default function SaleDetailPage() {
    const { id } = useParams<{ id: string }>();
    const navigate = useNavigate();
    const queryClient = useQueryClient();
-
-   const { data: apiDetail, isLoading, isError } = useQuery({
-      queryKey: ['resaleListingDetail', id],
-      queryFn: () => fetchResaleListingDetail(id!),
-      enabled: !!id,
-   });
+   const resaleListQuery = useMyResaleListData();
+   const apiDetail = (resaleListQuery.data ?? []).find((item) => item.id === id);
 
    const { mutate: cancelListing, isPending: isCanceling } = useMutation({
       mutationFn: () => cancelResaleListing(id!),
       onSuccess: () => {
-         queryClient.invalidateQueries({ queryKey: ['resaleListingDetail', id] });
          queryClient.invalidateQueries({ queryKey: ['myResales'] });
+         queryClient.invalidateQueries({ queryKey: ['myResaleSummary'] });
+         queryClient.invalidateQueries({ queryKey: ['myResaleUnsettledAmount'] });
       },
    });
 
-   if (isLoading) return <div className="py-24 text-center text-body-1-regular">정보를 불러오는 중입니다...</div>;
-   if (isError || !apiDetail) {
+   if (resaleListQuery.isLoading) return <div className="py-24 text-center text-body-1-regular">정보를 불러오는 중입니다...</div>;
+   if (resaleListQuery.isError || !apiDetail) {
       return (
          <div className="flex flex-col items-center justify-center py-24 gap-4">
-            <p className="text-body-1-regular text-muted-foreground">판매 내역을 찾을 수 없습니다.</p>
+            <p className="text-body-1-regular text-muted-foreground">
+               판매 내역을 불러오지 못했거나 존재하지 않습니다.
+            </p>
             <Button variant="tertiary" onClick={() => navigate('/mypage')}>마이페이지로 돌아가기</Button>
          </div>
       );
    }
 
-   const overallStatus = mapSaleStatus(apiDetail.listingStatus);
+   const overallStatus = apiDetail.saleStatus as SaleStatus;
    const isCancelPending = overallStatus === '취소 대기' || overallStatus === '취소 완료';
    const isSoldComplete = overallStatus === '판매 완료';
+   const firstSeatDetail = apiDetail.game.seats[0] ?? '-';
 
    const seatItem = {
-      orderId: apiDetail.listingId.slice(0, 8).toUpperCase(),
-      section: apiDetail.seatInfo.split(' ')[0] ?? '',
-      seatDetail: apiDetail.seatInfo,
+      orderId: apiDetail.orderId,
+      section: apiDetail.game.section,
+      seatDetail: firstSeatDetail,
       status: isCancelPending ? '판매취소' : '판매중',
-      price: apiDetail.listingPrice,
+      price: apiDetail.salePrice,
    } as const;
 
-   const estimatedFee = -Math.round(apiDetail.listingPrice * FEE_RATE / 100);
-   const estimatedTotal = apiDetail.listingPrice + estimatedFee;
+   const estimatedFee = -Math.round(apiDetail.salePrice * FEE_RATE / 100);
+   const estimatedTotal = apiDetail.salePrice + estimatedFee;
 
    return (
       <div className="flex flex-col items-center pt-12.5 pb-30 px-4">
@@ -107,11 +96,11 @@ export default function SaleDetailPage() {
                   <StatusBadge label={overallStatus} variant={SALE_BADGE[overallStatus]} />
                   <div className="flex flex-col gap-4">
                      <p className="text-[32px] font-bold text-[#161d24] tracking-[-0.032px] leading-[1.45]">
-                        {apiDetail.gameTitle}
+                        {apiDetail.game.teams}
                      </p>
                      <div className="flex flex-col gap-1 text-[18px] font-medium text-[#374553]">
-                        <p className="leading-[1.55]">{apiDetail.gameDate}</p>
-                        <p className="leading-[1.55]">{apiDetail.stadiumName}</p>
+                        <p className="leading-[1.55]">{apiDetail.game.datetime}</p>
+                        <p className="leading-[1.55]">{apiDetail.game.venue}</p>
                      </div>
                   </div>
                </SectionCard>
@@ -121,8 +110,8 @@ export default function SaleDetailPage() {
                   <InfoItem
                      heading="취소 정보"
                      rows={[
-                        { label: '등록번호', value: apiDetail.listingId.slice(0, 8).toUpperCase() },
-                        { label: '취소일시', value: apiDetail.canceledAt ?? '' },
+                        { label: '등록번호', value: apiDetail.orderId },
+                        { label: '취소일시', value: apiDetail.canceledAt ?? '-' },
                      ]}
                      helperTexts={[
                         '• 판매 취소된 티켓은 예매 내역에서 확인하실 수 있습니다.',
@@ -133,9 +122,9 @@ export default function SaleDetailPage() {
                   <InfoItem
                      heading="판매 정보"
                      rows={[
-                        { label: '등록번호', value: apiDetail.listingId.slice(0, 8).toUpperCase() },
-                        { label: '판매일시', value: apiDetail.listedAt },
-                        ...(isSoldComplete ? [{ label: '정산일시', value: apiDetail.listedAt }] : []),
+                        { label: '등록번호', value: apiDetail.orderId },
+                        { label: '판매일시', value: apiDetail.orderDate },
+                        ...(isSoldComplete ? [{ label: '판매완료일시', value: apiDetail.soldAt ?? '-' }] : []),
                      ]}
                      helperTexts={[
                         isSoldComplete
@@ -172,7 +161,7 @@ export default function SaleDetailPage() {
                      statusText={isSoldComplete ? '정산 완료' : '정산 대기'}
                      statusColor={isSoldComplete ? 'text-primary' : 'text-muted-foreground'}
                      summaryRows={[
-                        { label: '티켓 금액 (1매)', amount: apiDetail.listingPrice },
+                        { label: '티켓 금액 (1매)', amount: apiDetail.salePrice },
                         { label: `수수료(${FEE_RATE}%)`, amount: estimatedFee },
                      ]}
                      totalLabel="예상 정산 금액"
@@ -183,7 +172,7 @@ export default function SaleDetailPage() {
             </div>
 
             {/* 판매 취소 버튼 — 판매 중일 때만 */}
-            {apiDetail.isCancelable && (
+            {apiDetail.canCancel && (
                <Button
                   variant="tertiary"
                   className="w-full py-3"

--- a/src/shared/api/mocks/handlers/auth.ts
+++ b/src/shared/api/mocks/handlers/auth.ts
@@ -20,9 +20,25 @@ type MockRefreshSession = {
    mobile?: string;
 };
 
+type MockMemberAccount = {
+   accountId: string;
+   accountNumber: string;
+   bankName: string;
+   accountHolder: string;
+};
+
+type MockMemberAddress = {
+   addressId: string;
+   zipCode: string;
+   baseAddress: string;
+   detailAddress: string;
+};
+
 // 팝업 창과 부모 창 간 세션 공유를 위해 localStorage 사용
 const MOCK_AUTH_SESSIONS_KEY = '__mock_auth_sessions__';
 const MOCK_REFRESH_SESSION_KEY = '__mock_refresh_session__';
+const MOCK_MEMBER_ACCOUNTS_KEY = '__mock_member_accounts__';
+const MOCK_MEMBER_ADDRESSES_KEY = '__mock_member_addresses__';
 
 const mockAuthSessions = {
    get(token: string): MockAuthSession | undefined {
@@ -71,6 +87,50 @@ const mockRefreshSession = {
    },
 };
 
+const mockMemberAccounts = {
+   get(memberKey: string): MockMemberAccount | undefined {
+      try {
+         const raw = localStorage.getItem(MOCK_MEMBER_ACCOUNTS_KEY);
+         const map: Record<string, MockMemberAccount> = raw ? JSON.parse(raw) : {};
+         return map[memberKey];
+      } catch {
+         return undefined;
+      }
+   },
+   set(memberKey: string, account: MockMemberAccount) {
+      try {
+         const raw = localStorage.getItem(MOCK_MEMBER_ACCOUNTS_KEY);
+         const map: Record<string, MockMemberAccount> = raw ? JSON.parse(raw) : {};
+         map[memberKey] = account;
+         localStorage.setItem(MOCK_MEMBER_ACCOUNTS_KEY, JSON.stringify(map));
+      } catch {
+         // ignore
+      }
+   },
+};
+
+const mockMemberAddresses = {
+   get(memberKey: string): MockMemberAddress | undefined {
+      try {
+         const raw = localStorage.getItem(MOCK_MEMBER_ADDRESSES_KEY);
+         const map: Record<string, MockMemberAddress> = raw ? JSON.parse(raw) : {};
+         return map[memberKey];
+      } catch {
+         return undefined;
+      }
+   },
+   set(memberKey: string, address: MockMemberAddress) {
+      try {
+         const raw = localStorage.getItem(MOCK_MEMBER_ADDRESSES_KEY);
+         const map: Record<string, MockMemberAddress> = raw ? JSON.parse(raw) : {};
+         map[memberKey] = address;
+         localStorage.setItem(MOCK_MEMBER_ADDRESSES_KEY, JSON.stringify(map));
+      } catch {
+         // ignore
+      }
+   },
+};
+
 const createId = (prefix: string) => {
    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
       return `${prefix}-${crypto.randomUUID()}`;
@@ -93,6 +153,34 @@ const buildMockAccessToken = (payload: Record<string, unknown>) => {
    const signature = encodeBase64Url('mock-signature');
 
    return `${header}.${body}.${signature}`;
+};
+
+const parseMockTokenPayload = (token: string): Record<string, string> | null => {
+   if (!token) {
+      return null;
+   }
+
+   try {
+      const payloadB64 = token.split('.')[1] ?? '';
+      return JSON.parse(
+         decodeURIComponent(
+            atob(payloadB64.replace(/-/g, '+').replace(/_/g, '/'))
+               .split('')
+               .map(c => '%' + c.charCodeAt(0).toString(16).padStart(2, '0'))
+               .join(''),
+         ),
+      ) as Record<string, string>;
+   } catch {
+      return null;
+   }
+};
+
+const getMockMemberKey = (request: Request) => {
+   const authHeader = request.headers.get('Authorization') ?? '';
+   const token = authHeader.replace(/^Bearer\s+/i, '');
+   const decoded = parseMockTokenPayload(token);
+
+   return decoded?.userId || decoded?.sub || decoded?.email || 'guest';
 };
 
 const resolveRegisteredState = (authCode: string) => {
@@ -295,23 +383,12 @@ export const authHandlers = [
       let mobile = '010-0000-0000';
       let email = '';
 
-      if (token) {
-         try {
-            const payloadB64 = token.split('.')[1] ?? '';
-            const decoded = JSON.parse(
-               decodeURIComponent(
-                  atob(payloadB64.replace(/-/g, '+').replace(/_/g, '/'))
-                     .split('')
-                     .map(c => '%' + c.charCodeAt(0).toString(16).padStart(2, '0'))
-                     .join(''),
-               ),
-            ) as Record<string, string>;
-            if (decoded.name) name = decoded.name;
-            if (decoded.mobile) mobile = decoded.mobile;
-            if (decoded.email) email = decoded.email;
-         } catch {
-            // 파싱 실패 시 기본값 사용
-         }
+      const decoded = parseMockTokenPayload(token);
+
+      if (decoded) {
+         if (decoded.name) name = decoded.name;
+         if (decoded.mobile) mobile = decoded.mobile;
+         if (decoded.email) email = decoded.email;
       }
 
       return HttpResponse.json({
@@ -324,6 +401,62 @@ export const authHandlers = [
             gender: 'MALE',
             birthDate: '1990-01-01',
          },
+      });
+   }),
+
+   http.post('/api/v1/members/accounts', async ({ request }) => {
+      const body = (await request.json()) as {
+         accountNumber?: string;
+         bankName?: string;
+         accountHolder?: string;
+      };
+
+      if (!body?.accountNumber || !body?.bankName || !body?.accountHolder) {
+         return HttpResponse.json({ message: 'Missing member account fields.' }, { status: 400 });
+      }
+
+      const memberKey = getMockMemberKey(request);
+      const savedAccount = {
+         accountId: createId('account'),
+         accountNumber: body.accountNumber,
+         bankName: body.bankName,
+         accountHolder: body.accountHolder,
+      };
+
+      mockMemberAccounts.set(memberKey, savedAccount);
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: savedAccount,
+      });
+   }),
+
+   http.post('/api/v1/members/addresses', async ({ request }) => {
+      const body = (await request.json()) as {
+         zipCode?: string;
+         baseAddress?: string;
+         detailAddress?: string;
+      };
+
+      if (!body?.zipCode || !body?.baseAddress || !body?.detailAddress) {
+         return HttpResponse.json({ message: 'Missing member address fields.' }, { status: 400 });
+      }
+
+      const memberKey = getMockMemberKey(request);
+      const savedAddress = {
+         addressId: createId('address'),
+         zipCode: body.zipCode,
+         baseAddress: body.baseAddress,
+         detailAddress: body.detailAddress,
+      };
+
+      mockMemberAddresses.set(memberKey, savedAddress);
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: savedAddress,
       });
    }),
 

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -1499,6 +1499,20 @@ export const paymentHandlers = [
       });
    }),
 
+   http.get('/api/v1/payments/resales/unsettled', async () => {
+      const unsettledAmount = Array.from(resaleListings.values())
+         .filter((listing) => listing.listingStatus === 'SOLD')
+         .reduce((sum, listing) => sum + listing.listingPrice, 0);
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            unsettledAmount,
+         },
+      });
+   }),
+
    http.get('/api/v1/payments/resales/ledgers/orders/:orderId', async ({ params }) => {
       const ledger = resaleLedgers.get(String(params.orderId));
 
@@ -1745,40 +1759,49 @@ export const paymentHandlers = [
 
    // 리셀 등록
    http.post('/api/v1/resales/listings', async ({ request }) => {
-      const body = (await request.json()) as { ticketId?: string; listingPrice?: number } | null;
+      const body = (await request.json()) as
+         | { ticketId?: string; listingPrice?: number }
+         | { listings?: Array<{ ticketId?: string; listingPrice?: number }> }
+         | null;
 
-      if (!body?.ticketId || !body?.listingPrice) {
+      const listings = 'listings' in (body ?? {}) ? body?.listings ?? [] : body ? [body] : [];
+
+      if (listings.length === 0 || listings.some((item) => !item?.ticketId || !item?.listingPrice)) {
          return buildErrorResponse('Missing ticketId or listingPrice.');
       }
 
-      const ticket = ticketRecords.get(body.ticketId);
-      if (!ticket) {
-         return buildErrorResponse('Ticket not found.', 404);
+      const createdListingIds: string[] = [];
+
+      for (const item of listings) {
+         const ticket = ticketRecords.get(item.ticketId!);
+         if (!ticket) {
+            return buildErrorResponse('Ticket not found.', 404);
+         }
+
+         const listingId = createId('listing');
+         const listing: ResaleListing = {
+            listingId,
+            ticketId: ticket.ticketId,
+            sellerId: 'mock-seller',
+            seatInfo: ticket.seatInfo,
+            listingPrice: item.listingPrice!,
+            listingStatus: 'LISTING',
+            listedAt: new Date().toISOString(),
+            gameTitle: ticket.gameTitle,
+            gameDate: ticket.gameDate,
+            stadiumName: ticket.stadiumName,
+         };
+         resaleListings.set(listingId, listing);
+         createdListingIds.push(listingId);
+
+         ticketRecords.set(ticket.ticketId, {
+            ...ticket,
+            ticketStatus: 'ISSUED',
+            resaleEnabledStatus: 'DISABLED',
+         });
       }
 
-      const listingId = createId('listing');
-      const listing: ResaleListing = {
-         listingId,
-         ticketId: ticket.ticketId,
-         sellerId: 'mock-seller',
-         seatInfo: ticket.seatInfo,
-         listingPrice: body.listingPrice,
-         listingStatus: 'LISTING',
-         listedAt: new Date().toISOString(),
-         gameTitle: ticket.gameTitle,
-         gameDate: ticket.gameDate,
-         stadiumName: ticket.stadiumName,
-      };
-      resaleListings.set(listingId, listing);
-
-      // 티켓 상태 RESALE_ISSUED로 변경 및 리셀 등록 후 canSell 비활성화
-      ticketRecords.set(ticket.ticketId, {
-         ...ticket,
-         ticketStatus: 'ISSUED',
-         resaleEnabledStatus: 'DISABLED',
-      });
-
-      return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: { listingId } });
+      return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: { listingIds: createdListingIds } });
    }),
 
    // 내 리셀 목록 조회
@@ -1806,6 +1829,21 @@ export const paymentHandlers = [
       }));
 
       return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: listings });
+   }),
+
+   http.get('/api/v1/resales/listings/count/listing', async () => {
+      const listings = Array.from(resaleListings.values());
+      const listingCount = listings.filter((item) => item.listingStatus === 'LISTING' || item.listingStatus === 'HOLD').length;
+      const soldCount = listings.filter((item) => item.listingStatus === 'SETTLED').length;
+
+      return HttpResponse.json({
+         code: 'SUCCESS',
+         message: 'ok',
+         data: {
+            listingCount,
+            soldCount,
+         },
+      });
    }),
 
    // 리셀 상세 조회

--- a/src/shared/lib/jwt.ts
+++ b/src/shared/lib/jwt.ts
@@ -45,3 +45,37 @@ export const resolveUserIdFromJwt = (accessToken: string | null) => {
 
    return typeof userId === 'string' && userId.length > 0 ? userId : null;
 };
+
+type JwtProfileField = 'name' | 'email' | 'mobile';
+
+const resolveStringClaim = (payload: Record<string, unknown>, keys: string[]) => {
+   for (const key of keys) {
+      const value = payload[key];
+
+      if (typeof value === 'string' && value.length > 0) {
+         return value;
+      }
+   }
+
+   return undefined;
+};
+
+export const resolveProfileFromJwt = (accessToken: string | null) => {
+   const payload = decodeJwtPayload(accessToken);
+
+   if (!payload) {
+      return null;
+   }
+
+   const claimMap: Record<JwtProfileField, string[]> = {
+      name: ['name'],
+      email: ['email'],
+      mobile: ['mobile', 'phone', 'phoneNumber', 'phone_number'],
+   };
+
+   return {
+      name: resolveStringClaim(payload, claimMap.name),
+      email: resolveStringClaim(payload, claimMap.email),
+      mobile: resolveStringClaim(payload, claimMap.mobile),
+   };
+};


### PR DESCRIPTION
## #️⃣ 관련 이슈
  - #186
  <br/>

  ## 🔎 개요
마이페이지 계정 정보, 판매 요약, 구매/판매 상세, 리셀 등록 흐름을 실제 API 및 문서 기준으로 정리하고, 상세 화면에서 통신 실패가 성공처럼 보이거나 런타임 오류로 이어지던 부분을 보완했습니다.
  <br/>

  ## 📋 작업 내용

  - 마이페이지 계정 정보 화면에 회원 계좌 등록, 주소 등록 API를 연결했습니다.
  - JWT 기반 프로필 보강 로직을 정리해 프로필 조회 응답의 누락 필드를 토큰 정보로만 보완하도록 변경했습니다.
  - 마이페이지 메인 상단 티켓 현황 카드에 판매 중 개수, 판매 완료 개수, 미정산 금액 API를 연결했습니다.
  - 계정 정보/마이페이지 메인 조회 실패 시 재시도 가능한 에러 상태를 추가했습니다.
  - 주소 조회 API가 없는 상태를 고려해 기본 더미 주소 노출을 제거했습니다.
  - 구매 상세의 결제 정보/환불 정보 영역에서 결제 조회 실패를 성공 상태처럼 보이지 않도록 예외 처리를 분리했습니다.
  - 무통장 취소 확인 다이얼로그에서 하드코딩 계좌 mock을 제거하고, 조회 API 부재를 안내하는 문구로 정리했습니다.
  - 판매 상세 화면이 비문서 상세 API 없이도 목록 조회 결과를 재사용해 동작하도록 정리했습니다.
  - 리셀 판매 등록 다이얼로그에서 정적 mock 시세 데이터를 제거하고, 좌석 등급/거래 그래프 API 기반으로 차트와 최근 거래 내역을 표시하도록 변경했습니다.
  - 리셀 등록 요청을 문서 기준의 listings[] 일괄 등록 바디로 맞췄습니다.
  - 위 연동 사항을 확인할 수 있도록 MSW mock handler도 함께 보강했습니다.
  <br/>