### PR TITLE
[bug] 봇탐지 오류 및 선행 api 실패 시 방어로직 추가

### DIFF
--- a/src/pages/books/model/useBookingZones.ts
+++ b/src/pages/books/model/useBookingZones.ts
@@ -14,6 +14,7 @@ import { isPurchasableResaleListing, resolveResaleListingZoneId } from '@/pages/
 import type { ZoneItem } from '@/pages/books/model/types';
 import { getBookingZones, getZoneDisplayOrder } from '@/pages/books/model/zoneData';
 import { getCompletedResalePurchaseLookup } from '@/shared/lib/paymentCompleteStorage';
+import { ApiError } from '@/shared/api/client';
 import type { BookingFlowMode } from '@/shared/lib/booking-flow';
 import type { BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 
@@ -23,11 +24,28 @@ type UseBookingZonesParams = {
    patchBookingEntry: (partialEntry: Partial<BookingEntryState>) => void;
 };
 
+type UseBookingZonesResult = {
+   zones: ZoneItem[];
+   isSeatGradeBotBlocked: boolean;
+};
+
+const hasBotBlockedMessage = (value: unknown): boolean => {
+   if (typeof value === 'string') {
+      return value.includes('봇 감지');
+   }
+
+   if (value && typeof value === 'object' && 'message' in value) {
+      return hasBotBlockedMessage((value as { message?: unknown }).message);
+   }
+
+   return false;
+};
+
 export function useBookingZones({
    bookingEntryState,
    bookingFlowMode,
    patchBookingEntry,
-}: UseBookingZonesParams): ZoneItem[] {
+}: UseBookingZonesParams): UseBookingZonesResult {
    const shouldForceNewSessionRef = useRef(Boolean(bookingEntryState?.forceNewSession));
 
    const localZones = useMemo(
@@ -40,7 +58,7 @@ export function useBookingZones({
       [bookingEntryState?.homeTeamId],
    );
 
-   const { data: apiZones } = useQuery({
+   const { data: apiZones, error: apiZonesError } = useQuery({
       queryKey: [
          'booking-zones',
          bookingFlowMode,
@@ -174,5 +192,12 @@ export function useBookingZones({
       });
    }, [patchBookingEntry, zones]);
 
-   return zones;
+   const isSeatGradeBotBlocked =
+      apiZonesError instanceof ApiError &&
+      (hasBotBlockedMessage(apiZonesError.message) || hasBotBlockedMessage(apiZonesError.data));
+
+   return {
+      zones,
+      isSeatGradeBotBlocked,
+   };
 }

--- a/src/pages/books/model/useZoneSeatState.ts
+++ b/src/pages/books/model/useZoneSeatState.ts
@@ -24,7 +24,15 @@ export function useZoneSeatState({
    zone,
 }: UseZoneSeatStateParams) {
    const initialSeats = useMemo(() => createSeatsForZone(zone), [zone]);
-   const { apiSeatItems, seatBlocks, hasApiSeatMap, isSeatMapLoading, refetchSeatMap } = useSeatMapData({
+   const {
+      apiSeatItems,
+      seatBlocks,
+      hasApiSeatMap,
+      isSeatMapError,
+      seatMapErrorMessage,
+      isSeatMapLoading,
+      refetchSeatMap,
+   } = useSeatMapData({
       gameId: bookingEntryState?.gameId,
       stadiumId: bookingEntryState?.stadiumId,
       zone,
@@ -83,8 +91,11 @@ export function useZoneSeatState({
    return {
       allSelectedSeatsAreHeld,
       clearSelectedSeats,
+      hasApiSeatMap,
       holdSeat,
       holdsBySeatId,
+      isSeatMapError,
+      seatMapErrorMessage,
       isSeatInteractionLocked,
       pendingSeatIds,
       releaseSeat,

--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
@@ -30,11 +30,12 @@ const BooksPage = () => {
       [bookingEntryState?.homeTeamId],
    );
    const requiresCaptcha = Boolean(bookingEntryState?.requireCaptcha);
-   const zones = useBookingZones({
+   const { zones, isSeatGradeBotBlocked } = useBookingZones({
       bookingEntryState,
       bookingFlowMode,
       patchBookingEntry,
    });
+   const hasShownBotBlockedAlertRef = useRef(false);
    const [selectedZoneId, setSelectedZoneId] = useState(
       () => zones.find(zone => zone.remaining > 0)?.id ?? zones[0]?.id ?? '',
    );
@@ -90,6 +91,16 @@ const BooksPage = () => {
    const exitGuard = useBookingExitGuard({
       onExit: exitBookingFlow,
    });
+
+   useEffect(() => {
+      if (!isSeatGradeBotBlocked || hasShownBotBlockedAlertRef.current) {
+         return;
+      }
+
+      hasShownBotBlockedAlertRef.current = true;
+      window.alert('매크로 사용 시 예매에 접근할 수 없습니다.');
+      exitBookingFlow();
+   }, [exitBookingFlow, isSeatGradeBotBlocked]);
 
    useEffect(() => {
       if (captcha.isCaptchaOpen) {

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -30,8 +30,11 @@ function SeatsPage() {
    const {
       allSelectedSeatsAreHeld: allStandardSelectedSeatsAreHeld,
       clearSelectedSeats,
+      hasApiSeatMap,
       holdSeat,
       holdsBySeatId,
+      isSeatMapError,
+      seatMapErrorMessage,
       isSeatInteractionLocked,
       pendingSeatIds,
       releaseSeat,
@@ -83,7 +86,7 @@ function SeatsPage() {
          return resellSeatSelection.displaySeats;
       }
 
-      if (isSeatInteractionLocked) {
+      if (isSeatInteractionLocked || !hasApiSeatMap) {
          return seats.map(
             seat =>
                ({
@@ -151,6 +154,13 @@ function SeatsPage() {
 
    const toggleSeat = (seat: SeatItem) => {
       if (isSeatInteractionLocked) {
+         return;
+      }
+
+      if (!isResellMode && !hasApiSeatMap) {
+         if (isSeatMapError && seatMapErrorMessage) {
+            window.alert(seatMapErrorMessage);
+         }
          return;
       }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #177
- #114

<br/>

## 🔎 개요
봇탐지 오류 시 임시 안내 alert 추가 및 메인화면 이동 구현 완료했습니다. 좌석 예매 플로우 시 선행 api 실패시 방어로직을 추가했습니다. 

<br/>

## 📋 작업 내용
- 좌석 API 맵을 못 받은 경우 fallback 좌석으로 hold 요청이 나가지 않도록 막음
- 좌석등급 조회에서 봇 감지 응답이 오면 메인으로 이동시키고 매크로 사용 시 '예매에 접근할 수 없습니다.' 임시 alert 추가

<br/>
