### PR TITLE
 [bug] 예매 플로우 상태 병합 및 구역 조회 보완

### DIFF
--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -13,8 +13,8 @@ import type { DaySchedule, GameRow, GameStatus, ReselStatus, TicketStatus } from
 
 export type NormalizedScheduleGame = {
   id: string;
-  serverHomeTeamId: string;
-  serverAwayTeamId: string;
+  serverHomeTeamId?: string;
+  serverAwayTeamId?: string;
   leagueType: ApiLeagueType;
   homeTeamId?: string;
   awayTeamId?: string;
@@ -197,8 +197,8 @@ const mergeScheduleWithTeamDetails = (game: GameScheduleResponse, teamDetails: M
   teamName: string;
   homeGround?: string;
 }>) => {
-  const homeTeamDetail = teamDetails.get(game.homeTeamId);
-  const awayTeamDetail = teamDetails.get(game.awayTeamId);
+  const homeTeamDetail = game.homeTeamId ? teamDetails.get(game.homeTeamId) : undefined;
+  const awayTeamDetail = game.awayTeamId ? teamDetails.get(game.awayTeamId) : undefined;
 
   return {
     ...game,

--- a/src/pages/books/model/useBookingZones.ts
+++ b/src/pages/books/model/useBookingZones.ts
@@ -47,9 +47,7 @@ export function useBookingZones({
 }: UseBookingZonesParams): UseBookingZonesResult {
    const shouldForceNewSessionRef = useRef(Boolean(bookingEntryState?.forceNewSession));
    const isEnabled = Boolean(
-      bookingEntryState?.stadiumId &&
-         bookingEntryState?.gameId &&
-         bookingEntryState?.serverHomeTeamId &&
+      bookingEntryState?.gameId &&
          bookingEntryState?.leagueType &&
          bookingEntryState?.gameDate,
    );
@@ -93,21 +91,32 @@ export function useBookingZones({
             gameId: bookingEntryState!.gameId!,
             forceNewSession: shouldForceNewSession,
          });
+         const resolvedStadiumId = bookingEntryState?.stadiumId ?? grades.find((grade) => grade.stadiumId)?.stadiumId;
 
          const [sections, pricingPolicy] = await Promise.all([
-            fetchSeatSections({
-               stadiumId: bookingEntryState!.stadiumId!,
-               gameId: bookingEntryState!.gameId!,
-            }),
-            fetchTicketPricingPolicy(bookingEntryState!.serverHomeTeamId!).catch(() => undefined),
+            resolvedStadiumId
+               ? fetchSeatSections({
+                    stadiumId: resolvedStadiumId,
+                    gameId: bookingEntryState!.gameId!,
+                 })
+               : Promise.resolve([]),
+            bookingEntryState?.serverHomeTeamId
+               ? fetchTicketPricingPolicy(bookingEntryState.serverHomeTeamId).catch(() => undefined)
+               : Promise.resolve(undefined),
          ]);
 
-         if (shouldForceNewSession) {
-            shouldForceNewSessionRef.current = false;
-            logBookingFlow('useBookingZones', 'clear forceNewSession after query');
-            patchBookingEntry({
-               forceNewSession: false,
-            });
+         if (shouldForceNewSession || resolvedStadiumId !== bookingEntryState?.stadiumId) {
+            const nextEntryPatch = {
+               forceNewSession: shouldForceNewSession ? false : bookingEntryState?.forceNewSession,
+               stadiumId: resolvedStadiumId,
+            } satisfies Partial<BookingEntryState>;
+
+            if (shouldForceNewSession) {
+               shouldForceNewSessionRef.current = false;
+               logBookingFlow('useBookingZones', 'clear forceNewSession after query');
+            }
+
+            patchBookingEntry(nextEntryPatch);
          }
 
          const pricingByGradeId = resolvePricingByGradeId({

--- a/src/pages/books/model/useBooksPageEntry.ts
+++ b/src/pages/books/model/useBooksPageEntry.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { logBookingFlow, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
-import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
+import { mergeBookingEntryState, useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 
 type UseBooksPageEntryResult = {
    bookingEntryState: BookingEntryState | null;
@@ -17,7 +17,7 @@ export function useBooksPageEntry(): UseBooksPageEntryResult {
    const setBookingEntry = useBookingEntryStore(state => state.setEntry);
    const patchBookingEntry = useBookingEntryStore(state => state.patchEntry);
    const clearBookingEntry = useBookingEntryStore(state => state.clearEntry);
-   const bookingEntryState = routeBookingEntryState ?? storedBookingEntryState;
+   const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
 
    useEffect(() => {
       logBookingFlow('useBooksPageEntry', 'resolved bookingEntryState', {

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -219,12 +219,17 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
          }
 
          if (!isAggregatedSectionCode(zone.sectionCode)) {
-            const resolvedSection =
-               (await resolveSeatSectionByCode({
-                  stadiumId,
-                  gameId,
-                  sectionCode: zone.sectionCode,
-               }));
+            const resolvedSectionId = zone.sectionIds?.[0];
+            const resolvedSection = resolvedSectionId
+               ? {
+                    sectionId: resolvedSectionId,
+                    sectionCode: zone.sectionCode,
+                 }
+               : await resolveSeatSectionByCode({
+                    stadiumId,
+                    gameId,
+                    sectionCode: zone.sectionCode,
+                 });
 
             if (!resolvedSection) {
                throw new Error(DEFAULT_SEAT_MAP_ERROR_MESSAGE);
@@ -235,7 +240,7 @@ export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) =
                statuses,
             });
 
-           const [seatBlock] = buildSeatBlockFromApiSeats(zone.sectionCode, seats);
+            const [seatBlock] = buildSeatBlockFromApiSeats(zone.sectionCode, seats);
 
             if (!seatBlock) {
                throw new Error(DEFAULT_SEAT_MAP_ERROR_MESSAGE);

--- a/src/pages/books/model/useSeatsPageEntry.ts
+++ b/src/pages/books/model/useSeatsPageEntry.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { getBookingFlowMode } from '@/shared/lib/booking-flow';
-import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
+import { mergeBookingEntryState, useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import { getBookingZones, getStadiumName, getZoneOverviewImage } from './zoneData';
 
 export function useSeatsPageEntry(zoneId: string) {
@@ -12,7 +12,7 @@ export function useSeatsPageEntry(zoneId: string) {
    const routeBookingEntryState = location.state as BookingEntryState | null;
    const storedBookingEntryState = useBookingEntryStore(state => state.entry);
    const setBookingEntry = useBookingEntryStore(state => state.setEntry);
-   const bookingEntryState = routeBookingEntryState ?? storedBookingEntryState;
+   const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
 
    useEffect(() => {
       if (routeBookingEntryState) {

--- a/src/pages/queue/ui/QueuePage.tsx
+++ b/src/pages/queue/ui/QueuePage.tsx
@@ -3,7 +3,7 @@ import Lottie from 'lottie-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { createBookingFlowSearch, getBookingFlowMode } from '@/shared/lib/booking-flow';
 import { logBookingFlow, logBookingFlowError, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
-import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
+import { mergeBookingEntryState, useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import apiClient from '@/shared/api/client';
 import {
   enterQueue,
@@ -147,7 +147,7 @@ const QueuePage = () => {
   const storedBookingEntryState = useBookingEntryStore(state => state.entry);
   const setBookingEntry = useBookingEntryStore(state => state.setEntry);
   const patchEntry = useBookingEntryStore(state => state.patchEntry);
-  const bookingEntryState = routeBookingEntryState ?? storedBookingEntryState;
+  const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
   const bookingFlowMode = getBookingFlowMode(location.search);
 
   const [phase, setPhase] = useState<QueuePhase>('entering');

--- a/src/pages/tickets/ui/payment/TicketPaymentPage.tsx
+++ b/src/pages/tickets/ui/payment/TicketPaymentPage.tsx
@@ -11,7 +11,7 @@ import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSe
 import { getBookingTeamConfig, getBookingZones } from '@/pages/books/model/zoneData';
 import { Button } from '@/shared/ui/button';
 import { logBookingFlow, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
-import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
+import { mergeBookingEntryState, useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import BooksPurchaseLimitDialog from '@/shared/widgets/layout/books/BooksPurchaseLimitDialog';
 import type { TicketCheckoutRequest } from '@/pages/tickets/api/paymentApi';
 import {
@@ -55,7 +55,7 @@ export default function TicketPaymentPage() {
    const locationState = location.state as BookingEntryState | null;
    const routeBookingEntryState = locationState;
    const storedBookingEntryState = useBookingEntryStore(state => state.entry);
-   const bookingEntryState = routeBookingEntryState ?? storedBookingEntryState;
+   const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
    const setBookingEntry = useBookingEntryStore(state => state.setEntry);
    const zonesState = useSeatSelectionStore(state => state.zones);
    const holdsBySeatId = useSeatHoldStore(state => state.holdsBySeatId);

--- a/src/shared/lib/useBookingEntryStore.ts
+++ b/src/shared/lib/useBookingEntryStore.ts
@@ -25,6 +25,28 @@ export type BookingEntryState = {
    botData?: BotReport;
 };
 
+export const mergeBookingEntryState = (
+   routeEntry: BookingEntryState | null | undefined,
+   storedEntry: BookingEntryState | null | undefined,
+): BookingEntryState | null => {
+   if (!routeEntry) {
+      return storedEntry ?? null;
+   }
+
+   if (!storedEntry) {
+      return routeEntry;
+   }
+
+   if (routeEntry.gameId && storedEntry.gameId && routeEntry.gameId !== storedEntry.gameId) {
+      return routeEntry;
+   }
+
+   return {
+      ...routeEntry,
+      ...storedEntry,
+   };
+};
+
 type BookingEntryStore = {
    hasHydrated: boolean;
    entry: BookingEntryState | null;

--- a/src/shared/types/game.ts
+++ b/src/shared/types/game.ts
@@ -32,9 +32,9 @@ export interface GameScheduleResponse {
    gameId: string;
    startAt: string;
    leagueType: ApiLeagueType;
-   homeTeamId: string;
-   awayTeamId: string;
-   stadiumId: string;
+   homeTeamId?: string;
+   awayTeamId?: string;
+   stadiumId?: string;
    gameStatus: ApiGameStatus;
    homeTeamScore: number;
    awayTeamScore: number;

--- a/src/shared/widgets/layout/books/BooksHeader.tsx
+++ b/src/shared/widgets/layout/books/BooksHeader.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { getBookingTeamConfig, getBookingTeamId } from '@/pages/books/model/zoneData';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 import { formatBookingHeaderDateTime } from '@/shared/lib/bookingDateTime';
-import { useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
+import { mergeBookingEntryState, useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import { DEFAULT_BOOKING_TIMER_SECONDS, useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
 import { mockGameSchedules } from '@/shared/api/mocks/handlers/game';
 import { teams } from '@/entities/team/model/teams';
@@ -136,7 +136,7 @@ const BooksHeader = ({
    const { pathname, state } = useLocation();
    const routeBookingEntryState = state as BookingEntryState | null;
    const storedBookingEntryState = useBookingEntryStore((store) => store.entry);
-   const bookingEntryState = routeBookingEntryState ?? storedBookingEntryState;
+   const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
    const clearBookingEntry = useBookingEntryStore((store) => store.clearEntry);
    const bookingTeamConfig = getBookingTeamConfig(bookingEntryState?.homeTeamId);
    const bookingEntryGameFallback = resolveBookingEntryGameFallback(bookingEntryState);


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #306

<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->

<br/>

## 🔎 개요
예매 진입 상태와 저장된 상태를 병합해 대기열, 구역 선택, 좌석 선택, 결제 화면에서 컨텍스트가 유실되던 문제를 보완했습니다. 또한 경기 메타데이터 일부가 비어 있는 경우에도 예매 구역 조회와 좌석도 조회가 가능하도록 조회 로직을 보강했습니다
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>

## 📋 작업 내용
 - `mergeBookingEntryState`를 추가해 라우트 state와 스토어 state를 단순 대체하지 않고 병합하도록 변경
  - `QueuePage`, `useBooksPageEntry`, `useSeatsPageEntry`, `TicketPaymentPage`, `BooksHeader`에서 공통 병합 로직을 사용하도록 정리
  - 게임 메타데이터의 `homeTeamId`, `awayTeamId`, `stadiumId`, `serverHomeTeamId`, `serverAwayTeamId`를 선택값으로 처리해 불완전한 응답도 수용하도록 수정
  - 예매 구역 조회 시 `stadiumId`가 없으면 좌석 등급 응답에서 구장 정보를 보완해 `fetchSeatSections`에 사용하도록 변경
  - `serverHomeTeamId`가 없는 경우 가격 정책 조회를 안전하게 우회하도록 처리
  - 좌석도 조회 시 구역에 이미 `sectionIds`가 있으면 추가 섹션 코드 해석 없이 해당 값을 우선 사용하도록 수정
  - 포함 커밋
  - `3a7b6d9` `[bug]예매 진입 상태 병합 처리 보완`
  - `44dfb60` `[bug]예매 구역 조회 메타데이터 보완`
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

<br/>
