### PR TITLE
[bug] 새로고침 시 토큰 재발급 전에 queue api 요청 버그 수정

### DIFF
--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -320,6 +320,21 @@ const mapTicketStatus = (value: string): TicketStatus => {
   }
 };
 
+const closeTicketStatusForEmptyInventory = (
+  ticketStatus: TicketStatus,
+  remainingSeatCount?: number,
+): TicketStatus => {
+  if (ticketStatus !== '예매하기') {
+    return ticketStatus;
+  }
+
+  if (typeof remainingSeatCount === 'number' && remainingSeatCount <= 0) {
+    return '매진';
+  }
+
+  return ticketStatus;
+};
+
 const mapResellStatus = (ticketStatus: TicketStatus): ReselStatus => {
   switch (ticketStatus) {
     case '예매하기':
@@ -377,7 +392,10 @@ const normalizeScheduleGame = (game: GameScheduleResponse): NormalizedScheduleGa
   const gameDateTime = date && time ? new Date(`${date}T${time}`) : null;
   const status: GameStatus = (apiStatus !== '종료' && gameDateTime && gameDateTime < new Date()) ? '종료' : apiStatus;
 
-  const ticket = closeTicketStatusForUnavailableGame(mapTicketStatus(game.ticketingStatus), status);
+  const ticket = closeTicketStatusForUnavailableGame(
+    closeTicketStatusForEmptyInventory(mapTicketStatus(game.ticketingStatus), game.remainingSeatCount),
+    status,
+  );
   const fallbackHomeName = game.homeTeamDisplayName ?? game.homeTeamName ?? game.homeTeamCode ?? game.homeTeamId;
   const fallbackAwayName = game.awayTeamDisplayName ?? game.awayTeamName ?? game.awayTeamCode ?? game.awayTeamId;
 
@@ -442,6 +460,7 @@ export const mapGamesToDaySchedules = (games: NormalizedScheduleGame[]): DaySche
       resell: game.resell,
       ticketInfo: game.ticketInfo,
       reselInfo: game.reselInfo,
+      remainingSeatCount: game.remainingSeatCount,
     };
 
     const current = grouped.get(game.date);

--- a/src/pages/home/ui/FavoriteTeamMatchCard.tsx
+++ b/src/pages/home/ui/FavoriteTeamMatchCard.tsx
@@ -84,6 +84,7 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
    const homeTeamName = match.homeTeamFullName;
    const resaleCount = resaleCountsQuery.data?.get(match.id);
    const resaleStatus = resaleStatusesQuery.data?.get(match.id);
+   const canBook = match.ticket === '예매하기' && (match.remainingSeatCount === undefined || match.remainingSeatCount > 0);
    const canResellBook = resaleStatus === 'AVAILABLE' && typeof resaleCount === 'number' && resaleCount > 0;
    const resellButtonLabel =
       resaleStatus === 'SCHEDULED'
@@ -97,6 +98,10 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
                : '리셀매진';
 
    const handleBookingClick = () => {
+      if (!canBook) {
+         return;
+      }
+
       openBookingEntry({
          homeTeamId: match.homeTeamId,
          serverHomeTeamId: match.serverHomeTeamId,
@@ -188,6 +193,7 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
                <Button
                   variant="primary"
                   className="flex-1 max-w-[300px] h-[46px] text-[14px] font-bold rounded-[10px] tracking-[-0.15px]"
+                  disabled={!canBook}
                   onClick={handleBookingClick}
                >
                   예매하기
@@ -263,6 +269,7 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
                   <Button
                      variant="primary"
                      className="h-12 text-[16px] font-bold rounded-lg"
+                     disabled={!canBook}
                      onClick={handleBookingClick}
                   >
                      예매하기

--- a/src/pages/home/ui/game-schedule/ScheduleList.tsx
+++ b/src/pages/home/ui/game-schedule/ScheduleList.tsx
@@ -174,8 +174,9 @@ function ActionButtons({
    onOpenResellFlow: (game: GameRow) => void;
 }) {
    const { effectiveTicket, effectiveResell, ticketInfo, reselInfo } = getEffectiveSaleStatuses(game);
+   const hasRemainingSeats = game.remainingSeatCount === undefined || game.remainingSeatCount > 0;
 
-   const canBook = effectiveTicket === '예매하기';
+   const canBook = effectiveTicket === '예매하기' && hasRemainingSeats;
    const canResellBook = effectiveResell === '리셀예매';
    const isTicketScheduled = effectiveTicket === '판매예정';
    const isResellScheduled = effectiveResell === '리셀예정';

--- a/src/pages/home/ui/game-schedule/types.ts
+++ b/src/pages/home/ui/game-schedule/types.ts
@@ -13,6 +13,7 @@ export type GameRow = {
    rawDate?: string; // YYYY-MM-DD — 시간 기반 상태 전환용
    ticketingOpenedAt?: string;
    ticketingEndAt?: string;
+   remainingSeatCount?: number;
    time: string;
    venue: string;
    away: string;

--- a/src/pages/queue/api/queueApi.ts
+++ b/src/pages/queue/api/queueApi.ts
@@ -54,9 +54,11 @@ export const enterQueue = async (gameId: string): Promise<QueueEnterResponse> =>
 
 /** 대기열 전역 상태 조회 — CDN 1초 캐싱, 인증 불필요 */
 export const getQueueGlobalStatus = async (gameId: string): Promise<QueueStatusResponse> => {
+  logBookingFlow('queueApi', 'getQueueGlobalStatus request', { gameId });
   const response = await apiClient.get<ApiEnvelope<QueueStatusResponse>>(
     `/api/v1/queue/${encodeURIComponent(gameId)}/global-status`,
   );
+  logBookingFlow('queueApi', 'getQueueGlobalStatus response', response.data.data);
   return response.data.data;
 };
 

--- a/src/pages/queue/ui/QueuePage.tsx
+++ b/src/pages/queue/ui/QueuePage.tsx
@@ -5,9 +5,10 @@ import { createBookingFlowSearch, getBookingFlowMode } from '@/shared/lib/bookin
 import { logBookingFlow, logBookingFlowError, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
 import { mergeBookingEntryState, useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import apiClient from '@/shared/api/client';
+import { useAuthStore } from '@/entities/auth/model/authStore';
 import {
   enterQueue,
-  getQueueStatus,
+  getQueueGlobalStatus,
   leaveQueueKeepalive,
   type QueueEnterResponse,
   seatEnterQueue,
@@ -147,6 +148,8 @@ const QueuePage = () => {
   const storedBookingEntryState = useBookingEntryStore(state => state.entry);
   const setBookingEntry = useBookingEntryStore(state => state.setEntry);
   const patchEntry = useBookingEntryStore(state => state.patchEntry);
+  const hasHydrated = useAuthStore(state => state.hasHydrated);
+  const hasResolvedSession = useAuthStore(state => state.hasResolvedSession);
   const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
   const bookingFlowMode = getBookingFlowMode(location.search);
 
@@ -202,7 +205,7 @@ const QueuePage = () => {
 
   // 1단계: 대기열 진입
   useEffect(() => {
-    if (!gameId) return;
+    if (!gameId || !hasHydrated || !hasResolvedSession) return;
 
     let cancelled = false;
 
@@ -229,7 +232,7 @@ const QueuePage = () => {
     return () => {
       cancelled = true;
     };
-  }, [gameId]);
+  }, [gameId, hasHydrated, hasResolvedSession]);
 
   // 언마운트 시 대기열 이탈 (입장 허용 전에만)
   // cleanup에서는 apiClient 사용 (MSW 가로채기 가능)
@@ -265,7 +268,7 @@ const QueuePage = () => {
 
     const poll = async () => {
       try {
-        const status = await getQueueStatus(gameId);
+        const status = await getQueueGlobalStatus(gameId);
         logBookingFlow('QueuePage', 'poll status', status);
         setCurrentAllowedRank(status.currentAllowedRank);
         setPublishedRank(status.publishedRank);
@@ -289,7 +292,7 @@ const QueuePage = () => {
 
   // 3단계: 최종 입장 시도
   useEffect(() => {
-    if (phase !== 'checking' || !gameId || !queueToken) return;
+    if (phase !== 'checking' || !gameId || !queueToken || !hasHydrated || !hasResolvedSession) return;
     if (seatEnterInFlightRef.current) return;
 
     let cancelled = false;
@@ -346,7 +349,7 @@ const QueuePage = () => {
     return () => {
       cancelled = true;
     };
-  }, [phase, gameId, queueToken, patchEntry, navigate, bookingFlowMode, bookingEntryState]);
+  }, [phase, gameId, queueToken, patchEntry, navigate, bookingFlowMode, bookingEntryState, hasHydrated, hasResolvedSession]);
 
   // 표시할 대기 순서: 내 순번 - 현재 실제 허용 순번
   const displayRank = useMemo(() => {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #292

<br/>

## 🔎 개요
새로고침 시 토큰 재발급 전에 queue api 요청이 일어나 403 에러가 나는 버그 수정 및 잔여석 0석일 경우 매진 처리

<br/>

## 📋 작업 내용
- 새로고침 시 토큰 재발급 전에 queue api 요청이 일어나 403 에러가 나는 버그 수정
-  잔여석 0석일 경우 매진 처리
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

<br/>
