### PR TITLE
[bug] 대기열 이후 예매 플로우가 api 통신하지 않는 버그

### DIFF
--- a/src/app/providers/router/ui/BookingFlowStateGuard.tsx
+++ b/src/app/providers/router/ui/BookingFlowStateGuard.tsx
@@ -1,31 +1,64 @@
 import { useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
+import { leaveQueueKeepalive } from '@/pages/queue/api/queueApi';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 import { useBookingEntryStore } from '@/shared/lib/useBookingEntryStore';
 import { useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
 
 const isBookingFlowPath = (pathname: string) =>
    pathname.startsWith('/queue') || pathname.startsWith('/books') || pathname.startsWith('/tickets');
+const isBookSelectionPath = (pathname: string) => pathname.startsWith('/books');
+const isTicketCheckoutPath = (pathname: string) =>
+   pathname === '/tickets/payment' ||
+   pathname === '/tickets/resell-payment' ||
+   pathname === '/tickets/payment/processing';
 const requiresBookingEntry = (pathname: string) =>
    pathname.startsWith('/queue') ||
-   pathname.startsWith('/books') ||
-   pathname === '/tickets/payment' ||
-   pathname === '/tickets/resell-payment';
+   isBookSelectionPath(pathname) ||
+   isTicketCheckoutPath(pathname);
+const requiresQueueReentryOnBoot = (pathname: string) =>
+   isBookSelectionPath(pathname) || isTicketCheckoutPath(pathname);
+const shouldReleaseQueueOnUnload = (pathname: string) =>
+   isBookSelectionPath(pathname) || isTicketCheckoutPath(pathname);
+const isPageReload = () => {
+   if (typeof window === 'undefined' || typeof performance === 'undefined') {
+      return false;
+   }
+
+   const [navigationEntry] = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[];
+   return navigationEntry?.type === 'reload';
+};
 
 const BookingFlowStateGuard = () => {
    const navigate = useNavigate();
-   const { pathname } = useLocation();
+   const location = useLocation();
+   const { pathname, search } = location;
    const previousPathnameRef = useRef<string | null>(null);
+   const hasHydrated = useBookingEntryStore((state) => state.hasHydrated);
    const bookingEntry = useBookingEntryStore((state) => state.entry);
 
    useEffect(() => {
+      if (!hasHydrated) {
+         return;
+      }
+
       const previousPathname = previousPathnameRef.current;
+      const isInitialAppLoad = previousPathname === null;
       const isCurrentBookingFlow = isBookingFlowPath(pathname);
       const didExitBookingFlow = Boolean(
          previousPathname && isBookingFlowPath(previousPathname) && !isCurrentBookingFlow,
       );
       const requiresEntry = requiresBookingEntry(pathname);
+
+      if (isInitialAppLoad && isPageReload() && requiresQueueReentryOnBoot(pathname) && bookingEntry) {
+         useSeatHoldStore.getState().clearSeatHolds();
+         useSeatSelectionStore.getState().clearAllSelections();
+         useBookingFlowTimerStore.getState().clearTimer();
+         navigate('/queue', { replace: true, search, state: bookingEntry });
+         return;
+      }
+
       if (requiresEntry && !bookingEntry) {
          useSeatHoldStore.getState().clearSeatHolds();
          useSeatSelectionStore.getState().clearAllSelections();
@@ -42,7 +75,25 @@ const BookingFlowStateGuard = () => {
       }
 
       previousPathnameRef.current = pathname;
-   }, [bookingEntry, navigate, pathname]);
+   }, [bookingEntry, hasHydrated, navigate, pathname, search]);
+
+   useEffect(() => {
+      if (!shouldReleaseQueueOnUnload(pathname) || !bookingEntry?.gameId || !bookingEntry.queueTokenJti) {
+         return;
+      }
+
+      const handleUnload = () => {
+         leaveQueueKeepalive(bookingEntry.gameId!);
+      };
+
+      window.addEventListener('beforeunload', handleUnload);
+      window.addEventListener('pagehide', handleUnload);
+
+      return () => {
+         window.removeEventListener('beforeunload', handleUnload);
+         window.removeEventListener('pagehide', handleUnload);
+      };
+   }, [bookingEntry?.gameId, bookingEntry?.queueTokenJti, pathname]);
 
    return null;
 };

--- a/src/pages/books/model/useBookingZones.ts
+++ b/src/pages/books/model/useBookingZones.ts
@@ -46,6 +46,12 @@ export function useBookingZones({
 }: UseBookingZonesParams): UseBookingZonesResult {
    const shouldForceNewSessionRef = useRef(Boolean(bookingEntryState?.forceNewSession));
 
+   useEffect(() => {
+      if (bookingEntryState?.forceNewSession) {
+         shouldForceNewSessionRef.current = true;
+      }
+   }, [bookingEntryState?.forceNewSession]);
+
    const localZones = useMemo(
       () =>
          [...getBookingZones(bookingEntryState?.homeTeamId)].sort(
@@ -62,6 +68,7 @@ export function useBookingZones({
          bookingFlowMode,
          bookingEntryState?.stadiumId,
          bookingEntryState?.gameId,
+         bookingEntryState?.queueTokenJti,
          bookingEntryState?.serverHomeTeamId,
          bookingEntryState?.leagueType,
          bookingEntryState?.gameDate,

--- a/src/pages/queue/api/queueApi.ts
+++ b/src/pages/queue/api/queueApi.ts
@@ -74,6 +74,7 @@ export const seatEnterQueue = async (
   return response.data.data;
 };
 
+/** 대기열 이탈 — 결제 완료/명시적 종료 시 현재 수용 인원을 해제한다. */
 export const leaveQueue = async (gameId: string): Promise<QueueLeaveResponse> => {
   const response = await apiClient.post<ApiEnvelope<QueueLeaveResponse>>(
     `/api/v1/queue/${encodeURIComponent(gameId)}/leave`,

--- a/src/pages/queue/ui/QueuePage.tsx
+++ b/src/pages/queue/ui/QueuePage.tsx
@@ -150,7 +150,7 @@ const QueuePage = () => {
   const bookingFlowMode = getBookingFlowMode(location.search);
 
   const [phase, setPhase] = useState<QueuePhase>('entering');
-  const [queueToken, setQueueToken] = useState<string | null>(null);
+  const [queueToken, setQueueToken] = useState<string | null>(bookingEntryState?.queueTokenJti ?? null);
   const [queueNumber, setQueueNumber] = useState<number | null>(null);
   const [currentAllowedRank, setCurrentAllowedRank] = useState<number | null>(null);
   const [, setPublishedRank] = useState<number | null>(null);
@@ -188,6 +188,9 @@ const QueuePage = () => {
         if (cancelled) return;
         setQueueToken(res.queueToken);
         setQueueNumber(res.queueNumber);
+        patchEntry({
+          queueTokenJti: res.queueToken,
+        });
         setPhase('waiting');
       })
       .catch((err: unknown) => {
@@ -271,11 +274,18 @@ const QueuePage = () => {
           admittedRef.current = true;
           clearPendingLeave(gameId);
           clearQueuedEntryCache(gameId);
-          // 실제 queueToken을 bookingEntryState에 반영
-          patchEntry({ queueTokenJti: queueToken });
+          // queue 최종 입장 이후에는 예매 세션을 새로 열어 선행 API를 다시 호출한다.
+          const nextBookingEntryState = {
+            ...bookingEntryState,
+            queueTokenJti: queueToken,
+            forceNewSession: true,
+            bookingZones: undefined,
+          } satisfies BookingEntryState;
+
+          patchEntry(nextBookingEntryState);
           navigate(
             { pathname: '/books', search: createBookingFlowSearch(bookingFlowMode) },
-            { replace: true, state: { ...bookingEntryState, queueTokenJti: queueToken } },
+            { replace: true, state: nextBookingEntryState },
           );
         } else if (res.status === 'EXPIRED') {
           setErrorMessage('대기 시간이 만료되었습니다. 다시 시도해 주세요.');

--- a/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
+import { releaseQueueSession } from '@/pages/queue/api/queueApi';
 import {
    releaseResaleHold,
    releaseResaleHoldKeepalive,
@@ -16,6 +17,7 @@ import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 import { ApiError } from '@/shared/api/client';
 import { getErrorMessage } from '@/shared/lib/error/getErrorMessage';
+import { useBookingEntryStore } from '@/shared/lib/useBookingEntryStore';
 import BooksPurchaseLimitDialog from '@/shared/widgets/layout/books/BooksPurchaseLimitDialog';
 
 import { PaymentHeader } from './_shared';
@@ -129,16 +131,21 @@ export default function PaymentProcessingPage() {
       hasStartedRef.current = true;
 
       const { request: paymentRequest, amount: clientAmount } = locationState;
+      const bookingEntry = useBookingEntryStore.getState().entry;
       const isStillOnProcessingPage = () => window.location.pathname === '/tickets/payment/processing';
       const isResaleRequest = 'listingId' in paymentRequest;
 
-      const completePayment = (result: PaymentResponse) => {
+      const completePayment = async (result: PaymentResponse) => {
          if (!isMountedRef.current || !isStillOnProcessingPage()) {
             return;
          }
 
          hasCompletedRef.current = true;
          resaleHoldIdRef.current = null;
+
+         if (bookingEntry?.gameId) {
+            await releaseQueueSession(bookingEntry.gameId);
+         }
 
          try {
             savePaymentCompleteState({ ...result, amount: clientAmount });
@@ -206,7 +213,7 @@ export default function PaymentProcessingPage() {
                hasSuccessfulTicketPaymentRef.current = true;
             }
 
-            completePayment(result);
+            await completePayment(result);
          } catch (error) {
             if (isMountedRef.current && isStillOnProcessingPage()) {
                if (!isResaleRequest) {

--- a/src/shared/lib/useBookingEntryStore.ts
+++ b/src/shared/lib/useBookingEntryStore.ts
@@ -25,7 +25,9 @@ export type BookingEntryState = {
 };
 
 type BookingEntryStore = {
+   hasHydrated: boolean;
    entry: BookingEntryState | null;
+   setHasHydrated: (hasHydrated: boolean) => void;
    setEntry: (nextEntry: BookingEntryState) => void;
    patchEntry: (partialEntry: Partial<BookingEntryState>) => void;
    clearEntry: () => void;
@@ -34,7 +36,9 @@ type BookingEntryStore = {
 export const useBookingEntryStore = create<BookingEntryStore>()(
    persist(
       (set) => ({
+         hasHydrated: false,
          entry: null,
+         setHasHydrated: hasHydrated => set({ hasHydrated }),
 
          setEntry: (nextEntry) => set({ entry: nextEntry }),
 
@@ -51,6 +55,9 @@ export const useBookingEntryStore = create<BookingEntryStore>()(
          partialize: (state) => ({
             entry: state.entry,
          }),
+         onRehydrateStorage: () => state => {
+            state?.setHasHydrated(true);
+         },
       },
    ),
 );


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #306

<br/>

## 🔎 개요
대기열 이후 예매 플로우가 api 통신하지 않는 버그 수정 및 예매 플로우에 해당되는 화면에서 새로고침 시 대기열 재진입 로직 추가

<br/>

## 📋 작업 내용
- 대기열 이후 예매 플로우가 api 통신하지 않는 버그 수정
- 예매 플로우에 해당되는 화면에서 새로고침 시 대기열 재진입 로직 추가

<br/>
