### PR TITLE
[bug] 결제완료 pc 헤더 예매 정보 미동기 버그 수정

### DIFF
--- a/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
@@ -244,6 +244,9 @@ export default function PaymentCompletePage() {
          {/* 데스크톱 헤더 */}
          <div className="hidden lg:block">
             <BooksHeader
+               matchTitle={order.gameTitle}
+               venue={order.gameVenue}
+               dateTime={order.gameDate}
                confirmBeforeExit={false}
                showTimer={false}
                currentStepIndex={3}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #255 

<br/>

## 🔎 개요
결제 완료의 pc 헤더에서 props로 전달 해야 하는 예매 정보가 전달되지 않았던 문제 수정

<br/>

## 📋 작업 내용
- 결제완료 페이지의 pc 헤더에 대하여 경기명, 날짜, 위치 props 전달

<br/>
