### PR TITLE
[bug] 인증 세션 초기화 및 일정 예매 상태 계산 보정

### DIFF
--- a/src/entities/auth/model/authStore.ts
+++ b/src/entities/auth/model/authStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import { resolveUserIdFromJwt } from '@/shared/lib/jwt';
+import { markAuthSessionResolved, resetAuthSessionBarrier } from '@/shared/lib/authSessionBarrier';
 
 export type LoginAlert =
    | { type: 'failed_under_5'; failCount: number; redirectPath: string }
@@ -100,7 +101,15 @@ export const useAuthStore = create<AuthState>()(
          loginTimedOut: false,
          loginAlert: null,
          setHasHydrated: hasHydrated => set({ hasHydrated }),
-         setHasResolvedSession: hasResolvedSession => set({ hasResolvedSession }),
+         setHasResolvedSession: hasResolvedSession => {
+            if (hasResolvedSession) {
+               markAuthSessionResolved();
+            } else {
+               resetAuthSessionBarrier();
+            }
+
+            set({ hasResolvedSession });
+         },
          setAccessToken: accessToken => {
             const nextAuthExpiresAt = getNextAuthExpiresAt(accessToken);
             const nextCurrentUserId = resolveUserIdFromJwt(accessToken);

--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -38,6 +38,9 @@ export type NormalizedScheduleGame = {
   isToday: boolean;
   ticketingOpenedAt?: string;
   ticketingEndAt?: string;
+  ticketingOpenedAtMs?: number;
+  ticketingEndAtMs?: number;
+  resellOpenedAtMs?: number;
   remainingSeatCount: number;
 };
 
@@ -260,6 +263,17 @@ const parseScheduleBoundary = (value?: string) => {
   return Number.isNaN(parsedDate.getTime()) ? null : parsedDate;
 };
 
+const toTimestamp = (value?: string) => parseScheduleBoundary(value)?.getTime();
+
+const getResellOpenTimestamp = (date?: string) => {
+  if (!date) {
+    return undefined;
+  }
+
+  const parsedDate = new Date(`${date}T13:00:00`);
+  return Number.isNaN(parsedDate.getTime()) ? undefined : parsedDate.getTime();
+};
+
 const formatOpenBoundaryLabel = (value?: string, fallbackDate?: string): string => {
   const parsedDate = parseScheduleBoundary(value);
 
@@ -392,6 +406,9 @@ const normalizeScheduleGame = (game: GameScheduleResponse): NormalizedScheduleGa
   const apiStatus = mapGameStatus(game.gameStatus);
   const gameDateTime = date && time ? new Date(`${date}T${time}`) : null;
   const status: GameStatus = (apiStatus !== '종료' && gameDateTime && gameDateTime < new Date()) ? '종료' : apiStatus;
+  const ticketingOpenedAtMs = toTimestamp(game.ticketingOpenedAt);
+  const ticketingEndAtMs = toTimestamp(game.ticketingEndAt);
+  const resellOpenedAtMs = getResellOpenTimestamp(date);
 
   const ticket = closeTicketStatusForUnavailableGame(
     closeTicketStatusForEmptyInventory(mapTicketStatus(game.ticketingStatus), game.remainingSeatCount),
@@ -426,6 +443,9 @@ const normalizeScheduleGame = (game: GameScheduleResponse): NormalizedScheduleGa
     isToday: isSameCalendarDate(date, new Date()),
     ticketingOpenedAt: game.ticketingOpenedAt,
     ticketingEndAt: game.ticketingEndAt,
+    ticketingOpenedAtMs,
+    ticketingEndAtMs,
+    resellOpenedAtMs,
     remainingSeatCount: game.remainingSeatCount,
   };
 };
@@ -451,6 +471,9 @@ export const mapGamesToDaySchedules = (games: NormalizedScheduleGame[]): DaySche
       rawDate: game.date,
       ticketingOpenedAt: game.ticketingOpenedAt,
       ticketingEndAt: game.ticketingEndAt,
+      ticketingOpenedAtMs: game.ticketingOpenedAtMs,
+      ticketingEndAtMs: game.ticketingEndAtMs,
+      resellOpenedAtMs: game.resellOpenedAtMs,
       time: game.time,
       venue: game.venue,
       away: game.awayTeamName,

--- a/src/entities/game/model/schedule.ts
+++ b/src/entities/game/model/schedule.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { buildMockQueueTokenJti } from '@/shared/config/booking';
 import type { ApiLeagueType } from '@/shared/types/game';
+import { hasAvailableSeats } from '@/entities/game/model/seatAvailability';
 import {
   fetchBaseballTeamDetails,
   fetchGameSchedules,
@@ -37,7 +38,7 @@ export type NormalizedScheduleGame = {
   isToday: boolean;
   ticketingOpenedAt?: string;
   ticketingEndAt?: string;
-  remainingSeatCount?: number;
+  remainingSeatCount: number;
 };
 
 type TeamReference = {
@@ -322,13 +323,13 @@ const mapTicketStatus = (value: string): TicketStatus => {
 
 const closeTicketStatusForEmptyInventory = (
   ticketStatus: TicketStatus,
-  remainingSeatCount?: number,
+  remainingSeatCount: number,
 ): TicketStatus => {
   if (ticketStatus !== '예매하기') {
     return ticketStatus;
   }
 
-  if (typeof remainingSeatCount === 'number' && remainingSeatCount <= 0) {
+  if (!hasAvailableSeats(remainingSeatCount)) {
     return '매진';
   }
 

--- a/src/entities/game/model/seatAvailability.ts
+++ b/src/entities/game/model/seatAvailability.ts
@@ -1,0 +1,3 @@
+export const hasAvailableSeats = (remainingSeatCount: number): boolean => {
+   return remainingSeatCount > 0;
+};

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -1,5 +1,6 @@
 import apiClient, { unwrapApiData } from "@/shared/api/client";
 import type { ApiEnvelope } from "./types";
+import { reissueAccessTokenFromCookie } from '@/shared/lib/reissueAccessToken';
 
 // 로그인 성공 후 서버에서 반환하는 계정 상태
 export type LoginAccountStatus =
@@ -81,15 +82,8 @@ export const sendSignupSmsCode = async (
 };
 
 export const reissueAccessToken = async (): Promise<ReissueAccessTokenResponse> => {
-  const response = await apiClient.post<ApiEnvelope<ReissueAccessTokenResponse>>(
-    "/api/v1/auth/reissue",
-    undefined,
-    {
-      withCredentials: true,
-    },
-  );
-
-  return unwrapApiData<ReissueAccessTokenResponse>(response.data);
+  const accessToken = await reissueAccessTokenFromCookie();
+  return { accessToken };
 };
 
 export const logout = async (): Promise<void> => {

--- a/src/pages/home/ui/FavoriteTeamMatchCard.tsx
+++ b/src/pages/home/ui/FavoriteTeamMatchCard.tsx
@@ -3,6 +3,7 @@
 import { Calendar, MapPin } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
+import { hasAvailableSeats } from '@/entities/game/model/seatAvailability';
 import { teams } from '@/entities/team/model/teams';
 import type { Team } from '@/entities/team/model/types';
 import { getClosestMatch, getDDay, useGameSchedules } from '@/entities/game/model/schedule';
@@ -84,7 +85,7 @@ const FavoriteTeamMatchCard = ({ team }: { team: Team }) => {
    const homeTeamName = match.homeTeamFullName;
    const resaleCount = resaleCountsQuery.data?.get(match.id);
    const resaleStatus = resaleStatusesQuery.data?.get(match.id);
-   const canBook = match.ticket === '예매하기' && (match.remainingSeatCount === undefined || match.remainingSeatCount > 0);
+   const canBook = match.ticket === '예매하기' && hasAvailableSeats(match.remainingSeatCount);
    const canResellBook = resaleStatus === 'AVAILABLE' && typeof resaleCount === 'number' && resaleCount > 0;
    const resellButtonLabel =
       resaleStatus === 'SCHEDULED'

--- a/src/pages/home/ui/game-schedule/ScheduleList.tsx
+++ b/src/pages/home/ui/game-schedule/ScheduleList.tsx
@@ -1,5 +1,6 @@
 import { TicketX } from 'lucide-react';
 
+import { hasAvailableSeats } from '@/entities/game/model/seatAvailability';
 import { useBookingEntryFlow } from '@/shared/lib/use-booking-entry-flow';
 import { cn } from '@/shared/lib/utils';
 import { Badge } from '@/shared/ui/badge';
@@ -174,7 +175,7 @@ function ActionButtons({
    onOpenResellFlow: (game: GameRow) => void;
 }) {
    const { effectiveTicket, effectiveResell, ticketInfo, reselInfo } = getEffectiveSaleStatuses(game);
-   const hasRemainingSeats = game.remainingSeatCount === undefined || game.remainingSeatCount > 0;
+   const hasRemainingSeats = hasAvailableSeats(game.remainingSeatCount);
 
    const canBook = effectiveTicket === '예매하기' && hasRemainingSeats;
    const canResellBook = effectiveResell === '리셀예매';

--- a/src/pages/home/ui/game-schedule/types.ts
+++ b/src/pages/home/ui/game-schedule/types.ts
@@ -13,7 +13,7 @@ export type GameRow = {
    rawDate?: string; // YYYY-MM-DD — 시간 기반 상태 전환용
    ticketingOpenedAt?: string;
    ticketingEndAt?: string;
-   remainingSeatCount?: number;
+   remainingSeatCount: number;
    time: string;
    venue: string;
    away: string;

--- a/src/pages/home/ui/game-schedule/types.ts
+++ b/src/pages/home/ui/game-schedule/types.ts
@@ -13,6 +13,9 @@ export type GameRow = {
    rawDate?: string; // YYYY-MM-DD — 시간 기반 상태 전환용
    ticketingOpenedAt?: string;
    ticketingEndAt?: string;
+   ticketingOpenedAtMs?: number;
+   ticketingEndAtMs?: number;
+   resellOpenedAtMs?: number;
    remainingSeatCount: number;
    time: string;
    venue: string;

--- a/src/pages/home/ui/game-schedule/utils.ts
+++ b/src/pages/home/ui/game-schedule/utils.ts
@@ -112,13 +112,15 @@ type EffectiveSaleStatus = {
 };
 
 export const getEffectiveSaleStatuses = (game: GameRow, now = new Date()): EffectiveSaleStatus => {
-   const saleOpenTime = parseScheduleDateTime(game.ticketingOpenedAt);
-   const saleEndTime = parseScheduleDateTime(game.ticketingEndAt);
-   const resellOpenTime = game.rawDate ? new Date(`${game.rawDate}T13:00:00`) : null;
-   const saleBeforeOpen = saleOpenTime !== null && now < saleOpenTime;
-   const saleClosed = saleEndTime !== null && now > saleEndTime;
-   const saleWithinWindow = (saleOpenTime === null || now >= saleOpenTime) && (saleEndTime === null || now <= saleEndTime);
-   const resellNowOpen = resellOpenTime !== null && now >= resellOpenTime;
+   const nowMs = now.getTime();
+   const saleOpenTimeMs = game.ticketingOpenedAtMs;
+   const saleEndTimeMs = game.ticketingEndAtMs;
+   const resellOpenTimeMs = game.resellOpenedAtMs;
+   const saleBeforeOpen = saleOpenTimeMs !== undefined && nowMs < saleOpenTimeMs;
+   const saleClosed = saleEndTimeMs !== undefined && nowMs > saleEndTimeMs;
+   const saleWithinWindow =
+      (saleOpenTimeMs === undefined || nowMs >= saleOpenTimeMs) && (saleEndTimeMs === undefined || nowMs <= saleEndTimeMs);
+   const resellNowOpen = resellOpenTimeMs !== undefined && nowMs >= resellOpenTimeMs;
 
    const effectiveTicket: TicketStatus = (() => {
       if (game.ticket === '매진') {
@@ -137,7 +139,7 @@ export const getEffectiveSaleStatuses = (game: GameRow, now = new Date()): Effec
          return '예매하기';
       }
 
-      if (saleOpenTime !== null && now >= saleOpenTime) {
+      if (saleOpenTimeMs !== undefined && nowMs >= saleOpenTimeMs) {
          return '매진';
       }
 

--- a/src/pages/queue/ui/QueuePage.tsx
+++ b/src/pages/queue/ui/QueuePage.tsx
@@ -150,7 +150,10 @@ const QueuePage = () => {
   const patchEntry = useBookingEntryStore(state => state.patchEntry);
   const hasHydrated = useAuthStore(state => state.hasHydrated);
   const hasResolvedSession = useAuthStore(state => state.hasResolvedSession);
-  const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
+  const bookingEntryState = useMemo(
+    () => mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState),
+    [routeBookingEntryState, storedBookingEntryState],
+  );
   const bookingFlowMode = getBookingFlowMode(location.search);
 
   const [phase, setPhase] = useState<QueuePhase>('entering');

--- a/src/pages/teams/api/useGameSchedules.ts
+++ b/src/pages/teams/api/useGameSchedules.ts
@@ -85,6 +85,7 @@ function transformSchedules(raw: GameScheduleResponse[]): DaySchedule[] {
       const venue = homeTeam?.stadiumName ?? '-';
 
       const gameRow: GameRow = {
+         remainingSeatCount: game.remainingSeatCount,
          time: `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`,
          venue,
          away: awayName,

--- a/src/pages/tickets/ui/TicketsPage.tsx
+++ b/src/pages/tickets/ui/TicketsPage.tsx
@@ -103,7 +103,7 @@ const TicketsPage = () => {
                      ? 25000
                      : game.ticket === '매진'
                        ? 0
-                       : (game.remainingSeatCount ?? 0),
+                       : game.remainingSeatCount,
                resellRemainingSeats: fallbackResellStatus === '리셀 가능' ? 999 : 0,
                minPrice: 0,
                maxPrice: 0,

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -3,6 +3,7 @@ import { useAuthStore } from "@/entities/auth/model/authStore";
 import { redirectToErrorPage } from '@/shared/lib/error-navigation';
 import { applyGuardrailHeadersToAxiosConfig } from '@/shared/lib/guardrailHeaders';
 import { waitForAuthSessionResolution } from '@/shared/lib/authSessionBarrier';
+import { reissueAccessTokenFromCookie } from '@/shared/lib/reissueAccessToken';
 import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
 
 export class ApiError extends Error {
@@ -221,54 +222,6 @@ const apiClient = axios.create({
     "Content-Type": "application/json",
   },
 });
-
-let refreshAccessTokenPromise: Promise<string> | null = null;
-
-const reissueAccessTokenFromCookie = async () => {
-  if (useAuthStore.getState().isManualLogout) {
-    throw new ApiError("수동 로그아웃 상태에서는 토큰을 재발급하지 않습니다.", 401);
-  }
-
-  if (!refreshAccessTokenPromise) {
-    refreshAccessTokenPromise = axios
-      .post(
-        tokenReissuePath,
-        undefined,
-        {
-          baseURL: shouldUseRelativeApiBase ? "" : configuredApiBaseUrl,
-          headers: {
-            "Content-Type": "application/json",
-          },
-          withCredentials: true,
-        },
-      )
-      .then((response) => {
-        const data = unwrapApiData<{ accessToken: string }>(response.data);
-
-        if (!data.accessToken) {
-          throw new ApiError("토큰 재발급 응답에 accessToken이 없습니다.", response.status, response.data);
-        }
-
-        if (useAuthStore.getState().isManualLogout) {
-          throw new ApiError("로그아웃 이후 도착한 토큰 재발급 응답은 무시합니다.", 401, response.data);
-        }
-
-        useAuthStore.getState().setAccessToken(data.accessToken);
-        return data.accessToken;
-      })
-      .catch((error: unknown) => {
-        if (!useAuthStore.getState().isManualLogout) {
-          useAuthStore.getState().clearAuth("expired");
-        }
-        throw error;
-      })
-      .finally(() => {
-        refreshAccessTokenPromise = null;
-      });
-  }
-
-  return refreshAccessTokenPromise;
-};
 
 apiClient.interceptors.request.use(async (config) => {
   if (shouldWaitForInitialSessionResolution(config)) {

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -26,6 +26,8 @@ const authorizationOptionalApiPaths = new Set([
 ]);
 const shouldKeepSessionAlivePathPrefixes = ["/books", "/tickets"];
 const PUBLIC_API_PATH_PATTERNS = [
+  /^\/api\/v1\/games(?:\/|$)/,
+  /^\/api\/v1\/baseball-teams(?:\/|$)/,
   /^\/api\/v1\/queue(?:\/|$)/,
   /^\/api\/v1\/seat-reservations(?:\/|$)/,
   // 예매/리셀 플로우 API는 queue token / hold 기반으로 동작하므로
@@ -150,6 +152,10 @@ const shouldWaitForInitialSessionResolution = (config: AxiosRequestConfig) => {
   }
 
   if (useAuthStore.getState().hasResolvedSession) {
+    return false;
+  }
+
+  if (shouldSkipAuthorizationHeader(config) || shouldSkipCredentials(config)) {
     return false;
   }
 

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -2,6 +2,7 @@ import axios, { AxiosError, AxiosHeaders, type AxiosRequestConfig } from "axios"
 import { useAuthStore } from "@/entities/auth/model/authStore";
 import { redirectToErrorPage } from '@/shared/lib/error-navigation';
 import { applyGuardrailHeadersToAxiosConfig } from '@/shared/lib/guardrailHeaders';
+import { waitForAuthSessionResolution } from '@/shared/lib/authSessionBarrier';
 import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
 
 export class ApiError extends Error {
@@ -143,6 +144,25 @@ const shouldSkipAuthorizationHeader = (config: AxiosRequestConfig) => {
   }
 };
 
+const shouldWaitForInitialSessionResolution = (config: AxiosRequestConfig) => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  if (useAuthStore.getState().hasResolvedSession) {
+    return false;
+  }
+
+  const requestUrl = toAbsoluteUrl(config);
+
+  try {
+    const { pathname } = new URL(requestUrl, window.location.origin);
+    return pathname !== tokenReissuePath;
+  } catch {
+    return true;
+  }
+};
+
 const shouldSkipCredentials = (config: AxiosRequestConfig) => {
   const requestUrl = toAbsoluteUrl(config);
 
@@ -244,7 +264,11 @@ const reissueAccessTokenFromCookie = async () => {
   return refreshAccessTokenPromise;
 };
 
-apiClient.interceptors.request.use((config) => {
+apiClient.interceptors.request.use(async (config) => {
+  if (shouldWaitForInitialSessionResolution(config)) {
+    await waitForAuthSessionResolution();
+  }
+
   const accessToken = useAuthStore.getState().accessToken;
   const shouldSkipAuth = shouldSkipAuthorizationHeader(config);
   const shouldOmitCredentials = shouldSkipCredentials(config);

--- a/src/shared/lib/authSessionBarrier.ts
+++ b/src/shared/lib/authSessionBarrier.ts
@@ -1,0 +1,23 @@
+let resolveSessionBarrier: (() => void) | null = null;
+
+const createSessionBarrier = () =>
+  new Promise<void>((resolve) => {
+    resolveSessionBarrier = resolve;
+  });
+
+let sessionBarrierPromise = createSessionBarrier();
+
+export const waitForAuthSessionResolution = () => sessionBarrierPromise;
+
+export const markAuthSessionResolved = () => {
+  resolveSessionBarrier?.();
+  resolveSessionBarrier = null;
+};
+
+export const resetAuthSessionBarrier = () => {
+  if (resolveSessionBarrier !== null) {
+    return;
+  }
+
+  sessionBarrierPromise = createSessionBarrier();
+};

--- a/src/shared/lib/reissueAccessToken.ts
+++ b/src/shared/lib/reissueAccessToken.ts
@@ -1,0 +1,55 @@
+import axios from 'axios';
+import { useAuthStore } from '@/entities/auth/model/authStore';
+import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
+import { ApiError, unwrapApiData } from '@/shared/api/client';
+
+const tokenReissuePath = '/api/v1/auth/reissue';
+
+let reissueAccessTokenPromise: Promise<string> | null = null;
+
+export const reissueAccessTokenFromCookie = async (): Promise<string> => {
+  if (useAuthStore.getState().isManualLogout) {
+    throw new ApiError('수동 로그아웃 상태에서는 토큰을 재발급하지 않습니다.', 401);
+  }
+
+  if (!reissueAccessTokenPromise) {
+    reissueAccessTokenPromise = axios
+      .post(
+        tokenReissuePath,
+        undefined,
+        {
+          baseURL: shouldUseRelativeApiBase ? '' : configuredApiBaseUrl,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          withCredentials: true,
+        },
+      )
+      .then((response) => {
+        const data = unwrapApiData<{ accessToken: string }>(response.data);
+
+        if (!data.accessToken) {
+          throw new ApiError('토큰 재발급 응답에 accessToken이 없습니다.', response.status, response.data);
+        }
+
+        if (useAuthStore.getState().isManualLogout) {
+          throw new ApiError('로그아웃 이후 도착한 토큰 재발급 응답은 무시합니다.', 401, response.data);
+        }
+
+        useAuthStore.getState().setAccessToken(data.accessToken);
+        return data.accessToken;
+      })
+      .catch((error: unknown) => {
+        if (!useAuthStore.getState().isManualLogout) {
+          useAuthStore.getState().clearAuth('expired');
+        }
+
+        throw error;
+      })
+      .finally(() => {
+        reissueAccessTokenPromise = null;
+      });
+  }
+
+  return reissueAccessTokenPromise;
+};

--- a/src/shared/types/game.ts
+++ b/src/shared/types/game.ts
@@ -42,7 +42,7 @@ export interface GameScheduleResponse {
    ticketingStatus: ApiTicketingStatus;
    ticketingOpenedAt?: string;
    ticketingEndAt?: string;
-   remainingSeatCount?: number;
+   remainingSeatCount: number;
    homeTeamDisplayName?: string;
    awayTeamDisplayName?: string;
    stadiumLocation?: string;


### PR DESCRIPTION
## #️⃣ 관련 이슈

  - #327

  <br/>

  ## 🔎 개요

  인증 세션 복원 및 액세스 토큰 재발급 흐름을 정리해 초기 요청 경쟁 상태를 줄이고, 경기 일정의 예매/매진 상태 계산 로직을 보정했습니다.

  <br/>

  ## 📋 작업 내용

  - 초기 세션 복원 전 인증이 필요한 요청은 대기하도록 `authSessionBarrier`를 추가했습니다.
  - 액세스 토큰 재발급 로직을 `reissueAccessTokenFromCookie`로 분리하고, 중복 재발급 호출이 발생하지 않도록 단일 Promise로 관리했습니다.
  - 공개 일정/구단 조회 API는 초기 세션 대기 대상에서 제외해 비로그인 상태 첫 화면 진입 지연을 줄였습니다.
  - 인증 스토어에서 세션 해제/복원 시 barrier 상태가 함께 갱신되도록 연동했습니다.
  - 경기 일정 모델에 예매 시작/종료 시각과 리셀 오픈 시각의 timestamp 필드를 추가해 상태 계산 비용을 줄였습니다.
  - `remainingSeatCount`를 필수값으로 통일하고, 잔여석 여부 판단 로직을 `hasAvailableSeats`로 공통화했습니다.
  - 홈 일정 카드, 일정 리스트, 티켓 페이지에서 잔여석 기준 예매 가능/매진 상태가 일관되게 반영되도록 수정했습니다.
  - `QueuePage`의 booking entry state 병합 결과를 `useMemo`로 감싸 불필요한 재계산을 줄였습니다.