### PR TITLE
[feat] 리셀 예매 전용 플로우 및 mock 결제 흐름 연결

### DIFF
--- a/src/app/providers/router/ui/AppRouter.tsx
+++ b/src/app/providers/router/ui/AppRouter.tsx
@@ -29,6 +29,8 @@ import PaymentProcessingPage from '@/pages/tickets/ui/payment/PaymentProcessingP
 import PaymentCompletePage from '@/pages/tickets/ui/payment/PaymentCompletePage';
 import BooksPage from '@/pages/books';
 import SeatsPage from '@/pages/books/ui/SeatsPage';
+import ResellBooksPage from '@/pages/resell-books';
+import ResellSeatsPage from '@/pages/resell-books/ui/ResellSeatsPage';
 import SeatHoldLifecycleController from '@/features/seat-booking/ui/SeatHoldLifecycleController';
 import {
    MypagePage,
@@ -84,6 +86,10 @@ const AppRouter = () => {
             <Route path="/books" element={<BooksLayout />}>
                <Route index element={<BooksPage />} />
                <Route path="seats/:zoneId" element={<SeatsPage />} />
+            </Route>
+            <Route path="/resell-books" element={<BooksLayout />}>
+               <Route index element={<ResellBooksPage />} />
+               <Route path="seats/:zoneId" element={<ResellSeatsPage />} />
             </Route>
             <Route path="/button" element={<ButtonPage />} />
             <Route path="/control" element={<ControlPage />} />

--- a/src/app/providers/router/ui/AuthSessionController.tsx
+++ b/src/app/providers/router/ui/AuthSessionController.tsx
@@ -5,7 +5,7 @@ import { reissueAccessToken } from '@/features/auth/api/authApi';
 import SessionWarningDialog from '@/shared/widgets/layout/auth/SessionWarningDialog';
 
 const shouldKeepSessionAlivePath = (pathname: string) =>
-   pathname.startsWith('/books') || pathname.startsWith('/tickets');
+   pathname.startsWith('/books') || pathname.startsWith('/resell-books') || pathname.startsWith('/tickets');
 
 const shouldAttemptInitialSessionResolve = (pathname: string) => {
    if (pathname === '/session-expired') {

--- a/src/app/providers/router/ui/BookingFlowStateGuard.tsx
+++ b/src/app/providers/router/ui/BookingFlowStateGuard.tsx
@@ -8,8 +8,9 @@ import { useBookingEntryStore } from '@/shared/lib/useBookingEntryStore';
 import { useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
 
 const isBookingFlowPath = (pathname: string) =>
-   pathname.startsWith('/queue') || pathname.startsWith('/books') || pathname.startsWith('/tickets');
-const isBookSelectionPath = (pathname: string) => pathname.startsWith('/books');
+   pathname.startsWith('/queue') || pathname.startsWith('/books') || pathname.startsWith('/resell-books') || pathname.startsWith('/tickets');
+const isBookSelectionPath = (pathname: string) =>
+   pathname.startsWith('/books') || pathname.startsWith('/resell-books');
 const isTicketCheckoutPath = (pathname: string) =>
    pathname === '/tickets/payment' ||
    pathname === '/tickets/resell-payment' ||
@@ -75,7 +76,7 @@ const BookingFlowStateGuard = () => {
          useSeatHoldStore.getState().clearSeatHolds();
          useSeatSelectionStore.getState().clearAllSelections();
          useBookingFlowTimerStore.getState().clearTimer();
-         navigate({ pathname: '/queue', search }, { replace: true, state: bookingEntry });
+         navigate({ pathname: '/queue' }, { replace: true, state: bookingEntry });
          return;
       }
 

--- a/src/entities/resale/api/resaleApi.ts
+++ b/src/entities/resale/api/resaleApi.ts
@@ -4,7 +4,18 @@ import apiClient from '@/shared/api/client';
 import type { ApiEnvelope } from '@/features/auth/api/types';
 import { createBookingFlowHeaders } from '@/shared/lib/guardrailHeaders';
 import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
-const FORCE_RESALE_SOLD_OUT_MOCK = true;
+import { isResaleDemoEnabled } from '@/shared/config/runtime';
+import {
+   createDemoResaleHold,
+   getDemoResaleCountByGame,
+   getDemoResaleCountsByGrades,
+   getDemoResaleHistory,
+   getDemoResaleListings,
+   getDemoResaleStatusByGame,
+   releaseDemoResaleHold,
+   releaseDemoResaleHoldSync,
+} from '@/shared/lib/demo/resaleDemo';
+const FORCE_RESALE_SOLD_OUT_MOCK = !isResaleDemoEnabled;
 
 export interface ResaleListingItem {
    listingId: string;
@@ -54,11 +65,19 @@ const getResaleHoldReleaseUrl = (holdId: string) => {
 export const fetchMyResaleListings = async (): Promise<ResaleListingItem[]> => fetchResaleListings();
 
 export const holdResaleListing = async (body: ResaleHoldRequest): Promise<ResaleHoldResponse> => {
+   if (isResaleDemoEnabled) {
+      return createDemoResaleHold(body.listingId, body.queueTokenJti);
+   }
+
    const response = await apiClient.post<ApiEnvelope<ResaleHoldResponse>>('/api/v1/resales/holds', body);
    return response.data.data;
 };
 
 export const releaseResaleListingHold = async (holdId: string): Promise<ResaleHoldResponse> => {
+   if (isResaleDemoEnabled) {
+      return releaseDemoResaleHold(holdId);
+   }
+
    const response = await apiClient.patch<ApiEnvelope<ResaleHoldResponse>>(
       `/api/v1/resales/holds/${encodeURIComponent(holdId)}/release`,
    );
@@ -68,6 +87,11 @@ export const releaseResaleListingHold = async (holdId: string): Promise<ResaleHo
 
 export const releaseResaleListingHoldKeepalive = (holdId: string) => {
    if (typeof window === 'undefined') {
+      return;
+   }
+
+   if (isResaleDemoEnabled) {
+      releaseDemoResaleHoldSync(holdId);
       return;
    }
 
@@ -204,6 +228,10 @@ export interface ResaleHistoryPointResponse {
 }
 
 export const fetchResaleListingCountByGame = async (gameId: string): Promise<number> => {
+   if (isResaleDemoEnabled) {
+      return getDemoResaleCountByGame(gameId);
+   }
+
    if (FORCE_RESALE_SOLD_OUT_MOCK) {
       return 0;
    }
@@ -222,6 +250,10 @@ export const fetchResaleListingCountsByGames = async (gameIds: string[]): Promis
       return new Map<string, number>();
    }
 
+   if (isResaleDemoEnabled) {
+      return new Map<string, number>(uniqueGameIds.map((gameId) => [gameId, getDemoResaleCountByGame(gameId)]));
+   }
+
    if (FORCE_RESALE_SOLD_OUT_MOCK) {
       return new Map<string, number>(uniqueGameIds.map((gameId) => [gameId, 0]));
    }
@@ -235,6 +267,10 @@ export const fetchResaleListingCountsByGames = async (gameIds: string[]): Promis
 
 /** 경기의 등급별 리셀 좌석 개수 조회 (gradeId 기준) */
 export const fetchResaleListingCountByGameAndGrade = async (gameId: string, gradeId: string): Promise<number> => {
+   if (isResaleDemoEnabled) {
+      return getDemoResaleCountsByGrades(gameId, [gradeId]).get(gradeId) ?? 0;
+   }
+
    const response = await apiClient.get<ApiEnvelope<ResaleGameListingCountResponse>>(
       `/api/v1/resales/games/${encodeURIComponent(gameId)}/grade/${encodeURIComponent(gradeId)}/count`,
    );
@@ -251,6 +287,10 @@ export const fetchResaleListingCountsByGrades = async (
 
    if (!gameId || uniqueGradeIds.length === 0) {
       return new Map<string, number>();
+   }
+
+   if (isResaleDemoEnabled) {
+      return getDemoResaleCountsByGrades(gameId, uniqueGradeIds);
    }
 
    const counts = await Promise.all(
@@ -278,6 +318,10 @@ export const fetchResaleListings = async (): Promise<ResaleListingItem[]> => {
 
 /** 구매자용 마켓 전체 리스팅 조회 — GET /api/v1/resales/listings */
 export const fetchMarketResaleListings = async (): Promise<ResaleListingItem[]> => {
+   if (isResaleDemoEnabled) {
+      return getDemoResaleListings();
+   }
+
    if (FORCE_RESALE_SOLD_OUT_MOCK) {
       return [];
    }
@@ -295,6 +339,10 @@ export const fetchMyResaleListingSummary = async (userId: string): Promise<MyRes
 };
 
 export const fetchResaleGameStatusByGame = async (gameId: string): Promise<ResaleGameStatus> => {
+   if (isResaleDemoEnabled) {
+      return getDemoResaleStatusByGame(gameId);
+   }
+
    if (FORCE_RESALE_SOLD_OUT_MOCK) {
       return 'UNAVAILABLE';
    }
@@ -313,6 +361,10 @@ export const fetchResaleGameStatusesByGames = async (gameIds: string[]): Promise
       return new Map<string, ResaleGameStatus>();
    }
 
+   if (isResaleDemoEnabled) {
+      return new Map<string, ResaleGameStatus>(uniqueGameIds.map((gameId) => [gameId, getDemoResaleStatusByGame(gameId)]));
+   }
+
    if (FORCE_RESALE_SOLD_OUT_MOCK) {
       return new Map<string, ResaleGameStatus>(uniqueGameIds.map((gameId) => [gameId, 'UNAVAILABLE']));
    }
@@ -329,6 +381,10 @@ export const fetchResaleHistoryGraph = async (
    gradeId: string,
    range: 'HOUR' | 'DAY' | 'WEEK',
 ): Promise<ResaleHistoryPointResponse[]> => {
+   if (isResaleDemoEnabled) {
+      return getDemoResaleHistory(range);
+   }
+
    const response = await apiClient.get<ApiEnvelope<ResaleHistoryPointResponse[]>>(
       `/api/v1/resales/histories/games/${encodeURIComponent(gameId)}/grade/${encodeURIComponent(gradeId)}/ranges/${range}/graph`,
    );
@@ -379,6 +435,10 @@ export const fetchResaleLedgerByOrderId = async (orderId: string): Promise<Resal
 };
 
 export const fetchResaleGameStatus = async (gameId: string): Promise<ResaleGameStatusResponse> => {
+   if (isResaleDemoEnabled) {
+      return { status: getDemoResaleStatusByGame(gameId) };
+   }
+
    const response = await apiClient.get<ApiEnvelope<ResaleGameStatusResponse>>(
       `/api/v1/resales/games/${encodeURIComponent(gameId)}/status`,
    );

--- a/src/entities/resale/api/resaleApi.ts
+++ b/src/entities/resale/api/resaleApi.ts
@@ -4,7 +4,7 @@ import apiClient from '@/shared/api/client';
 import type { ApiEnvelope } from '@/features/auth/api/types';
 import { createBookingFlowHeaders } from '@/shared/lib/guardrailHeaders';
 import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
-import { isResaleDemoEnabled } from '@/shared/config/runtime';
+import { isResaleBookingMockEnabled, isResaleDemoEnabled } from '@/shared/config/runtime';
 import {
    createDemoResaleHold,
    getDemoResaleCountByGame,
@@ -15,7 +15,8 @@ import {
    releaseDemoResaleHold,
    releaseDemoResaleHoldSync,
 } from '@/shared/lib/demo/resaleDemo';
-const FORCE_RESALE_SOLD_OUT_MOCK = !isResaleDemoEnabled;
+const shouldUseResaleBookingMock = isResaleDemoEnabled || isResaleBookingMockEnabled;
+const FORCE_RESALE_SOLD_OUT_MOCK = !shouldUseResaleBookingMock;
 
 export interface ResaleListingItem {
    listingId: string;
@@ -65,7 +66,7 @@ const getResaleHoldReleaseUrl = (holdId: string) => {
 export const fetchMyResaleListings = async (): Promise<ResaleListingItem[]> => fetchResaleListings();
 
 export const holdResaleListing = async (body: ResaleHoldRequest): Promise<ResaleHoldResponse> => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return createDemoResaleHold(body.listingId, body.queueTokenJti);
    }
 
@@ -74,7 +75,7 @@ export const holdResaleListing = async (body: ResaleHoldRequest): Promise<Resale
 };
 
 export const releaseResaleListingHold = async (holdId: string): Promise<ResaleHoldResponse> => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return releaseDemoResaleHold(holdId);
    }
 
@@ -90,7 +91,7 @@ export const releaseResaleListingHoldKeepalive = (holdId: string) => {
       return;
    }
 
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       releaseDemoResaleHoldSync(holdId);
       return;
    }
@@ -228,7 +229,7 @@ export interface ResaleHistoryPointResponse {
 }
 
 export const fetchResaleListingCountByGame = async (gameId: string): Promise<number> => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return getDemoResaleCountByGame(gameId);
    }
 
@@ -250,7 +251,7 @@ export const fetchResaleListingCountsByGames = async (gameIds: string[]): Promis
       return new Map<string, number>();
    }
 
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return new Map<string, number>(uniqueGameIds.map((gameId) => [gameId, getDemoResaleCountByGame(gameId)]));
    }
 
@@ -267,7 +268,7 @@ export const fetchResaleListingCountsByGames = async (gameIds: string[]): Promis
 
 /** 경기의 등급별 리셀 좌석 개수 조회 (gradeId 기준) */
 export const fetchResaleListingCountByGameAndGrade = async (gameId: string, gradeId: string): Promise<number> => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return getDemoResaleCountsByGrades(gameId, [gradeId]).get(gradeId) ?? 0;
    }
 
@@ -289,7 +290,7 @@ export const fetchResaleListingCountsByGrades = async (
       return new Map<string, number>();
    }
 
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return getDemoResaleCountsByGrades(gameId, uniqueGradeIds);
    }
 
@@ -318,7 +319,7 @@ export const fetchResaleListings = async (): Promise<ResaleListingItem[]> => {
 
 /** 구매자용 마켓 전체 리스팅 조회 — GET /api/v1/resales/listings */
 export const fetchMarketResaleListings = async (): Promise<ResaleListingItem[]> => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return getDemoResaleListings();
    }
 
@@ -339,7 +340,7 @@ export const fetchMyResaleListingSummary = async (userId: string): Promise<MyRes
 };
 
 export const fetchResaleGameStatusByGame = async (gameId: string): Promise<ResaleGameStatus> => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return getDemoResaleStatusByGame(gameId);
    }
 
@@ -361,7 +362,7 @@ export const fetchResaleGameStatusesByGames = async (gameIds: string[]): Promise
       return new Map<string, ResaleGameStatus>();
    }
 
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return new Map<string, ResaleGameStatus>(uniqueGameIds.map((gameId) => [gameId, getDemoResaleStatusByGame(gameId)]));
    }
 
@@ -381,8 +382,8 @@ export const fetchResaleHistoryGraph = async (
    gradeId: string,
    range: 'HOUR' | 'DAY' | 'WEEK',
 ): Promise<ResaleHistoryPointResponse[]> => {
-   if (isResaleDemoEnabled) {
-      return getDemoResaleHistory(range);
+   if (shouldUseResaleBookingMock) {
+      return getDemoResaleHistory(gameId, gradeId, range);
    }
 
    const response = await apiClient.get<ApiEnvelope<ResaleHistoryPointResponse[]>>(
@@ -435,7 +436,7 @@ export const fetchResaleLedgerByOrderId = async (orderId: string): Promise<Resal
 };
 
 export const fetchResaleGameStatus = async (gameId: string): Promise<ResaleGameStatusResponse> => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return { status: getDemoResaleStatusByGame(gameId) };
    }
 

--- a/src/features/seat-booking/ui/SeatHoldLifecycleController.tsx
+++ b/src/features/seat-booking/ui/SeatHoldLifecycleController.tsx
@@ -6,7 +6,10 @@ import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
 
 const isSeatHoldManagedPath = (pathname: string) =>
-   pathname.startsWith('/books') || pathname === '/tickets/payment' || pathname === '/tickets/payment/processing';
+   pathname.startsWith('/books') ||
+   pathname.startsWith('/resell-books') ||
+   pathname === '/tickets/payment' ||
+   pathname === '/tickets/payment/processing';
 
 const getSeatHolds = () => Object.values(useSeatHoldStore.getState().holdsBySeatId);
 

--- a/src/pages/books/model/resellMatching.ts
+++ b/src/pages/books/model/resellMatching.ts
@@ -63,6 +63,10 @@ const matchesSectionId = (listingSeatId: string, sectionIds?: string[]) => {
    return sectionIds.some((sectionId) => listingSeatId.includes(sectionId));
 };
 
+const matchesMockSeatId = (listingSeatId: string, zoneId: string) => {
+   return listingSeatId.startsWith(`${zoneId}-`);
+};
+
 export const isPurchasableResaleListing = (listing: ApiResaleListingItem, gameId?: string) => {
    return (
       Boolean(gameId) &&
@@ -80,7 +84,11 @@ export const matchesResaleListingToZone = ({
    zone: ZoneItem;
    listing: ApiResaleListingItem;
 }) => {
-   return matchesSectionId(listing.seatId, zone.sectionIds) || matchesSeatInfoSectionExpression(zone.sectionCode, listing.seatInfo);
+   return (
+      matchesSectionId(listing.seatId, zone.sectionIds) ||
+      matchesMockSeatId(listing.seatId, zone.id) ||
+      matchesSeatInfoSectionExpression(zone.sectionCode, listing.seatInfo)
+   );
 };
 
 export const resolveResaleListingZoneId = ({
@@ -94,6 +102,12 @@ export const resolveResaleListingZoneId = ({
 
    if (matchedBySectionId) {
       return matchedBySectionId.id;
+   }
+
+   const matchedByMockSeatId = zones.find((zone) => matchesMockSeatId(listing.seatId, zone.id));
+
+   if (matchedByMockSeatId) {
+      return matchedByMockSeatId.id;
    }
 
    return zones.find((zone) => matchesSeatInfoSectionExpression(zone.sectionCode, listing.seatInfo))?.id;

--- a/src/pages/books/model/useBookingZones.ts
+++ b/src/pages/books/model/useBookingZones.ts
@@ -13,9 +13,12 @@ import {
 import type { ZoneItem } from '@/pages/books/model/types';
 import { getBookingZones, getZoneDisplayOrder } from '@/pages/books/model/zoneData';
 import { ApiError } from '@/shared/api/client';
+import { isResaleBookingMockEnabled } from '@/shared/config/runtime';
 import { logBookingFlow, logBookingFlowError, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
 import type { BookingFlowMode } from '@/shared/lib/booking-flow';
 import type { BookingEntryState } from '@/shared/lib/useBookingEntryStore';
+import { getDemoResaleListings, getDemoResaleTargetCountForZone } from '@/shared/lib/demo/resaleDemo';
+import { isPurchasableResaleListing, matchesResaleListingToZone } from './resellMatching';
 
 type UseBookingZonesParams = {
    bookingEntryState: BookingEntryState | null;
@@ -68,6 +71,27 @@ export function useBookingZones({
       [bookingEntryState?.homeTeamId],
    );
 
+   const mockResellZones = useMemo(() => {
+      if (bookingFlowMode !== 'resell' || !isResaleBookingMockEnabled || !bookingEntryState?.gameId) {
+         return localZones;
+      }
+
+      const demoListings = getDemoResaleListings();
+
+      return localZones.map((zone) => ({
+         ...zone,
+         remaining: (() => {
+            const count = demoListings.filter(
+               (listing) =>
+                  isPurchasableResaleListing(listing, bookingEntryState.gameId) &&
+                  matchesResaleListingToZone({ zone, listing }),
+            ).length;
+
+            return count > 0 ? count : getDemoResaleTargetCountForZone(zone.id);
+         })(),
+      }));
+   }, [bookingEntryState?.gameId, bookingFlowMode, localZones]);
+
    const { data: apiZones, error: apiZonesError } = useQuery({
       queryKey: [
          'booking-zones',
@@ -79,7 +103,7 @@ export function useBookingZones({
          bookingEntryState?.leagueType,
          bookingEntryState?.gameDate,
       ],
-      enabled: isEnabled,
+      enabled: isEnabled && !(bookingFlowMode === 'resell' && isResaleBookingMockEnabled),
       queryFn: async () => {
          const shouldForceNewSession = shouldForceNewSessionRef.current;
          logBookingFlow('useBookingZones', 'queryFn start', {
@@ -159,14 +183,16 @@ export function useBookingZones({
       });
    }, [bookingEntryState, bookingFlowMode, isEnabled]);
 
-   const mergedBaseZones = useMemo(
-      () =>
-         mergeBookingZones({
-            localZones,
-            apiZones,
-         }),
-      [apiZones, localZones],
-   );
+   const mergedBaseZones = useMemo(() => {
+      if (bookingFlowMode === 'resell' && isResaleBookingMockEnabled) {
+         return mockResellZones;
+      }
+
+      return mergeBookingZones({
+         localZones,
+         apiZones,
+      });
+   }, [apiZones, bookingFlowMode, localZones, mockResellZones]);
 
    const zones = useMemo<ZoneItem[]>(() => {
       return [...mergedBaseZones].sort(

--- a/src/pages/books/model/useResellSeatSelection.ts
+++ b/src/pages/books/model/useResellSeatSelection.ts
@@ -6,6 +6,7 @@ import {
    releaseResaleListingHoldKeepalive,
 } from '@/entities/resale/api/resaleApi';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
+import { isResaleBookingMockEnabled } from '@/shared/config/runtime';
 import { getErrorMessage } from '@/shared/lib/error/getErrorMessage';
 import type { BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import { createResellSeatLookupKey, parseResellSeatInfo } from '@/pages/books/lib/resellSeatParser';
@@ -138,6 +139,24 @@ export function useResellSeatSelection({
             nextMap.set(matchedSeat.id, listing);
          }
       });
+
+      if (
+         isResaleBookingMockEnabled &&
+         nextMap.size === 0 &&
+         (resellInsights?.listings?.length ?? 0) > 0 &&
+         seats.length > 0
+      ) {
+         resellInsights!.listings.slice(0, seats.length).forEach((listing, index) => {
+            const fallbackSeat = seats[index];
+
+            if (fallbackSeat) {
+               nextMap.set(fallbackSeat.id, {
+                  ...listing,
+                  seatId: fallbackSeat.id,
+               });
+            }
+         });
+      }
 
       return nextMap;
    }, [resellInsights?.listings, seats]);

--- a/src/pages/books/model/useResellZoneInsights.ts
+++ b/src/pages/books/model/useResellZoneInsights.ts
@@ -12,7 +12,7 @@ import {
 } from './resellData';
 import { isPurchasableResaleListing, matchesResaleListingToZone } from './resellMatching';
 import { getCompletedResalePurchaseLookup } from '@/shared/lib/paymentCompleteStorage';
-import { isResaleDemoEnabled } from '@/shared/config/runtime';
+import { isResaleBookingMockEnabled, isResaleDemoEnabled } from '@/shared/config/runtime';
 import { ensureDemoListingsForZone } from '@/shared/lib/demo/resaleDemo';
 
 const sortListings = (left: ApiResaleListingItem, right: ApiResaleListingItem) => {
@@ -26,7 +26,13 @@ const sortListings = (left: ApiResaleListingItem, right: ApiResaleListingItem) =
    return left.listingPrice - right.listingPrice;
 };
 
-const buildSeatLabel = (_zone: ZoneItem, seatInfo: string) => seatInfo;
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const buildSeatLabel = (zone: ZoneItem, seatInfo: string) => {
+   const zonePrefixPattern = new RegExp(`^${escapeRegExp(zone.name)}\\s+`, 'i');
+
+   return seatInfo.replace(zonePrefixPattern, '').trim();
+};
 
 const toResellListingItem = (zone: ZoneItem, listing: ApiResaleListingItem): ResellListingItem => ({
    listingId: listing.listingId,
@@ -57,7 +63,9 @@ export const useResellZoneInsights = ({
    zone: ZoneItem;
    seats: SeatItem[];
 }) => {
-   const primaryGradeId = zone.gradeIds?.[0];
+   const primaryGradeId =
+      zone.gradeIds?.[0] ??
+      (isResaleDemoEnabled || isResaleBookingMockEnabled ? `demo-grade-${zone.id}` : undefined);
    const seatIdentifierSet = new Set(seats.flatMap((seat) => [seat.id, seat.apiSeatId]));
 
    return useQuery({
@@ -69,7 +77,7 @@ export const useResellZoneInsights = ({
          }
 
          const [listings, minuteGraph, dayGraph] = await Promise.all([
-            isResaleDemoEnabled
+            isResaleDemoEnabled || isResaleBookingMockEnabled
                ? Promise.resolve(
                     ensureDemoListingsForZone({
                        gameId,

--- a/src/pages/books/model/useResellZoneInsights.ts
+++ b/src/pages/books/model/useResellZoneInsights.ts
@@ -12,6 +12,8 @@ import {
 } from './resellData';
 import { isPurchasableResaleListing, matchesResaleListingToZone } from './resellMatching';
 import { getCompletedResalePurchaseLookup } from '@/shared/lib/paymentCompleteStorage';
+import { isResaleDemoEnabled } from '@/shared/config/runtime';
+import { ensureDemoListingsForZone } from '@/shared/lib/demo/resaleDemo';
 
 const sortListings = (left: ApiResaleListingItem, right: ApiResaleListingItem) => {
    const leftTime = new Date(left.listedAt).getTime();
@@ -67,7 +69,15 @@ export const useResellZoneInsights = ({
          }
 
          const [listings, minuteGraph, dayGraph] = await Promise.all([
-            fetchMarketResaleListings(),
+            isResaleDemoEnabled
+               ? Promise.resolve(
+                    ensureDemoListingsForZone({
+                       gameId,
+                       zone,
+                       seats,
+                    }),
+                 )
+               : fetchMarketResaleListings(),
             primaryGradeId ? fetchResaleHistoryGraph(gameId, primaryGradeId, 'HOUR') : Promise.resolve([]),
             primaryGradeId ? fetchResaleHistoryGraph(gameId, primaryGradeId, 'DAY') : Promise.resolve([]),
          ]);

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -23,6 +23,7 @@ const MEANINGFUL_SEAT_MAP_ERROR_PATTERNS = [/예매 가능/i, /권한/i, /로그
 
 type SeatMapDataParams = {
    gameId?: string;
+   preferMockSeatMap?: boolean;
    stadiumId?: string;
    zone: ZoneItem;
 };
@@ -207,12 +208,12 @@ const fetchAggregatedSeatSections = async ({
    return sectionBundles;
 };
 
-export const useSeatMapData = ({ gameId, stadiumId, zone }: SeatMapDataParams) => {
+export const useSeatMapData = ({ gameId, preferMockSeatMap = false, stadiumId, zone }: SeatMapDataParams) => {
    const defaultSeatBlocks = useMemo(() => getSeatBlocks(zone), [zone]);
 
    const { data, error, isError, isFetching, isLoading, refetch } = useQuery({
       queryKey: ['booking-seat-map', gameId, stadiumId, zone.id, zone.sectionCode],
-      enabled: Boolean(gameId && zone.id && zone.sectionCode),
+      enabled: !preferMockSeatMap && Boolean(gameId && zone.id && zone.sectionCode),
       queryFn: async (): Promise<SeatMapApiSnapshot | null> => {
          if (!gameId || !zone.id || !zone.sectionCode) {
             return null;

--- a/src/pages/books/model/useSeatMapLayout.ts
+++ b/src/pages/books/model/useSeatMapLayout.ts
@@ -5,7 +5,10 @@ import type { SeatBlock } from './types';
 const BLOCK_SEAT_SIZE = 18;
 const BLOCK_SEAT_GAP = 2;
 const BLOCK_CARD_COLUMN_GAP = 48;
-const STAGE_WIDTH = 1240;
+const STAGE_MIN_WIDTH = 1240;
+const STAGE_MIN_HEIGHT = 620;
+const STAGE_HORIZONTAL_PADDING = 160;
+const STAGE_VERTICAL_PADDING = 180;
 const STAGE_TOP_OFFSET = 56;
 const MINIMAP_WIDTH = 215;
 const MINIMAP_HEIGHT = 140;
@@ -91,6 +94,26 @@ export function useSeatMapLayout({
       };
    }, [sectionBounds]);
 
+   const stageSize = useMemo(() => {
+      if (!sectionBounds) {
+         return {
+            width: STAGE_MIN_WIDTH,
+            height: STAGE_MIN_HEIGHT,
+         };
+      }
+
+      return {
+         width: Math.max(
+            STAGE_MIN_WIDTH,
+            Math.ceil(sectionBounds.right - sectionBounds.left + STAGE_HORIZONTAL_PADDING * 2),
+         ),
+         height: Math.max(
+            STAGE_MIN_HEIGHT,
+            Math.ceil(sectionBounds.bottom - sectionBounds.top + STAGE_VERTICAL_PADDING * 2),
+         ),
+      };
+   }, [sectionBounds]);
+
    const minimapLayout = useMemo(() => {
       if (!sectionBounds) {
          return null;
@@ -128,7 +151,7 @@ export function useSeatMapLayout({
          return null;
       }
 
-      const stageLeft = (mapViewportSize.width - STAGE_WIDTH * seatMapScale) / 2 + seatMapOffset.x;
+      const stageLeft = (mapViewportSize.width - stageSize.width * seatMapScale) / 2 + seatMapOffset.x;
       const stageTop = STAGE_TOP_OFFSET + seatMapOffset.y;
       const visibleLeft = (0 - stageLeft) / seatMapScale;
       const visibleTop = (0 - stageTop) / seatMapScale;
@@ -149,12 +172,13 @@ export function useSeatMapLayout({
          width: (intersectRight - intersectLeft) * minimapLayout.scale,
          height: (intersectBottom - intersectTop) * minimapLayout.scale,
       };
-   }, [mapViewportSize.height, mapViewportSize.width, minimapLayout, seatMapOffset.x, seatMapOffset.y, seatMapScale, sectionBounds]);
+   }, [mapViewportSize.height, mapViewportSize.width, minimapLayout, seatMapOffset.x, seatMapOffset.y, seatMapScale, sectionBounds, stageSize.width]);
 
    return {
       directionBadgePosition,
       minimapLayout,
       minimapViewport,
       sectionBounds,
+      stageSize,
    };
 }

--- a/src/pages/books/model/useSeatMapViewport.ts
+++ b/src/pages/books/model/useSeatMapViewport.ts
@@ -4,17 +4,17 @@ import type { SeatMapSectionBounds } from './useSeatMapLayout';
 
 const MIN_SCALE = 0.8;
 const MAX_SCALE = 2.4;
-const STAGE_WIDTH = 1240;
 const STAGE_TOP_OFFSET = 56;
 const DEFAULT_SEAT_MAP_LEFT_PADDING = 24;
 const DEFAULT_SEAT_MAP_TOP_PADDING = 24;
 
 type UseSeatMapViewportParams = {
    sectionBounds: SeatMapSectionBounds;
+   stageWidth: number;
    zoneId: string;
 };
 
-export function useSeatMapViewport({ sectionBounds, zoneId }: UseSeatMapViewportParams) {
+export function useSeatMapViewport({ sectionBounds, stageWidth, zoneId }: UseSeatMapViewportParams) {
    const [seatMapScale, setSeatMapScale] = useState(1);
    const [seatMapOffset, setSeatMapOffset] = useState({ x: 0, y: 0 });
    const [isSeatMapDragging, setIsSeatMapDragging] = useState(false);
@@ -67,7 +67,7 @@ export function useSeatMapViewport({ sectionBounds, zoneId }: UseSeatMapViewport
       return {
          scale: Number(scale.toFixed(2)),
          offset: {
-            x: (STAGE_WIDTH / 2 - contentCenterX) * scale,
+            x: (stageWidth / 2 - contentCenterX) * scale,
             y: targetCenterY - STAGE_TOP_OFFSET - contentCenterY * scale,
          },
       };
@@ -85,7 +85,7 @@ export function useSeatMapViewport({ sectionBounds, zoneId }: UseSeatMapViewport
 
       setSeatMapScale(nextView.scale);
       setSeatMapOffset(nextView.offset);
-   }, [mapViewportSize.height, mapViewportSize.width, sectionBounds, zoneId]);
+   }, [mapViewportSize.height, mapViewportSize.width, sectionBounds, stageWidth, zoneId]);
 
    return {
       isSeatMapDragging,

--- a/src/pages/books/model/useSeatsPageEntry.ts
+++ b/src/pages/books/model/useSeatsPageEntry.ts
@@ -1,13 +1,13 @@
 import { useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { getBookingFlowMode } from '@/shared/lib/booking-flow';
+import type { BookingFlowMode } from '@/shared/lib/booking-flow';
 import { mergeBookingEntryState, useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import { getBookingZones, getStadiumName, getZoneOverviewImage } from './zoneData';
 
 export function useSeatsPageEntry(zoneId: string) {
    const location = useLocation();
-   const bookingFlowMode = getBookingFlowMode(location.search);
+   const bookingFlowMode: BookingFlowMode = location.pathname.startsWith('/resell-books') ? 'resell' : 'standard';
    const isResellMode = bookingFlowMode === 'resell';
    const routeBookingEntryState = location.state as BookingEntryState | null;
    const storedBookingEntryState = useBookingEntryStore(state => state.entry);

--- a/src/pages/books/model/useZoneSeatState.ts
+++ b/src/pages/books/model/useZoneSeatState.ts
@@ -14,6 +14,7 @@ type UseZoneSeatStateParams = {
    bookingEntryState: BookingEntryState | null;
    bookingZones: ZoneItem[];
    onPurchaseLimitReached?: () => void;
+   preferMockSeatMap?: boolean;
    zone: ZoneItem;
 };
 
@@ -21,6 +22,7 @@ export function useZoneSeatState({
    bookingEntryState,
    bookingZones,
    onPurchaseLimitReached,
+   preferMockSeatMap = false,
    zone,
 }: UseZoneSeatStateParams) {
    const initialSeats = useMemo(() => createSeatsForZone(zone), [zone]);
@@ -34,6 +36,7 @@ export function useZoneSeatState({
       refetchSeatMap,
    } = useSeatMapData({
       gameId: bookingEntryState?.gameId,
+      preferMockSeatMap,
       stadiumId: bookingEntryState?.stadiumId,
       zone,
    });

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -10,6 +10,7 @@ import { useSeatMapViewport } from '@/pages/books/model/useSeatMapViewport';
 import { useSeatsPageEntry } from '@/pages/books/model/useSeatsPageEntry';
 import { useZoneSeatState } from '@/pages/books/model/useZoneSeatState';
 import { formatPrice } from '@/pages/books/model/zoneData';
+import { isResaleBookingMockEnabled } from '@/shared/config/runtime';
 import { logBookingFlow, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
 import { useBotDetector } from '@/shared/lib/useBotDetector';
 import { Drawer, DrawerContent, DrawerTrigger } from '@/shared/ui/drawer';
@@ -48,6 +49,7 @@ function SeatsPage() {
       bookingEntryState,
       bookingZones,
       onPurchaseLimitReached: () => setIsPurchaseLimitDialogOpen(true),
+      preferMockSeatMap: isResellMode && isResaleBookingMockEnabled,
       zone,
    });
    const [isSeatDrawerOpen, setIsSeatDrawerOpen] = useState(true);
@@ -67,6 +69,7 @@ function SeatsPage() {
    });
    const seatMapViewport = useSeatMapViewport({
       sectionBounds: baseSeatMapLayout.sectionBounds,
+      stageWidth: baseSeatMapLayout.stageSize.width,
       zoneId: zone.id,
    });
    const seatMapLayout = useSeatMapLayout({
@@ -274,6 +277,7 @@ function SeatsPage() {
                      seatBlocks={seatBlocks}
                      seatMapOffset={seatMapViewport.seatMapOffset}
                      seatMapScale={seatMapViewport.seatMapScale}
+                     stageSize={seatMapLayout.stageSize}
                      seats={displaySeats}
                      selectedSeatIdSet={selectedSeatIdSet}
                      zoneColor={zone.color}

--- a/src/pages/books/ui/components/BookingZoneDesktopLayout.tsx
+++ b/src/pages/books/ui/components/BookingZoneDesktopLayout.tsx
@@ -9,6 +9,7 @@ type BookingZoneDesktopLayoutProps = {
    onSelectZone: (zoneId: string) => void;
    stadiumImage: string;
    stadiumImageAlt: string;
+   showPrice?: boolean;
 };
 
 function BookingZoneDesktopLayout({
@@ -17,6 +18,7 @@ function BookingZoneDesktopLayout({
    onSelectZone,
    stadiumImage,
    stadiumImageAlt,
+   showPrice = true,
 }: BookingZoneDesktopLayoutProps) {
    return (
       <main className="hidden min-h-[calc(100vh-140px)] lg:grid lg:h-[calc(100vh-140px)] lg:grid-cols-[minmax(0,1fr)_420px]">
@@ -27,7 +29,12 @@ function BookingZoneDesktopLayout({
             stadiumImage={stadiumImage}
             stadiumImageAlt={stadiumImageAlt}
          />
-         <BookingZoneList zones={zones} selectedZoneId={selectedZoneId} onSelectZone={onSelectZone} />
+         <BookingZoneList
+            zones={zones}
+            selectedZoneId={selectedZoneId}
+            onSelectZone={onSelectZone}
+            showPrice={showPrice}
+         />
       </main>
    );
 }

--- a/src/pages/books/ui/components/BookingZoneList.tsx
+++ b/src/pages/books/ui/components/BookingZoneList.tsx
@@ -6,9 +6,16 @@ type BookingZoneListProps = {
    selectedZoneId: string;
    onSelectZone: (zoneId: string) => void;
    variant?: 'panel' | 'drawer';
+   showPrice?: boolean;
 };
 
-function BookingZoneList({ zones, selectedZoneId, onSelectZone, variant = 'panel' }: BookingZoneListProps) {
+function BookingZoneList({
+   zones,
+   selectedZoneId,
+   onSelectZone,
+   variant = 'panel',
+   showPrice = true,
+}: BookingZoneListProps) {
    const isDrawer = variant === 'drawer';
 
    return (
@@ -49,7 +56,7 @@ function BookingZoneList({ zones, selectedZoneId, onSelectZone, variant = 'panel
                         </div>
                         <div className="flex min-w-0 flex-1 items-center gap-2 text-body-2-regular text-muted-foreground">
                            <span className="truncate text-body-1-medium text-foreground">{zone.name}</span>
-                           <span className="shrink-0">{formatPrice(zone.price)}</span>
+                           {showPrice ? <span className="shrink-0">{formatPrice(zone.price)}</span> : null}
                         </div>
                         <span
                            className={[

--- a/src/pages/books/ui/components/BookingZoneMobileLayout.tsx
+++ b/src/pages/books/ui/components/BookingZoneMobileLayout.tsx
@@ -15,6 +15,7 @@ type BookingZoneMobileLayoutProps = {
    onSelectZone: (zoneId: string) => void;
    stadiumImage: string;
    stadiumImageAlt: string;
+   showPrice?: boolean;
 };
 
 function BookingZoneMobileLayout({
@@ -27,6 +28,7 @@ function BookingZoneMobileLayout({
    onSelectZone,
    stadiumImage,
    stadiumImageAlt,
+   showPrice = true,
 }: BookingZoneMobileLayoutProps) {
    return (
       <section className="relative min-h-[calc(100vh-140px)] bg-[#f1f2f4] lg:hidden">
@@ -74,6 +76,7 @@ function BookingZoneMobileLayout({
                         zones={zones}
                         selectedZoneId={selectedZoneId}
                         onSelectZone={onSelectZone}
+                        showPrice={showPrice}
                      />
                   </div>
                </DrawerContent>

--- a/src/pages/books/ui/components/ResellPriceChart.tsx
+++ b/src/pages/books/ui/components/ResellPriceChart.tsx
@@ -42,7 +42,6 @@ const formatTooltipChangeRate = (price: number, previousClose: number) => {
    return `${changeRate >= 0 ? '+' : ''}${changeRate.toFixed(2)}%`;
 };
 
-// ─── dialog 용: 세로 정렬 + 가운데 정렬 ───────────────────────────
 function MetricCard({ label, value, valueClassName }: { label: string; value: string; valueClassName?: string }) {
    return (
       <div className="flex flex-col items-center gap-1 text-center px-2">
@@ -52,7 +51,6 @@ function MetricCard({ label, value, valueClassName }: { label: string; value: st
    );
 }
 
-// ─── sidebar 용: 가로 정렬 ─────────────────────────────────────────
 function MetricRow({ label, value, valueClassName }: { label: string; value: string; valueClassName?: string }) {
    return (
       <div className="flex min-w-0 items-center gap-2">
@@ -69,7 +67,6 @@ export default function ResellPriceChart({ insights, zoneName, height = 200, var
    const chartMin = Math.min(...priceValues);
    const chartMax = Math.max(...priceValues);
 
-   // 지표: price points 기준으로 계산
    const dayPrices = useMemo(
       () => insights.pricePointsByRange.day.map(p => p.price),
       [insights.pricePointsByRange.day],
@@ -205,7 +202,6 @@ export default function ResellPriceChart({ insights, zoneName, height = 200, var
 
    return (
       <div className="flex flex-col gap-4">
-         {/* 헤딩 + 변동률 */}
          <div className="flex items-center gap-1">
             <h2 className="text-heading-3-bold text-foreground">거래 변동</h2>
             <span className={cn('text-label-2-semibold', displayChangeAmount >= 0 ? 'text-destructive' : 'text-primary')}>
@@ -214,9 +210,7 @@ export default function ResellPriceChart({ insights, zoneName, height = 200, var
             </span>
          </div>
 
-         {/* 지표 — variant에 따라 다른 레이아웃 */}
          {variant === 'dialog' ? (
-            /* dialog: 3열 카드 (Figma node 4131:30267) */
             <div className="bg-[#f7f8f9] rounded-xl grid grid-cols-3 py-4">
                <MetricCard label="최근 거래 체결가" value={formatPrice(displayRecentTrade)} />
                <MetricCard
@@ -231,7 +225,6 @@ export default function ResellPriceChart({ insights, zoneName, height = 200, var
                />
             </div>
          ) : (
-            /* sidebar: 4개 2열 인라인 */
             <div className="grid grid-cols-2 gap-x-8 gap-y-1">
                <MetricRow label="전일 종가" value={formatPrice(insights.previousClose)} />
                <MetricRow label="최근 거래 체결가" value={formatPrice(displayRecentTrade)} />
@@ -248,7 +241,6 @@ export default function ResellPriceChart({ insights, zoneName, height = 200, var
             </div>
          )}
 
-         {/* 범위 토글 */}
          <div className="flex rounded-xl bg-[#f1f2f4] p-1">
             {([
                { key: 'minute', label: '1분' },
@@ -268,7 +260,6 @@ export default function ResellPriceChart({ insights, zoneName, height = 200, var
             ))}
          </div>
 
-         {/* 차트 */}
          <div className="bg-background py-3">
             <div role="img" aria-label={zoneName ? `${zoneName} 리셀 가격 추이` : '리셀 가격 추이'}>
                <Chart

--- a/src/pages/books/ui/components/SeatMapStage.tsx
+++ b/src/pages/books/ui/components/SeatMapStage.tsx
@@ -8,8 +8,6 @@ import SeatBlockGrid from './SeatBlockGrid';
 const MIN_SCALE = 0.8;
 const MAX_SCALE = 2.4;
 const SCALE_STEP = 0.2;
-const STAGE_WIDTH = 1240;
-const STAGE_HEIGHT = 620;
 const MINIMAP_WIDTH = 215;
 const MINIMAP_HEIGHT = 140;
 
@@ -48,6 +46,10 @@ type SeatMapStageProps = {
       y: number;
    };
    seatMapScale: number;
+   stageSize: {
+      width: number;
+      height: number;
+   };
    seats: SeatItem[];
    selectedSeatIdSet: Set<string>;
    zoneColor: string;
@@ -69,6 +71,7 @@ function SeatMapStage({
    seatBlocks,
    seatMapOffset,
    seatMapScale,
+   stageSize,
    seats,
    selectedSeatIdSet,
    zoneColor,
@@ -106,8 +109,8 @@ function SeatMapStage({
                   'touch-none',
                ].join(' ')}
                style={{
-                  width: `${STAGE_WIDTH}px`,
-                  height: `${STAGE_HEIGHT}px`,
+                  width: `${stageSize.width}px`,
+                  height: `${stageSize.height}px`,
                   transform: `translate3d(calc(-50% + ${seatMapOffset.x}px), ${seatMapOffset.y}px, 0) scale(${seatMapScale})`,
                }}
                onPointerDown={onMapPointerDown}

--- a/src/pages/mypage/model/useMypageData.ts
+++ b/src/pages/mypage/model/useMypageData.ts
@@ -27,6 +27,8 @@ import {
 import type { PurchaseHistoryItem, SaleHistoryItem, PurchaseStatus, SaleStatus } from './historyCard';
 import type { TicketType } from '../ui/TicketTypeBadge';
 import { formatTicketNumber } from './ticketNumber';
+import { readStoredPaymentCompleteItems, type StoredPaymentCompleteItem } from '@/shared/lib/paymentCompleteStorage';
+import { isResaleBookingMockEnabled, isResaleDemoEnabled } from '@/shared/config/runtime';
 
 const formatDate = (dateStr: string) => {
    const date = new Date(dateStr);
@@ -73,6 +75,7 @@ const mapPurchaseStatus = (status: string): PurchaseStatus => {
       case 'PENDING':
          return '입금 대기';
       case 'CONFIRMED':
+      case 'COMPLETED':
          return '예매 완료';
       case 'PARTIALLY_CANCELED':
          return '부분 처리';
@@ -112,7 +115,7 @@ type EnrichedResaleListingItem = ResaleListingItem & {
 const fetchMyOrderSummaries = async (): Promise<EnrichedOrderListItem[]> => {
    // GET /api/v1/orders 는 백엔드에 존재하지 않음 (POST만 지원)
    // 구매 내역은 /api/v1/payments/purchases 단일 엔드포인트만 사용
-   const purchaseHistory = await fetchPurchaseHistory({ type: 'NORMAL', size: 100 });
+   const purchaseHistory = await fetchPurchaseHistory({ size: 100 });
    const orders: PaymentPurchaseHistoryItem[] = purchaseHistory.list;
 
    return Promise.all(
@@ -136,6 +139,35 @@ const fetchMyOrderSummaries = async (): Promise<EnrichedOrderListItem[]> => {
          }
       }),
    );
+};
+
+const mapStoredPaymentCompleteItemToPurchaseHistory = (item: StoredPaymentCompleteItem): PurchaseHistoryItem => {
+   const seats = item.seats.length > 0
+      ? item.seats.map((seatInfo) => parseSeatDetail(seatInfo))
+      : Array.from({ length: item.quantity }, (_, index) => `좌석${index + 1}`);
+   const primarySeatInfo = item.seats[0];
+   const sectionLabel = primarySeatInfo ? parseGradeName(primarySeatInfo) : '좌석 정보';
+
+   return {
+      id: item.ticketId ?? item.orderId ?? item.orderNumber,
+      rawOrderId: item.orderId,
+      orderId: formatTicketNumber(item.orderNumber, item.orderType === 'resale' ? 'resale' : 'ticket'),
+      orderDate: formatDate(item.orderedAt),
+      type: item.orderType === 'resale' ? ('리셀' as TicketType) : ('티켓' as TicketType),
+      seatGradeName: sectionLabel,
+      game: {
+         teams: item.gameTitle,
+         venue: item.gameVenue,
+         datetime: item.gameDate ? formatDateTime(item.gameDate) : formatDateTime(item.orderedAt),
+         quantity: item.quantity,
+         section: sectionLabel,
+         seats,
+      },
+      price: item.amount,
+      paymentStatus: mapPurchaseStatus(item.orderStatus ?? item.paymentStatus ?? 'CONFIRMED'),
+      deliveryType: '모바일 티켓',
+      canSell: item.orderType !== 'resale',
+   };
 };
 
 const fetchMyResaleListingsWithGameInfo = async (): Promise<EnrichedResaleListingItem[]> => {
@@ -219,7 +251,7 @@ export const useMyOrdersData = () => {
    });
 
    const data = useMemo((): PurchaseHistoryItem[] => {
-      return (query.data ?? []).map(({ order, tickets, primaryTicketDetail }) => {
+      const apiOrders = (query.data ?? []).map(({ order, tickets, primaryTicketDetail }) => {
          // PurchaseSearchResponse 기준: seatInfos 배열 직접 사용
          const displaySeatInfos = order.seatInfos.length > 0
             ? order.seatInfos
@@ -250,7 +282,7 @@ export const useMyOrdersData = () => {
             stadiumId: order.stadiumId,
             orderId: formatTicketNumber(order.orderNumber, 'ticket'),
             orderDate: formatDate(order.orderedAt),
-            type: '티켓' as TicketType,
+            type: order.purchaseType === 'RESALE' ? ('리셀' as TicketType) : ('티켓' as TicketType),
             seatGradeName: sectionLabel,
             game: {
                teams: gameTitle,
@@ -265,11 +297,26 @@ export const useMyOrdersData = () => {
             price: purchaseAmount,
             paymentStatus: mapPurchaseStatus(order.orderStatus),
             deliveryType: '모바일 티켓',
-            canSell: order.orderStatus === 'CONFIRMED',
+            canSell: order.purchaseType !== 'RESALE' && order.orderStatus === 'CONFIRMED',
             ticketIds: ticketIds.length > 0 ? ticketIds : undefined,
             seatPrices: seatPrices.length > 0 ? seatPrices : undefined,
          };
       });
+
+      const storedResaleOrders =
+         isResaleDemoEnabled || isResaleBookingMockEnabled
+            ? readStoredPaymentCompleteItems()
+                 .filter((item) => item.orderType === 'resale')
+                 .filter((item) => item.orderId || item.orderNumber)
+                 .filter((item) =>
+                    !apiOrders.some((order) =>
+                       Boolean(item.orderId) && (order.rawOrderId === item.orderId || order.id === item.orderId),
+                    ),
+                 )
+                 .map(mapStoredPaymentCompleteItemToPurchaseHistory)
+            : [];
+
+      return [...apiOrders, ...storedResaleOrders];
    }, [query.data]);
 
    const sortedData = useMemo(() => {

--- a/src/pages/mypage/ui/HistoryCard.tsx
+++ b/src/pages/mypage/ui/HistoryCard.tsx
@@ -134,14 +134,17 @@ export default function HistoryCard(props: HistoryCardProps) {
    const priceLabel = isPurchase ? '구매가' : '판매가';
    const price = isPurchase ? (item as PurchaseHistoryItem).price : (item as SaleHistoryItem).salePrice;
    const status = isPurchase ? (item as PurchaseHistoryItem).paymentStatus : (item as SaleHistoryItem).saleStatus;
+   const isResalePurchase = isPurchase && purchaseItem?.type === '리셀';
 
    const hasPurchaseOrder = Boolean(purchaseOrderId);
    const isCancelablePurchaseStatus =
-      purchaseItem?.paymentStatus === '입금 대기' ||
-      purchaseItem?.paymentStatus === '예매 완료' ||
-      purchaseItem?.paymentStatus === '부분 처리';
+      !isResalePurchase &&
+      (purchaseItem?.paymentStatus === '입금 대기' ||
+         purchaseItem?.paymentStatus === '예매 완료' ||
+         purchaseItem?.paymentStatus === '부분 처리');
    const isSellablePurchaseStatus =
-      purchaseItem?.paymentStatus === '예매 완료' || purchaseItem?.paymentStatus === '부분 처리';
+      !isResalePurchase &&
+      (purchaseItem?.paymentStatus === '예매 완료' || purchaseItem?.paymentStatus === '부분 처리');
    const actionTickets = actionTicketsQuery.data ?? [];
    const requestedTicketIds = new Set((purchaseItem?.ticketIds ?? []).filter(Boolean));
    const requestedSeatDetails = new Set(purchaseItem?.game.seats ?? []);
@@ -161,7 +164,10 @@ export default function HistoryCard(props: HistoryCardProps) {
       purchaseItem?.deliveryType === '모바일 티켓' &&
       isSellablePurchaseStatus;
    const showCancelBtn = hasPurchaseOrder && isCancelablePurchaseStatus;
-   const showQrBtn = hasPurchaseOrder && isSellablePurchaseStatus && item.deliveryType === '모바일 티켓';
+   const showQrBtn =
+      hasPurchaseOrder &&
+      item.deliveryType === '모바일 티켓' &&
+      (isResalePurchase || isSellablePurchaseStatus);
    const showDash =
       isPurchase && (purchaseItem?.paymentStatus === '취소/환불' || purchaseItem?.paymentStatus === '관람 완료');
    const canCancelSale = !isPurchase && (item as SaleHistoryItem).canCancel;

--- a/src/pages/queue/api/queueApi.ts
+++ b/src/pages/queue/api/queueApi.ts
@@ -4,7 +4,10 @@ import apiClient from '@/shared/api/client';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import type { ApiEnvelope } from '@/features/auth/api/types';
 import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
+import { buildMockQueueTokenJti } from '@/shared/config/booking';
+import { isResaleBookingMockEnabled } from '@/shared/config/runtime';
 import { logBookingFlow, logBookingFlowError } from '@/shared/lib/bookingFlowDebug';
+import { useBookingEntryStore } from '@/shared/lib/useBookingEntryStore';
 
 export interface QueueEnterResponse {
   queueToken: string;
@@ -36,9 +39,37 @@ export interface QueueLeaveResponse {
   status: 'WAITING' | 'ADMITTED' | 'LEFT' | 'EXPIRED';
 }
 
+const getShouldUseResellQueueMock = () => {
+  const bookingEntry = useBookingEntryStore.getState().entry;
+  return isResaleBookingMockEnabled && bookingEntry?.bookingFlowMode === 'resell';
+};
+
+const createMockQueueEnterResponse = (gameId: string): QueueEnterResponse => ({
+  gameId,
+  issuedAt: new Date().toISOString(),
+  queueNumber: 1,
+  queueToken: buildMockQueueTokenJti(gameId) ?? `queue-token-${gameId}`,
+});
+
+const createMockQueueStatusResponse = (gameId: string): QueueStatusResponse => ({
+  gameId,
+  maxCapacity: 1000,
+  activeCount: 1,
+  availableSlots: 999,
+  currentAllowedRank: 1,
+  publishedRank: 1,
+  updatedAt: new Date().toISOString(),
+});
+
 /** 대기열 진입 — 새 대기 순번(queueNumber)과 토큰(queueToken) 발급 */
 export const enterQueue = async (gameId: string): Promise<QueueEnterResponse> => {
   logBookingFlow('queueApi', 'enterQueue request', { gameId });
+  if (getShouldUseResellQueueMock()) {
+    const response = createMockQueueEnterResponse(gameId);
+    logBookingFlow('queueApi', 'enterQueue mock response', response);
+    return response;
+  }
+
   try {
     const response = await apiClient.post<ApiEnvelope<QueueEnterResponse>>(
       '/api/v1/queue/enter',
@@ -55,6 +86,12 @@ export const enterQueue = async (gameId: string): Promise<QueueEnterResponse> =>
 /** 대기열 전역 상태 조회 — CDN 1초 캐싱, 인증 불필요 */
 export const getQueueGlobalStatus = async (gameId: string): Promise<QueueStatusResponse> => {
   logBookingFlow('queueApi', 'getQueueGlobalStatus request', { gameId });
+  if (getShouldUseResellQueueMock()) {
+    const response = createMockQueueStatusResponse(gameId);
+    logBookingFlow('queueApi', 'getQueueGlobalStatus mock response', response);
+    return response;
+  }
+
   const response = await apiClient.get<ApiEnvelope<QueueStatusResponse>>(
     `/api/v1/queue/${encodeURIComponent(gameId)}/global-status`,
   );
@@ -65,6 +102,12 @@ export const getQueueGlobalStatus = async (gameId: string): Promise<QueueStatusR
 /** 대기열 실제 상태 조회 — 인증 기반 실시간 상태 */
 export const getQueueStatus = async (gameId: string): Promise<QueueStatusResponse> => {
   logBookingFlow('queueApi', 'getQueueStatus request', { gameId });
+  if (getShouldUseResellQueueMock()) {
+    const response = createMockQueueStatusResponse(gameId);
+    logBookingFlow('queueApi', 'getQueueStatus mock response', response);
+    return response;
+  }
+
   try {
     const response = await apiClient.get<ApiEnvelope<QueueStatusResponse>>(
       `/api/v1/queue/${encodeURIComponent(gameId)}/status`,
@@ -83,6 +126,17 @@ export const seatEnterQueue = async (
   queueToken: string,
 ): Promise<QueueSeatEnterResponse> => {
   logBookingFlow('queueApi', 'seatEnterQueue request', { gameId, queueToken });
+  if (getShouldUseResellQueueMock()) {
+    const response: QueueSeatEnterResponse = {
+      gameId,
+      enterAllowed: true,
+      queueNumber: 1,
+      status: 'ADMITTED',
+    };
+    logBookingFlow('queueApi', 'seatEnterQueue mock response', response);
+    return response;
+  }
+
   try {
     const response = await apiClient.post<ApiEnvelope<QueueSeatEnterResponse>>(
       `/api/v1/queue/${encodeURIComponent(gameId)}/seat-enter`,
@@ -99,6 +153,16 @@ export const seatEnterQueue = async (
 /** 대기열 이탈 — 결제 완료/명시적 종료 시 현재 수용 인원을 해제한다. */
 export const leaveQueue = async (gameId: string): Promise<QueueLeaveResponse> => {
   logBookingFlow('queueApi', 'leaveQueue request', { gameId });
+  if (getShouldUseResellQueueMock()) {
+    const response: QueueLeaveResponse = {
+      gameId,
+      released: true,
+      status: 'LEFT',
+    };
+    logBookingFlow('queueApi', 'leaveQueue mock response', response);
+    return response;
+  }
+
   try {
     const response = await apiClient.post<ApiEnvelope<QueueLeaveResponse>>(
       `/api/v1/queue/${encodeURIComponent(gameId)}/leave`,
@@ -123,6 +187,7 @@ const getLeaveQueueUrl = (gameId: string) => {
  */
 export const leaveQueueKeepalive = (gameId: string) => {
   if (typeof window === 'undefined') return;
+  if (getShouldUseResellQueueMock()) return;
 
   const accessToken = useAuthStore.getState().accessToken;
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };

--- a/src/pages/queue/ui/QueuePage.tsx
+++ b/src/pages/queue/ui/QueuePage.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Lottie from 'lottie-react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { createBookingFlowSearch, getBookingFlowMode } from '@/shared/lib/booking-flow';
 import { logBookingFlow, logBookingFlowError, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
 import { mergeBookingEntryState, useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
-import apiClient from '@/shared/api/client';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import {
   enterQueue,
   getQueueGlobalStatus,
+  leaveQueue,
   leaveQueueKeepalive,
   type QueueEnterResponse,
   seatEnterQueue,
@@ -72,7 +71,7 @@ const scheduleQueueLeave = (gameId: string) => {
   const timeoutId = window.setTimeout(() => {
     pendingLeaveTimeoutIds.delete(gameId);
     clearQueuedEntryCache(gameId);
-    void apiClient.post(`/api/v1/queue/${encodeURIComponent(gameId)}/leave`).catch(() => {});
+    void leaveQueue(gameId).catch(() => {});
   }, 300);
 
   pendingLeaveTimeoutIds.set(gameId, timeoutId);
@@ -154,7 +153,7 @@ const QueuePage = () => {
     () => mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState),
     [routeBookingEntryState, storedBookingEntryState],
   );
-  const bookingFlowMode = getBookingFlowMode(location.search);
+  const bookingFlowMode = bookingEntryState?.bookingFlowMode ?? 'standard';
 
   const [phase, setPhase] = useState<QueuePhase>('entering');
   const [queueToken, setQueueToken] = useState<string | null>(bookingEntryState?.queueTokenJti ?? null);
@@ -319,9 +318,13 @@ const QueuePage = () => {
           } satisfies BookingEntryState;
 
           patchEntry(nextBookingEntryState);
-          logBookingFlow('QueuePage', 'navigate /books with booking entry', summarizeBookingEntry(nextBookingEntryState));
+          const nextPathname = bookingFlowMode === 'resell' ? '/resell-books' : '/books';
+          logBookingFlow('QueuePage', 'navigate booking flow with booking entry', {
+            pathname: nextPathname,
+            bookingEntryState: summarizeBookingEntry(nextBookingEntryState),
+          });
           navigate(
-            { pathname: '/books', search: createBookingFlowSearch(bookingFlowMode) },
+            { pathname: nextPathname },
             { replace: true, state: nextBookingEntryState },
           );
         } else if (res.status === 'EXPIRED') {

--- a/src/pages/resell-books/index.ts
+++ b/src/pages/resell-books/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ui/ResellBooksPage';

--- a/src/pages/resell-books/ui/ResellBooksPage.tsx
+++ b/src/pages/resell-books/ui/ResellBooksPage.tsx
@@ -14,14 +14,14 @@ import type { BookingEntryState } from '@/shared/lib/useBookingEntryStore';
 import BooksExitDialog from '@/shared/widgets/layout/books/BooksExitDialog';
 import { releaseQueueSession } from '@/pages/queue/api/queueApi';
 
-import BookingCaptchaGate from './components/BookingCaptchaGate';
-import BookingZoneDesktopLayout from './components/BookingZoneDesktopLayout';
-import BookingZoneMobileLayout from './components/BookingZoneMobileLayout';
+import BookingCaptchaGate from '@/pages/books/ui/components/BookingCaptchaGate';
+import BookingZoneDesktopLayout from '@/pages/books/ui/components/BookingZoneDesktopLayout';
+import BookingZoneMobileLayout from '@/pages/books/ui/components/BookingZoneMobileLayout';
 
-const BooksPage = () => {
+const ResellBooksPage = () => {
    const navigate = useNavigate();
    const location = useLocation();
-   const bookingFlowMode = 'standard' as const;
+   const bookingFlowMode = 'resell' as const;
    const { bookingEntryState, patchBookingEntry, clearBookingEntry } = useBooksPageEntry();
    const clearAllSelections = useSeatSelectionStore(state => state.clearAllSelections);
    const clearSeatHolds = useSeatHoldStore(state => state.clearSeatHolds);
@@ -43,7 +43,7 @@ const BooksPage = () => {
    const [isZoneDrawerOpen, setIsZoneDrawerOpen] = useState(true);
 
    useEffect(() => {
-      logBookingFlow('BooksPage', 'render snapshot', {
+      logBookingFlow('ResellBooksPage', 'render snapshot', {
          pathname: location.pathname,
          search: location.search,
          bookingFlowMode,
@@ -53,7 +53,7 @@ const BooksPage = () => {
          selectedZoneId,
          isSeatGradeBotBlocked,
       });
-   }, [bookingEntryState, bookingFlowMode, isSeatGradeBotBlocked, location.pathname, location.search, requiresCaptcha, selectedZoneId, zones.length]);
+   }, [bookingEntryState, isSeatGradeBotBlocked, location.pathname, location.search, requiresCaptcha, selectedZoneId, zones.length]);
 
    useEffect(() => {
       setSelectedZoneId(zones.find(zone => zone.remaining > 0)?.id ?? zones[0]?.id ?? '');
@@ -82,14 +82,15 @@ const BooksPage = () => {
 
       return {
          ...bookingEntryState,
+         bookingFlowMode,
          requireCaptcha: undefined,
          forceNewSession: undefined,
          bookingZones: zones,
       } satisfies BookingEntryState;
-   }, [bookingEntryState, zones]);
+   }, [bookingEntryState, bookingFlowMode, zones]);
 
    const exitBookingFlow = async () => {
-      logBookingFlow('BooksPage', 'exitBookingFlow');
+      logBookingFlow('ResellBooksPage', 'exitBookingFlow');
       clearTimer();
       clearSeatHolds();
       clearAllSelections();
@@ -103,7 +104,7 @@ const BooksPage = () => {
       location,
       navigate,
       onCaptchaResolved: () => {
-         logBookingFlow('BooksPage', 'captcha resolved');
+         logBookingFlow('ResellBooksPage', 'captcha resolved');
          patchBookingEntry({
             forceNewSession: undefined,
             requireCaptcha: undefined,
@@ -122,8 +123,8 @@ const BooksPage = () => {
 
       hasShownBotBlockedAlertRef.current = true;
       window.alert('매크로 사용 시 예매에 접근할 수 없습니다.');
-      exitBookingFlow();
-   }, [exitBookingFlow, isSeatGradeBotBlocked]);
+      void exitBookingFlow();
+   }, [isSeatGradeBotBlocked]);
 
    useEffect(() => {
       if (captcha.isCaptchaOpen) {
@@ -132,7 +133,7 @@ const BooksPage = () => {
    }, [captcha.isCaptchaOpen]);
 
    const handleSelectZone = (zoneId: string) => {
-      logBookingFlow('BooksPage', 'handleSelectZone', {
+      logBookingFlow('ResellBooksPage', 'handleSelectZone', {
          zoneId,
          bookingEntryState: summarizeBookingEntry(resolvedBookingEntryState),
       });
@@ -145,7 +146,7 @@ const BooksPage = () => {
       setSelectedZoneId(zoneId);
       navigate(
          {
-            pathname: `/books/seats/${zoneId}`,
+            pathname: `/resell-books/seats/${zoneId}`,
          },
          {
             state: resolvedBookingEntryState,
@@ -180,6 +181,7 @@ const BooksPage = () => {
             onSelectZone={handleSelectZone}
             stadiumImage={bookingTeamConfig.stadiumImage}
             stadiumImageAlt={bookingTeamConfig.stadiumImageAlt}
+            showPrice={false}
          />
          <BookingZoneDesktopLayout
             zones={zones}
@@ -187,9 +189,10 @@ const BooksPage = () => {
             onSelectZone={handleSelectZone}
             stadiumImage={bookingTeamConfig.stadiumImage}
             stadiumImageAlt={bookingTeamConfig.stadiumImageAlt}
+            showPrice={false}
          />
       </div>
    );
 };
 
-export default BooksPage;
+export default ResellBooksPage;

--- a/src/pages/resell-books/ui/ResellSeatsPage.tsx
+++ b/src/pages/resell-books/ui/ResellSeatsPage.tsx
@@ -1,0 +1,278 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import type { SeatItem } from '@/pages/books/model/types';
+import { buildResellPaymentEntry } from '@/pages/books/model/buildSeatPaymentEntry';
+import { useResellSeatSelection } from '@/pages/books/model/useResellSeatSelection';
+import { useSeatMapLayout } from '@/pages/books/model/useSeatMapLayout';
+import { useSeatMapViewport } from '@/pages/books/model/useSeatMapViewport';
+import { useSeatsPageEntry } from '@/pages/books/model/useSeatsPageEntry';
+import { useZoneSeatState } from '@/pages/books/model/useZoneSeatState';
+import { logBookingFlow, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
+import { useBotDetector } from '@/shared/lib/useBotDetector';
+import { Drawer, DrawerContent, DrawerTrigger } from '@/shared/ui/drawer';
+
+import ResellSeatSidebar from '@/pages/books/ui/components/ResellSeatSidebar';
+import ResellZonePreviewSheet from '@/pages/books/ui/components/ResellZonePreviewSheet';
+import SeatMapStage from '@/pages/books/ui/components/SeatMapStage';
+
+function ResellSeatsPage() {
+   const navigate = useNavigate();
+   const { zoneId = '' } = useParams();
+   const { getBotReport } = useBotDetector();
+   const botData = getBotReport() ?? undefined;
+   const { bookingEntryState, bookingZones, stadiumName, zone, zoneOverviewImage } = useSeatsPageEntry(zoneId);
+   const {
+      isSeatInteractionLocked,
+      pendingSeatIds,
+      seatBlocks,
+      seats,
+   } = useZoneSeatState({
+      bookingEntryState,
+      bookingZones,
+      preferMockSeatMap: true,
+      zone,
+   });
+   const [isSeatDrawerOpen, setIsSeatDrawerOpen] = useState(true);
+   const resellSeatSelection = useResellSeatSelection({
+      bookingEntryState,
+      isResellMode: true,
+      isSeatInteractionLocked,
+      seats,
+      zone,
+   });
+   const baseSeatMapLayout = useSeatMapLayout({
+      mapViewportSize: { width: 0, height: 0 },
+      seatBlocks,
+      seatMapOffset: { x: 0, y: 0 },
+      seatMapScale: 1,
+   });
+   const seatMapViewport = useSeatMapViewport({
+      sectionBounds: baseSeatMapLayout.sectionBounds,
+      stageWidth: baseSeatMapLayout.stageSize.width,
+      zoneId: zone.id,
+   });
+   const seatMapLayout = useSeatMapLayout({
+      mapViewportSize: seatMapViewport.mapViewportSize,
+      seatBlocks,
+      seatMapOffset: seatMapViewport.seatMapOffset,
+      seatMapScale: seatMapViewport.seatMapScale,
+   });
+
+   useEffect(() => {
+      logBookingFlow('ResellSeatsPage', 'render snapshot', {
+         zoneId,
+         bookingEntryState: summarizeBookingEntry(bookingEntryState),
+         bookingZoneCount: bookingZones.length,
+         selectedSeatCount: resellSeatSelection.selectedSeatCount,
+         allSelectedSeatsAreHeld:
+            Boolean(resellSeatSelection.selectedResellListing) && Boolean(resellSeatSelection.selectedResellHoldId),
+         isSeatInteractionLocked,
+         isResellInsightsPending: resellSeatSelection.resellInsightsQuery.isPending,
+      });
+   }, [bookingEntryState, bookingZones.length, isSeatInteractionLocked, resellSeatSelection.resellInsightsQuery.isPending, resellSeatSelection.selectedResellHoldId, resellSeatSelection.selectedResellListing, resellSeatSelection.selectedSeatCount, zoneId]);
+
+   useEffect(() => {
+      const mediaQuery = window.matchMedia('(min-width: 1280px)');
+      const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+         if (event.matches) {
+            setIsSeatDrawerOpen(false);
+         }
+      };
+
+      handleChange(mediaQuery);
+      mediaQuery.addEventListener('change', handleChange);
+
+      return () => {
+         mediaQuery.removeEventListener('change', handleChange);
+      };
+   }, []);
+
+   const handleProceedToPayment = () => {
+      logBookingFlow('ResellSeatsPage', 'handleProceedToPayment', {
+         selectedSeatCount: resellSeatSelection.selectedSeatCount,
+         bookingEntryState: summarizeBookingEntry(bookingEntryState),
+      });
+      if (!resellSeatSelection.selectedResellListing) {
+         return;
+      }
+
+      resellSeatSelection.persistResellHoldRef.current = true;
+      navigate('/tickets/resell-payment', {
+         state: buildResellPaymentEntry({
+            bookingEntryState,
+            botData,
+            holdId: resellSeatSelection.selectedResellHoldId,
+            listing: resellSeatSelection.selectedResellListing,
+         }),
+      });
+   };
+
+   const toggleSeat = (seat: SeatItem) => {
+      logBookingFlow('ResellSeatsPage', 'toggleSeat', {
+         seat,
+         isSeatInteractionLocked,
+         pendingSeatIds,
+      });
+      if (isSeatInteractionLocked) {
+         return;
+      }
+
+      if (pendingSeatIds.includes(seat.id) || resellSeatSelection.isResellHoldPending) {
+         return;
+      }
+
+      if (seat.status === 'disabled' || seat.status === 'held') {
+         return;
+      }
+
+      const listing = resellSeatSelection.seatIdByResellListingId
+         ? resellSeatSelection.resellInsights?.listings.find(
+              item => resellSeatSelection.seatIdByResellListingId.get(item.listingId) === seat.id,
+           )
+         : null;
+
+      if (!listing) {
+         return;
+      }
+
+      void resellSeatSelection.handleSelectResellListing(seat.id, listing);
+   };
+
+   return (
+      <div className="w-full bg-background text-foreground">
+         <main className="flex min-h-[calc(100vh-140px)] flex-col xl:h-[calc(100vh-140px)] xl:flex-row">
+            <section className="relative flex min-h-[660px] flex-1 flex-col overflow-hidden bg-[#eef0f3] xl:min-h-[680px]">
+               <div className="flex items-center justify-between gap-4 px-5 py-5 lg:px-8 lg:py-3">
+                  <div className="inline-flex min-w-0 items-center gap-2 rounded-[12px] bg-background px-4 py-2 shadow-[0_1px_2px_rgba(15,23,42,0.04)] lg:px-3">
+                     <span className="inline-flex items-center justify-center rounded-[8px] bg-primary-light px-2 py-1 text-caption-1-bold text-primary">
+                        선택 구역
+                     </span>
+                     <span className="truncate text-body-1-bold text-foreground">{zone.name}</span>
+                  </div>
+               </div>
+
+               <div className="relative flex-1 overflow-hidden px-0 pb-[144px] lg:px-8 lg:pb-6 xl:pb-6">
+                  <SeatMapStage
+                     directionBadgePosition={seatMapLayout.directionBadgePosition}
+                     isSeatMapDragging={seatMapViewport.isSeatMapDragging}
+                     mapViewportRef={seatMapViewport.mapViewportRef}
+                     minimapLayout={seatMapLayout.minimapLayout}
+                     minimapViewport={seatMapLayout.minimapViewport}
+                     seatBlocks={seatBlocks}
+                     seatMapOffset={seatMapViewport.seatMapOffset}
+                     seatMapScale={seatMapViewport.seatMapScale}
+                     stageSize={seatMapLayout.stageSize}
+                     seats={resellSeatSelection.displaySeats}
+                     selectedSeatIdSet={resellSeatSelection.selectedSeatIdSet}
+                     zoneColor={zone.color}
+                     zoneName={zone.name}
+                     onMapPointerDown={seatMapViewport.onMapPointerDown}
+                     onMapPointerMove={seatMapViewport.onMapPointerMove}
+                     onMapPointerUp={seatMapViewport.onMapPointerUp}
+                     onResetSeatMapView={seatMapViewport.resetSeatMapView}
+                     onToggleSeat={toggleSeat}
+                     onUpdateSeatMapScale={seatMapViewport.onUpdateSeatMapScale}
+                  />
+               </div>
+
+               <Drawer open={isSeatDrawerOpen} onOpenChange={setIsSeatDrawerOpen} modal={false}>
+                  {!isSeatDrawerOpen ? (
+                     <div className="absolute inset-x-0 bottom-0 z-10 xl:hidden">
+                        <DrawerTrigger asChild>
+                           <button
+                              type="button"
+                              className="w-full rounded-t-[16px] bg-elevated px-5 py-4 text-left shadow-[0_-6px_24px_rgba(0,0,0,0.16)]"
+                           >
+                              <div className="mb-3 flex justify-center" aria-hidden="true">
+                                 <div className="h-1 w-9 rounded-full bg-border-light" />
+                              </div>
+                              <div className="flex items-center justify-between gap-3">
+                                 <div className="flex items-center gap-1 text-heading-3-bold text-foreground">
+                                    <span>리셀 예매</span>
+                                    <span className="text-primary">{resellSeatSelection.selectedSeatCount}</span>
+                                 </div>
+                                 <span className="text-body-1-medium text-tertiary">
+                                    {resellSeatSelection.selectedSeatCount > 0
+                                       ? `${resellSeatSelection.summaryPrice.toLocaleString('ko-KR')}원`
+                                       : '열기'}
+                                 </span>
+                              </div>
+                           </button>
+                        </DrawerTrigger>
+                     </div>
+                  ) : null}
+                  <DrawerContent
+                     showOverlay={false}
+                     resizable
+                     defaultHeight={488}
+                     minHeight={280}
+                     maxHeight={560}
+                     className="overflow-hidden border-none p-0 xl:hidden"
+                  >
+                     <div className="h-full overflow-y-auto">
+                        {resellSeatSelection.resellInsightsQuery.isPending ? (
+                           <div className="flex h-full min-h-[240px] items-center justify-center px-5 text-center text-body-1-medium text-muted-foreground">
+                              리셀 좌석 정보를 불러오는 중입니다.
+                           </div>
+                        ) : resellSeatSelection.resellInsightsQuery.isError ? (
+                           <div className="flex h-full min-h-[240px] items-center justify-center px-5 text-center text-body-1-medium text-muted-foreground">
+                              리셀 좌석 정보를 불러오지 못했습니다.
+                           </div>
+                        ) : resellSeatSelection.resellInsights ? (
+                           <ResellZonePreviewSheet
+                              insights={resellSeatSelection.resellInsights}
+                              zone={zone}
+                              selectedListingId={resellSeatSelection.selectedResellListing?.listingId}
+                              onSelectListing={listing => {
+                                 const mappedSeatId = resellSeatSelection.seatIdByResellListingId.get(listing.listingId);
+
+                                 if (!mappedSeatId) {
+                                    return;
+                                 }
+
+                                 void resellSeatSelection.handleSelectResellListing(mappedSeatId, listing);
+                              }}
+                              submitLabel="예매하기"
+                              submitDisabled={!resellSeatSelection.selectedResellListing}
+                              onSubmit={handleProceedToPayment}
+                           />
+                        ) : null}
+                     </div>
+                  </DrawerContent>
+               </Drawer>
+            </section>
+
+            {resellSeatSelection.resellInsightsQuery.isPending ? (
+               <aside className="hidden w-full shrink-0 items-center justify-center border-l border-border-light bg-background px-5 text-center text-body-1-medium text-muted-foreground xl:flex xl:w-[420px]">
+                  리셀 좌석 정보를 불러오는 중입니다.
+               </aside>
+            ) : resellSeatSelection.resellInsights ? (
+               <ResellSeatSidebar
+                  insights={resellSeatSelection.resellInsights}
+                  selectedListingId={resellSeatSelection.selectedResellListing?.listingId}
+                  zone={zone}
+                  zoneOverviewImage={zoneOverviewImage}
+                  stadiumName={stadiumName}
+                  onSelectListing={listing => {
+                     const mappedSeatId = resellSeatSelection.seatIdByResellListingId.get(listing.listingId);
+
+                     if (!mappedSeatId) {
+                        return;
+                     }
+
+                     void resellSeatSelection.handleSelectResellListing(mappedSeatId, listing);
+                  }}
+                  onSubmit={handleProceedToPayment}
+               />
+            ) : resellSeatSelection.resellInsightsQuery.isError ? (
+               <aside className="hidden w-full shrink-0 items-center justify-center border-l border-border-light bg-background px-5 text-center text-body-1-medium text-muted-foreground xl:flex xl:w-[420px]">
+                  리셀 좌석 정보를 불러오지 못했습니다.
+               </aside>
+            ) : null}
+         </main>
+      </div>
+   );
+}
+
+export default ResellSeatsPage;

--- a/src/pages/tickets/api/paymentApi.ts
+++ b/src/pages/tickets/api/paymentApi.ts
@@ -11,6 +11,16 @@ import { type StoredPaymentCompleteItem } from '@/shared/lib/paymentCompleteStor
 import { resolveUserIdFromJwt } from '@/shared/lib/jwt';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
+import { isResaleDemoEnabled } from '@/shared/config/runtime';
+import {
+   completeDemoResaleOrder,
+   createDemoResaleHold,
+   createDemoResaleOrder,
+   createDemoResalePayment,
+   getDemoResaleTransactions,
+   releaseDemoResaleHold,
+   releaseDemoResaleHoldSync,
+} from '@/shared/lib/demo/resaleDemo';
 
 interface CheckoutFormRequest {
    deliveryMethod: 'mobile' | 'onsite' | 'delivery';
@@ -250,12 +260,20 @@ const createOrderPayment = async (orderId: string, payload: OrderPaymentRequest)
 };
 
 const createResaleHold = async (payload: ResaleHoldRequest) => {
+   if (isResaleDemoEnabled) {
+      return createDemoResaleHold(payload.listingId, payload.queueTokenJti);
+   }
+
    const response = await apiClient.post<ApiEnvelope<ResaleHoldResponse>>('/api/v1/resales/holds', payload);
 
    return response.data.data;
 };
 
 export const releaseResaleHold = async (holdId: string) => {
+   if (isResaleDemoEnabled) {
+      return releaseDemoResaleHold(holdId);
+   }
+
    const response = await apiClient.patch<ApiEnvelope<ResaleHoldResponse>>(
       `/api/v1/resales/holds/${encodeURIComponent(holdId)}/release`,
    );
@@ -265,6 +283,11 @@ export const releaseResaleHold = async (holdId: string) => {
 
 export const releaseResaleHoldKeepalive = (holdId: string) => {
    if (typeof window === 'undefined') {
+      return;
+   }
+
+   if (isResaleDemoEnabled) {
+      releaseDemoResaleHoldSync(holdId);
       return;
    }
 
@@ -279,6 +302,13 @@ export const releaseResaleHoldKeepalive = (holdId: string) => {
 };
 
 const createResaleOrder = async (payload: ResaleOrderRequest) => {
+   if (isResaleDemoEnabled) {
+      return createDemoResaleOrder({
+         holdIds: payload.holdIds,
+         buyerId: resolveUserIdFromJwt(useAuthStore.getState().accessToken) ?? payload.buyerEmail,
+      });
+   }
+
    const response = await apiClient.post<ApiEnvelope<ResaleOrderResponse>>('/api/v1/resales/orders', payload);
 
    return response.data.data;
@@ -301,6 +331,10 @@ const normalizeTransactionIds = (payload: unknown): string[] => {
 };
 
 const getResaleTransactions = async (orderId: string) => {
+   if (isResaleDemoEnabled) {
+      return getDemoResaleTransactions(orderId);
+   }
+
    const response = await apiClient.get<ApiEnvelope<ResaleOrderTransactionsResponse | string[]>>(
       `/api/v1/resales/orders/${orderId}/transactions`,
    );
@@ -325,6 +359,13 @@ const getResaleTransactionsWithRetry = async (orderId: string, attempts = 5): Pr
 };
 
 const createResalePayment = async (payload: ResalePaymentRequest) => {
+   if (isResaleDemoEnabled) {
+      return createDemoResalePayment({
+         orderId: payload.orderId,
+         paymentMethod: payload.paymentMethod as PaymentMethodCode,
+      });
+   }
+
    const response = await apiClient.post<ApiEnvelope<OrderPaymentResponse>>('/api/v1/payments/resales', payload);
 
    return response.data.data;
@@ -345,6 +386,10 @@ type CompleteResaleOrderResponse = {
 };
 
 const completeResaleOrder = async (orderId: string, paymentId: string): Promise<CompleteResaleOrderResponse> => {
+   if (isResaleDemoEnabled) {
+      return completeDemoResaleOrder(orderId);
+   }
+
    const response = await apiClient.patch<ApiEnvelope<CompleteResaleOrderResponse>>(
       `/api/v1/resales/orders/${encodeURIComponent(orderId)}/complete`,
       undefined,

--- a/src/pages/tickets/api/paymentApi.ts
+++ b/src/pages/tickets/api/paymentApi.ts
@@ -11,7 +11,7 @@ import { type StoredPaymentCompleteItem } from '@/shared/lib/paymentCompleteStor
 import { resolveUserIdFromJwt } from '@/shared/lib/jwt';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
-import { isResaleDemoEnabled } from '@/shared/config/runtime';
+import { isResaleBookingMockEnabled, isResaleDemoEnabled } from '@/shared/config/runtime';
 import {
    completeDemoResaleOrder,
    createDemoResaleHold,
@@ -173,6 +173,7 @@ type ResalePaymentRequest = {
 
 type PaymentMethodCode = 'CARD' | 'ACCOUNT_TRANSFER';
 const PAYMENT_COMPLETE_STORAGE_KEY = 'ticket-payment-complete';
+const shouldUseResaleBookingMock = isResaleDemoEnabled || isResaleBookingMockEnabled;
 
 const formatOrderedAt = (date: Date) => {
    const pad = (n: number) => String(n).padStart(2, '0');
@@ -260,7 +261,7 @@ const createOrderPayment = async (orderId: string, payload: OrderPaymentRequest)
 };
 
 const createResaleHold = async (payload: ResaleHoldRequest) => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return createDemoResaleHold(payload.listingId, payload.queueTokenJti);
    }
 
@@ -270,7 +271,7 @@ const createResaleHold = async (payload: ResaleHoldRequest) => {
 };
 
 export const releaseResaleHold = async (holdId: string) => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return releaseDemoResaleHold(holdId);
    }
 
@@ -286,7 +287,7 @@ export const releaseResaleHoldKeepalive = (holdId: string) => {
       return;
    }
 
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       releaseDemoResaleHoldSync(holdId);
       return;
    }
@@ -302,7 +303,7 @@ export const releaseResaleHoldKeepalive = (holdId: string) => {
 };
 
 const createResaleOrder = async (payload: ResaleOrderRequest) => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return createDemoResaleOrder({
          holdIds: payload.holdIds,
          buyerId: resolveUserIdFromJwt(useAuthStore.getState().accessToken) ?? payload.buyerEmail,
@@ -331,7 +332,7 @@ const normalizeTransactionIds = (payload: unknown): string[] => {
 };
 
 const getResaleTransactions = async (orderId: string) => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return getDemoResaleTransactions(orderId);
    }
 
@@ -359,7 +360,7 @@ const getResaleTransactionsWithRetry = async (orderId: string, attempts = 5): Pr
 };
 
 const createResalePayment = async (payload: ResalePaymentRequest) => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return createDemoResalePayment({
          orderId: payload.orderId,
          paymentMethod: payload.paymentMethod as PaymentMethodCode,
@@ -386,7 +387,7 @@ type CompleteResaleOrderResponse = {
 };
 
 const completeResaleOrder = async (orderId: string, paymentId: string): Promise<CompleteResaleOrderResponse> => {
-   if (isResaleDemoEnabled) {
+   if (shouldUseResaleBookingMock) {
       return completeDemoResaleOrder(orderId);
    }
 

--- a/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentCompletePage.tsx
@@ -119,6 +119,10 @@ const isResalePaymentResponse = (order: PaymentResponse | null) => {
    return order.orderId?.toLowerCase().includes('resale') ?? false;
 };
 
+const isDemoResaleOrderId = (orderId: string | null) => {
+   return orderId?.startsWith('demo-resale-order-') ?? false;
+};
+
 const ENTRANCE_GUIDES: Record<DeliveryMethod, string[]> = {
    mobile: [
       '경기 시작 2시간 전부터 입장 가능합니다',
@@ -299,7 +303,7 @@ export default function PaymentCompletePage() {
 
       const fallbackOrder = locationOrder ?? readStoredPaymentCompleteState(orderId);
 
-      if (!orderId || !isResalePaymentResponse(fallbackOrder)) {
+      if (!orderId || !isResalePaymentResponse(fallbackOrder) || isDemoResaleOrderId(orderId)) {
          return;
       }
 

--- a/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
+++ b/src/pages/tickets/ui/payment/PaymentProcessingPage.tsx
@@ -169,6 +169,7 @@ export default function PaymentProcessingPage() {
             void queryClient.invalidateQueries({ queryKey: ['resales', 'game-counts'] });
             void queryClient.invalidateQueries({ queryKey: ['resales', 'listing-market'] });
             void queryClient.invalidateQueries({ queryKey: ['myResales'] });
+            void queryClient.invalidateQueries({ queryKey: ['myOrders'] });
          }
 
          useSeatHoldStore.getState().clearSeatHolds();

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -25,7 +25,7 @@ const authorizationOptionalApiPaths = new Set([
   "/api/v1/auth/signup/sms/send",
   tokenReissuePath,
 ]);
-const shouldKeepSessionAlivePathPrefixes = ["/books", "/tickets"];
+const shouldKeepSessionAlivePathPrefixes = ["/books", "/resell-books", "/tickets"];
 const PUBLIC_API_PATH_PATTERNS = [
   /^\/api\/v1\/games(?:\/|$)/,
   /^\/api\/v1\/baseball-teams(?:\/|$)/,

--- a/src/shared/api/mocks/handlers/game.ts
+++ b/src/shared/api/mocks/handlers/game.ts
@@ -20,29 +20,12 @@ type MockGameSchedule = {
   awayTeamDisplayName: string;
   stadiumLocation: string;
 };
-
-const formatLocalDate = (value: Date) => {
-  const year = value.getFullYear();
-  const month = String(value.getMonth() + 1).padStart(2, '0');
-  const day = String(value.getDate()).padStart(2, '0');
-
-  return `${year}-${month}-${day}`;
-};
-
-const formatLocalDateTime = (offsetDays: number, hour: number, minute: number) => {
-  const value = new Date();
-  value.setDate(value.getDate() + offsetDays);
-  value.setHours(hour, minute, 0, 0);
-
-  return `${formatLocalDate(value)} ${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
-};
-
-const MOCK_TODAY = formatLocalDate(new Date());
+const MOCK_TODAY = '2026-04-09';
 
 export const mockGameSchedules: MockGameSchedule[] = [
   {
     gameId: 'game-kia-home-yesterday',
-    startAt: formatLocalDateTime(-1, 18, 30),
+    startAt: '2026-04-08 18:30',
     leagueType: 'REGULAR',
     homeTeamId: 'e5f58f8c-fcde-4017-8033-d8deb34fd4a2',
     awayTeamId: 'f44d1e89-e2fe-40e7-a587-1157d7a9c80a',
@@ -61,7 +44,7 @@ export const mockGameSchedules: MockGameSchedule[] = [
   },
   {
     gameId: 'game-samsung-home-today',
-    startAt: formatLocalDateTime(0, 18, 30),
+    startAt: '2026-04-09 18:30',
     leagueType: 'REGULAR',
     homeTeamId: '412cfc77-2c5d-4583-8e79-968339223864',
     awayTeamId: 'd64b4220-6479-4e77-986a-f52447a433a6',
@@ -70,9 +53,9 @@ export const mockGameSchedules: MockGameSchedule[] = [
     homeTeamScore: 0,
     awayTeamScore: 0,
     gameResult: 'DRAW',
-    ticketingStatus: 'AVAILABLE',
-    ticketingOpenedAt: formatLocalDateTime(-7, 11, 0),
-    ticketingEndAt: formatLocalDateTime(0, 14, 30),
+    ticketingStatus: 'TERMINATED',
+    ticketingOpenedAt: '2026-04-02 11:00',
+    ticketingEndAt: '2026-04-09 14:30',
     remainingSeatCount: 12543,
     homeTeamDisplayName: '삼성',
     awayTeamDisplayName: 'NC',
@@ -80,7 +63,7 @@ export const mockGameSchedules: MockGameSchedule[] = [
   },
   {
     gameId: 'game-kia-home-tomorrow',
-    startAt: formatLocalDateTime(1, 18, 30),
+    startAt: '2026-04-10 18:30',
     leagueType: 'REGULAR',
     homeTeamId: 'e5f58f8c-fcde-4017-8033-d8deb34fd4a2',
     awayTeamId: '520af775-e84b-4112-aa02-18ed1a6c8458',
@@ -90,8 +73,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     awayTeamScore: 0,
     gameResult: 'DRAW',
     ticketingStatus: 'AVAILABLE',
-    ticketingOpenedAt: formatLocalDateTime(-6, 11, 0),
-    ticketingEndAt: formatLocalDateTime(1, 14, 30),
+    ticketingOpenedAt: '2026-04-03 11:00',
+    ticketingEndAt: '2026-04-10 14:30',
     remainingSeatCount: 9632,
     homeTeamDisplayName: 'KIA',
     awayTeamDisplayName: 'SSG',
@@ -99,7 +82,7 @@ export const mockGameSchedules: MockGameSchedule[] = [
   },
   {
     gameId: 'game-samsung-home-this-weekend',
-    startAt: formatLocalDateTime(3, 14, 0),
+    startAt: '2026-04-12 14:00',
     leagueType: 'REGULAR',
     homeTeamId: '412cfc77-2c5d-4583-8e79-968339223864',
     awayTeamId: '1e4022c6-3887-44f6-b510-d98aad5a4192',
@@ -109,8 +92,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     awayTeamScore: 0,
     gameResult: 'DRAW',
     ticketingStatus: 'AVAILABLE',
-    ticketingOpenedAt: formatLocalDateTime(-4, 11, 0),
-    ticketingEndAt: formatLocalDateTime(3, 10, 0),
+    ticketingOpenedAt: '2026-04-05 11:00',
+    ticketingEndAt: '2026-04-12 10:00',
     remainingSeatCount: 10124,
     homeTeamDisplayName: '삼성',
     awayTeamDisplayName: '키움',
@@ -118,7 +101,7 @@ export const mockGameSchedules: MockGameSchedule[] = [
   },
   {
     gameId: 'game-kia-home-next-week',
-    startAt: formatLocalDateTime(8, 18, 30),
+    startAt: '2026-04-17 18:30',
     leagueType: 'REGULAR',
     homeTeamId: 'e5f58f8c-fcde-4017-8033-d8deb34fd4a2',
     awayTeamId: 'd64b4220-6479-4e77-986a-f52447a433a6',
@@ -128,8 +111,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     awayTeamScore: 0,
     gameResult: 'DRAW',
     ticketingStatus: 'AVAILABLE',
-    ticketingOpenedAt: formatLocalDateTime(1, 11, 0),
-    ticketingEndAt: formatLocalDateTime(8, 14, 30),
+    ticketingOpenedAt: '2026-04-10 11:00',
+    ticketingEndAt: '2026-04-17 14:30',
     remainingSeatCount: 8740,
     homeTeamDisplayName: 'KIA',
     awayTeamDisplayName: 'NC',
@@ -137,7 +120,7 @@ export const mockGameSchedules: MockGameSchedule[] = [
   },
   {
     gameId: 'game-samsung-home-next-weekend',
-    startAt: formatLocalDateTime(9, 17, 0),
+    startAt: '2026-04-18 17:00',
     leagueType: 'REGULAR',
     homeTeamId: '412cfc77-2c5d-4583-8e79-968339223864',
     awayTeamId: 'f44d1e89-e2fe-40e7-a587-1157d7a9c80a',
@@ -147,8 +130,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     awayTeamScore: 0,
     gameResult: 'DRAW',
     ticketingStatus: 'SCHEDULED',
-    ticketingOpenedAt: formatLocalDateTime(5, 11, 0),
-    ticketingEndAt: formatLocalDateTime(9, 13, 0),
+    ticketingOpenedAt: '2026-04-14 11:00',
+    ticketingEndAt: '2026-04-18 13:00',
     remainingSeatCount: 11032,
     homeTeamDisplayName: '삼성',
     awayTeamDisplayName: 'LG',
@@ -156,7 +139,7 @@ export const mockGameSchedules: MockGameSchedule[] = [
   },
   {
     gameId: 'game-kia-home-two-weeks',
-    startAt: formatLocalDateTime(14, 18, 30),
+    startAt: '2026-04-23 18:30',
     leagueType: 'REGULAR',
     homeTeamId: 'e5f58f8c-fcde-4017-8033-d8deb34fd4a2',
     awayTeamId: '34159d27-2497-44d4-a4a2-c461dc3585c8',
@@ -166,8 +149,8 @@ export const mockGameSchedules: MockGameSchedule[] = [
     awayTeamScore: 0,
     gameResult: 'DRAW',
     ticketingStatus: 'AVAILABLE',
-    ticketingOpenedAt: formatLocalDateTime(8, 11, 0),
-    ticketingEndAt: formatLocalDateTime(14, 14, 30),
+    ticketingOpenedAt: '2026-04-17 11:00',
+    ticketingEndAt: '2026-04-23 14:30',
     remainingSeatCount: 11876,
     homeTeamDisplayName: 'KIA',
     awayTeamDisplayName: '두산',
@@ -176,25 +159,6 @@ export const mockGameSchedules: MockGameSchedule[] = [
 ];
 
 const matchesCalendarDate = (startAt: string, date: string) => startAt.slice(0, 10) === date;
-
-/** 현재 시각 기준으로 경기 상태와 티켓팅 상태를 동적으로 계산 */
-const resolveGameStatus = (game: MockGameSchedule): Pick<MockGameSchedule, 'gameStatus' | 'ticketingStatus'> => {
-  const now = Date.now();
-  const startMs = new Date(game.startAt.replace(' ', 'T')).getTime();
-  const GAME_DURATION_MS = 3 * 60 * 60 * 1000;   // 경기 지속 시간: 3시간
-  const TICKETING_CLOSE_MS = 4 * 60 * 60 * 1000; // 경기 시작 4시간 전 티켓팅 마감
-
-  if (now >= startMs + GAME_DURATION_MS) {
-    return { gameStatus: 'FINISHED', ticketingStatus: 'TERMINATED' };
-  }
-  if (now >= startMs) {
-    return { gameStatus: 'IN_PROGRESS', ticketingStatus: 'TERMINATED' };
-  }
-  if (now >= startMs - TICKETING_CLOSE_MS) {
-    return { gameStatus: 'SCHEDULED', ticketingStatus: 'TERMINATED' };
-  }
-  return { gameStatus: game.gameStatus, ticketingStatus: game.ticketingStatus };
-};
 
 export const gameHandlers = [
   http.get('/api/v1/games/schedules', async ({ request }) => {
@@ -227,8 +191,7 @@ export const gameHandlers = [
         }
 
         return true;
-      })
-      .map((game) => ({ ...game, ...resolveGameStatus(game) }));
+      });
 
     return HttpResponse.json({
       code: 'SUCCESS',

--- a/src/shared/api/mocks/handlers/payment.ts
+++ b/src/shared/api/mocks/handlers/payment.ts
@@ -266,6 +266,20 @@ const seatGradesByStadium: Record<string, SeatGrade[]> = {
          availableSeatCount: 24,
       },
       {
+         seatGradeId: 'grade-kia-tigers-family',
+         stadiumId: 'stadium-kia-champions-field',
+         name: '타이거즈가족석',
+         displayColorHex: '#7B3A99',
+         availableSeatCount: 34,
+      },
+      {
+         seatGradeId: 'grade-kia-surprise-zone',
+         stadiumId: 'stadium-kia-champions-field',
+         name: '서프라이즈존',
+         displayColorHex: '#0A005F',
+         availableSeatCount: 41,
+      },
+      {
          seatGradeId: 'grade-kia-party',
          stadiumId: 'stadium-kia-champions-field',
          name: '파티석',
@@ -287,6 +301,27 @@ const seatGradesByStadium: Record<string, SeatGrade[]> = {
          availableSeatCount: 47,
       },
       {
+         seatGradeId: 'grade-kia-ev',
+         stadiumId: 'stadium-kia-champions-field',
+         name: 'EV석',
+         displayColorHex: '#9574C1',
+         availableSeatCount: 52,
+      },
+      {
+         seatGradeId: 'grade-kia-outfield-free',
+         stadiumId: 'stadium-kia-champions-field',
+         name: '외야자유석',
+         displayColorHex: '#6CBE88',
+         availableSeatCount: 88,
+      },
+      {
+         seatGradeId: 'grade-kia-outfield-family',
+         stadiumId: 'stadium-kia-champions-field',
+         name: '외야가족석',
+         displayColorHex: '#4F9F72',
+         availableSeatCount: 20,
+      },
+      {
          seatGradeId: 'grade-kia-wheelchair',
          stadiumId: 'stadium-kia-champions-field',
          name: '휠체어석',
@@ -296,6 +331,20 @@ const seatGradesByStadium: Record<string, SeatGrade[]> = {
    ],
    'stadium-samsung-lions-park': [
       {
+         seatGradeId: 'grade-samsung-first-base-exciting',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '1루 익사이팅석',
+         displayColorHex: '#0A8AD8',
+         availableSeatCount: 186,
+      },
+      {
+         seatGradeId: 'grade-samsung-third-base-exciting',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '3루 익사이팅석',
+         displayColorHex: '#17A2C7',
+         availableSeatCount: 174,
+      },
+      {
          seatGradeId: 'grade-samsung-first-base-infield',
          stadiumId: 'stadium-samsung-lions-park',
          name: '1루 내야지정석',
@@ -303,11 +352,39 @@ const seatGradesByStadium: Record<string, SeatGrade[]> = {
          availableSeatCount: 341,
       },
       {
+         seatGradeId: 'grade-samsung-third-base-infield',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '3루 내야지정석',
+         displayColorHex: '#145EB8',
+         availableSeatCount: 324,
+      },
+      {
          seatGradeId: 'grade-samsung-blue-zone',
          stadiumId: 'stadium-samsung-lions-park',
          name: '블루존',
          displayColorHex: '#1F4D93',
          availableSeatCount: 127,
+      },
+      {
+         seatGradeId: 'grade-samsung-away-zone',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '원정 응원석',
+         displayColorHex: '#5B6DB2',
+         availableSeatCount: 96,
+      },
+      {
+         seatGradeId: 'grade-samsung-sky-lower',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: 'SKY 하단 지정석',
+         displayColorHex: '#5A7EE0',
+         availableSeatCount: 288,
+      },
+      {
+         seatGradeId: 'grade-samsung-sky-upper',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: 'SKY 상단 지정석',
+         displayColorHex: '#8AA0E8',
+         availableSeatCount: 412,
       },
       {
          seatGradeId: 'grade-samsung-wheelchair',
@@ -322,6 +399,62 @@ const seatGradesByStadium: Record<string, SeatGrade[]> = {
          name: '외야 지정석',
          displayColorHex: '#3AA66B',
          availableSeatCount: 218,
+      },
+      {
+         seatGradeId: 'grade-samsung-grass',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '잔디석',
+         displayColorHex: '#7BBE43',
+         availableSeatCount: 73,
+      },
+      {
+         seatGradeId: 'grade-samsung-center-table',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '중앙 테이블석',
+         displayColorHex: '#234785',
+         availableSeatCount: 54,
+      },
+      {
+         seatGradeId: 'grade-samsung-first-base-table',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '1루 테이블석',
+         displayColorHex: '#32559A',
+         availableSeatCount: 38,
+      },
+      {
+         seatGradeId: 'grade-samsung-third-base-table',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '3루 테이블석',
+         displayColorHex: '#4064B0',
+         availableSeatCount: 36,
+      },
+      {
+         seatGradeId: 'grade-samsung-yogibo-family',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: 'SKY 요기보 패밀리존',
+         displayColorHex: '#6F5BD3',
+         availableSeatCount: 12,
+      },
+      {
+         seatGradeId: 'grade-samsung-party-floor',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '파티플로어 라이브석',
+         displayColorHex: '#7840C9',
+         availableSeatCount: 10,
+      },
+      {
+         seatGradeId: 'grade-samsung-rooftop-table',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '루프탑 테이블석',
+         displayColorHex: '#9152D9',
+         availableSeatCount: 8,
+      },
+      {
+         seatGradeId: 'grade-samsung-camping-zone',
+         stadiumId: 'stadium-samsung-lions-park',
+         name: '캠핑존',
+         displayColorHex: '#A64DB3',
+         availableSeatCount: 6,
       },
    ],
 };
@@ -341,12 +474,22 @@ const pricingPoliciesByTeamId: Record<string, TicketPricingPolicy> = {
          { priceId: 'price-kia-special-weekday', gradeId: 'grade-kia-cheering-special', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 18000 },
          { priceId: 'price-kia-k5-weekday', gradeId: 'grade-kia-k5', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 12000 },
          { priceId: 'price-kia-family-weekday', gradeId: 'grade-kia-family', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 25000 },
+         { priceId: 'price-kia-tigers-family-weekday', gradeId: 'grade-kia-tigers-family', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 55000 },
+         { priceId: 'price-kia-surprise-zone-weekday', gradeId: 'grade-kia-surprise-zone', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 30000 },
          { priceId: 'price-kia-party-weekday', gradeId: 'grade-kia-party', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 55000 },
          { priceId: 'price-kia-sky-weekday', gradeId: 'grade-kia-sky-picnic', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 45000 },
          { priceId: 'price-kia-table-weekday', gradeId: 'grade-kia-table-table', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 40000 },
+         { priceId: 'price-kia-ev-weekday', gradeId: 'grade-kia-ev', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 10000 },
+         { priceId: 'price-kia-outfield-free-weekday', gradeId: 'grade-kia-outfield-free', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 10000 },
+         { priceId: 'price-kia-outfield-family-weekday', gradeId: 'grade-kia-outfield-family', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 35000 },
          { priceId: 'price-kia-wheelchair-weekday', gradeId: 'grade-kia-wheelchair', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 10000 },
          { priceId: 'price-kia-champion-weekend', gradeId: 'grade-kia-champion', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 60000 },
          { priceId: 'price-kia-k8-weekend', gradeId: 'grade-kia-k8', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 16000 },
+         { priceId: 'price-kia-tigers-family-weekend', gradeId: 'grade-kia-tigers-family', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 55000 },
+         { priceId: 'price-kia-surprise-zone-weekend', gradeId: 'grade-kia-surprise-zone', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 30000 },
+         { priceId: 'price-kia-ev-weekend', gradeId: 'grade-kia-ev', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 10000 },
+         { priceId: 'price-kia-outfield-free-weekend', gradeId: 'grade-kia-outfield-free', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 10000 },
+         { priceId: 'price-kia-outfield-family-weekend', gradeId: 'grade-kia-outfield-family', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 35000 },
          { priceId: 'price-kia-wheelchair-weekend', gradeId: 'grade-kia-wheelchair', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 10000 },
       ],
    },
@@ -357,14 +500,42 @@ const pricingPoliciesByTeamId: Record<string, TicketPricingPolicy> = {
       policyEndAt: '2026-10-31',
       isActive: true,
       prices: [
+         { priceId: 'price-samsung-first-base-exciting-weekday', gradeId: 'grade-samsung-first-base-exciting', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 28000 },
+         { priceId: 'price-samsung-third-base-exciting-weekday', gradeId: 'grade-samsung-third-base-exciting', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 28000 },
          { priceId: 'price-samsung-first-base-weekday', gradeId: 'grade-samsung-first-base-infield', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 22000 },
+         { priceId: 'price-samsung-third-base-weekday', gradeId: 'grade-samsung-third-base-infield', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 22000 },
          { priceId: 'price-samsung-blue-weekday', gradeId: 'grade-samsung-blue-zone', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 20000 },
+         { priceId: 'price-samsung-away-weekday', gradeId: 'grade-samsung-away-zone', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 17000 },
+         { priceId: 'price-samsung-sky-lower-weekday', gradeId: 'grade-samsung-sky-lower', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 18000 },
+         { priceId: 'price-samsung-sky-upper-weekday', gradeId: 'grade-samsung-sky-upper', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 14000 },
          { priceId: 'price-samsung-wheelchair-weekday', gradeId: 'grade-samsung-wheelchair', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 10000 },
          { priceId: 'price-samsung-outfield-weekday', gradeId: 'grade-samsung-outfield', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 12000 },
+         { priceId: 'price-samsung-grass-weekday', gradeId: 'grade-samsung-grass', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 10000 },
+         { priceId: 'price-samsung-center-table-weekday', gradeId: 'grade-samsung-center-table', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 30000 },
+         { priceId: 'price-samsung-first-base-table-weekday', gradeId: 'grade-samsung-first-base-table', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 30000 },
+         { priceId: 'price-samsung-third-base-table-weekday', gradeId: 'grade-samsung-third-base-table', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 30000 },
+         { priceId: 'price-samsung-yogibo-family-weekday', gradeId: 'grade-samsung-yogibo-family', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 36000 },
+         { priceId: 'price-samsung-party-floor-weekday', gradeId: 'grade-samsung-party-floor', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 42000 },
+         { priceId: 'price-samsung-rooftop-table-weekday', gradeId: 'grade-samsung-rooftop-table', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 45000 },
+         { priceId: 'price-samsung-camping-zone-weekday', gradeId: 'grade-samsung-camping-zone', ticketType: 'ADULT', dayType: 'WEEKDAY', leagueType: 'REGULAR', price: 50000 },
+         { priceId: 'price-samsung-first-base-exciting-weekend', gradeId: 'grade-samsung-first-base-exciting', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 30000 },
+         { priceId: 'price-samsung-third-base-exciting-weekend', gradeId: 'grade-samsung-third-base-exciting', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 30000 },
          { priceId: 'price-samsung-first-base-weekend', gradeId: 'grade-samsung-first-base-infield', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 24000 },
+         { priceId: 'price-samsung-third-base-weekend', gradeId: 'grade-samsung-third-base-infield', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 24000 },
          { priceId: 'price-samsung-blue-weekend', gradeId: 'grade-samsung-blue-zone', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 22000 },
+         { priceId: 'price-samsung-away-weekend', gradeId: 'grade-samsung-away-zone', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 19000 },
+         { priceId: 'price-samsung-sky-lower-weekend', gradeId: 'grade-samsung-sky-lower', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 20000 },
+         { priceId: 'price-samsung-sky-upper-weekend', gradeId: 'grade-samsung-sky-upper', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 16000 },
          { priceId: 'price-samsung-wheelchair-weekend', gradeId: 'grade-samsung-wheelchair', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 10000 },
          { priceId: 'price-samsung-outfield-weekend', gradeId: 'grade-samsung-outfield', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 14000 },
+         { priceId: 'price-samsung-grass-weekend', gradeId: 'grade-samsung-grass', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 12000 },
+         { priceId: 'price-samsung-center-table-weekend', gradeId: 'grade-samsung-center-table', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 32000 },
+         { priceId: 'price-samsung-first-base-table-weekend', gradeId: 'grade-samsung-first-base-table', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 32000 },
+         { priceId: 'price-samsung-third-base-table-weekend', gradeId: 'grade-samsung-third-base-table', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 32000 },
+         { priceId: 'price-samsung-yogibo-family-weekend', gradeId: 'grade-samsung-yogibo-family', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 38000 },
+         { priceId: 'price-samsung-party-floor-weekend', gradeId: 'grade-samsung-party-floor', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 44000 },
+         { priceId: 'price-samsung-rooftop-table-weekend', gradeId: 'grade-samsung-rooftop-table', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 47000 },
+         { priceId: 'price-samsung-camping-zone-weekend', gradeId: 'grade-samsung-camping-zone', ticketType: 'ADULT', dayType: 'WEEKEND', leagueType: 'REGULAR', price: 52000 },
       ],
    },
 };
@@ -411,6 +582,18 @@ const seatSectionsByStadium: Record<string, SeatSection[]> = {
       }),
       ...createSections({
          stadiumId: 'stadium-kia-champions-field',
+         gradeId: 'grade-kia-tigers-family',
+         codes: ['H-1', 'H-2'],
+         capacity: 96,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
+         gradeId: 'grade-kia-surprise-zone',
+         codes: ['G-1', 'G-2'],
+         capacity: 84,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
          gradeId: 'grade-kia-sky-picnic',
          codes: ['519', '520', '521', '522', '523'],
          capacity: 48,
@@ -420,6 +603,24 @@ const seatSectionsByStadium: Record<string, SeatSection[]> = {
          gradeId: 'grade-kia-table-table',
          codes: ['530', '531', '532', '533', '534', '535'],
          capacity: 64,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
+         gradeId: 'grade-kia-ev',
+         codes: ['509', '510', '527', '528'],
+         capacity: 72,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
+         gradeId: 'grade-kia-outfield-free',
+         codes: ['O-1', 'O-2', 'O-3', 'O-4'],
+         capacity: 120,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-kia-champions-field',
+         gradeId: 'grade-kia-outfield-family',
+         codes: ['P-1', 'P-2'],
+         capacity: 84,
       }),
       ...createSections({
          stadiumId: 'stadium-kia-champions-field',
@@ -435,53 +636,120 @@ const seatSectionsByStadium: Record<string, SeatSection[]> = {
       }),
    ],
    'stadium-samsung-lions-park': [
-      {
-         sectionId: 'section-samsung-1-6',
-         gradeId: 'grade-samsung-first-base-infield',
+      ...createSections({
          stadiumId: 'stadium-samsung-lions-park',
-         sectionCode: '1-6',
-         capacity: 500,
-      },
-      {
-         sectionId: 'section-samsung-1-7',
-         gradeId: 'grade-samsung-first-base-infield',
+         gradeId: 'grade-samsung-first-base-exciting',
+         codes: ['1-1', '1-2', '1-3', '1-4', '1-5'],
+         capacity: 120,
+      }),
+      ...createSections({
          stadiumId: 'stadium-samsung-lions-park',
-         sectionCode: '1-7',
-         capacity: 490,
-      },
-      {
-         sectionId: 'section-samsung-3-1',
+         gradeId: 'grade-samsung-first-base-infield',
+         codes: ['1-6', '1-7', '1-8', '1-9', '1-10', '1-11'],
+         capacity: 180,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
+         gradeId: 'grade-samsung-third-base-exciting',
+         codes: ['3E-1', '3E-2', '3E-3'],
+         capacity: 150,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
+         gradeId: 'grade-samsung-third-base-infield',
+         codes: ['3-6', '3-7', '3-8', '3-9', '3-10', '3-11'],
+         capacity: 180,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
          gradeId: 'grade-samsung-blue-zone',
+         codes: ['3-1', '3-2', '3-3', '3-4', '3-5'],
+         capacity: 140,
+      }),
+      ...createSections({
          stadiumId: 'stadium-samsung-lions-park',
-         sectionCode: '3-1',
-         capacity: 300,
-      },
+         gradeId: 'grade-samsung-away-zone',
+         codes: ['S1', 'S2', 'S3', 'S4', 'S5', 'S6'],
+         capacity: 100,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
+         gradeId: 'grade-samsung-sky-lower',
+         codes: ['S7', 'S8', 'S9', 'S10', 'S11', 'S12', 'S13', 'S14', 'S15', 'S16', 'S17', 'S18', 'S19', 'S20', 'S21', 'S22'],
+         capacity: 110,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
+         gradeId: 'grade-samsung-sky-upper',
+         codes: ['U1', 'U2', 'U3', 'U4', 'U5', 'U6', 'U7', 'U8', 'U9', 'U10', 'U11', 'U12', 'U13', 'U14', 'U15', 'U16', 'U17', 'U18', 'U19', 'U20', 'U21', 'U22', 'U23', 'U24'],
+         capacity: 90,
+      }),
       ...createSections({
          stadiumId: 'stadium-samsung-lions-park',
          gradeId: 'grade-samsung-wheelchair',
-         codes: ['W-1', 'W-2'],
+         codes: ['WC-1', 'WC-2'],
          capacity: 12,
       }),
-      {
-         sectionId: 'section-samsung-lf-1',
-         gradeId: 'grade-samsung-outfield',
+      ...createSections({
          stadiumId: 'stadium-samsung-lions-park',
-         sectionCode: 'LF-1',
-         capacity: 220,
-      },
-      {
-         sectionId: 'section-samsung-rf-1',
          gradeId: 'grade-samsung-outfield',
+         codes: ['LF-1', 'LF-2', 'LF-3', 'LF-4', 'LF-5', 'LF-6', 'LF-7', 'LF-8', 'LF-9', 'LF-10', 'RF-1', 'RF-2', 'RF-3', 'RF-4', 'RF-5', 'RF-6', 'RF-7', 'RF-8', 'RF-9', 'RF-10'],
+         capacity: 90,
+      }),
+      ...createSections({
          stadiumId: 'stadium-samsung-lions-park',
-         sectionCode: 'RF-1',
-         capacity: 220,
-      },
+         gradeId: 'grade-samsung-grass',
+         codes: ['GR-1', 'GR-2', 'GR-3'],
+         capacity: 80,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
+         gradeId: 'grade-samsung-center-table',
+         codes: ['CT-1', 'CT-2', 'CT-3'],
+         capacity: 72,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
+         gradeId: 'grade-samsung-first-base-table',
+         codes: ['1T-1', '1T-2'],
+         capacity: 56,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
+         gradeId: 'grade-samsung-third-base-table',
+         codes: ['3T-1', '3T-2'],
+         capacity: 56,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
+         gradeId: 'grade-samsung-yogibo-family',
+         codes: ['YG-1', 'YG-2'],
+         capacity: 24,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
+         gradeId: 'grade-samsung-party-floor',
+         codes: ['PF-1', 'PF-2'],
+         capacity: 24,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
+         gradeId: 'grade-samsung-rooftop-table',
+         codes: ['RT-1'],
+         capacity: 20,
+      }),
+      ...createSections({
+         stadiumId: 'stadium-samsung-lions-park',
+         gradeId: 'grade-samsung-camping-zone',
+         codes: ['CP-1'],
+         capacity: 20,
+      }),
    ],
 };
 
 // ── MSW localStorage 영속화 ────────────────────────────────────────
 
-const MSW_STORAGE_VERSION = '7';
+const MSW_STORAGE_VERSION = '8';
 const MSW_VERSION_KEY = '__msw_storage_version__';
 const MSW_STORAGE_KEYS = [
    '__msw_ticket_orders__',
@@ -689,14 +957,11 @@ const mockResaleListings = [
       sellerId: 'seller-samsung-001',
       listedAtSeed: '2026-03-27T04:00:00.000Z',
       seatIds: [
-         'section-samsung-1-6-A-1',
-         'section-samsung-1-6-A-2',
-         'section-samsung-1-6-B-1',
-         'section-samsung-1-6-B-2',
-         'section-samsung-1-7-A-3',
-         'section-samsung-1-7-A-4',
-         'section-samsung-1-7-B-3',
-         'section-samsung-3-1-A-1',
+         'section-samsung-1-6-A-3',
+         'section-samsung-1-7-B-4',
+         'section-samsung-1-8-A-5',
+         'section-samsung-3-1-A-3',
+         'section-samsung-3-2-B-4',
       ],
    }),
    ...createMockResaleListings({
@@ -704,12 +969,11 @@ const mockResaleListings = [
       sellerId: 'seller-kia-001',
       listedAtSeed: '2026-03-28T02:00:00.000Z',
       seatIds: [
-         'section-stadium-kia-champions-field-104-A-1',
-         'section-stadium-kia-champions-field-104-A-2',
-         'section-stadium-kia-champions-field-105-B-1',
-         'section-stadium-kia-champions-field-108-A-1',
-         'section-stadium-kia-champions-field-108-B-1',
-         'section-stadium-kia-champions-field-118-A-1',
+         'section-stadium-kia-champions-field-104-A-3',
+         'section-stadium-kia-champions-field-105-B-4',
+         'section-stadium-kia-champions-field-108-A-5',
+         'section-stadium-kia-champions-field-118-B-3',
+         'section-stadium-kia-champions-field-119-A-4',
       ],
    }),
    ...createMockResaleListings({
@@ -717,12 +981,11 @@ const mockResaleListings = [
       sellerId: 'seller-samsung-002',
       listedAtSeed: '2026-03-30T03:00:00.000Z',
       seatIds: [
-         'section-samsung-1-6-C-1',
-         'section-samsung-1-6-C-2',
-         'section-samsung-1-7-C-1',
-         'section-samsung-1-7-C-2',
-         'section-samsung-3-1-B-1',
-         'section-samsung-3-1-B-2',
+         'section-samsung-1-6-C-3',
+         'section-samsung-1-7-C-4',
+         'section-samsung-3-1-B-3',
+         'section-samsung-3-2-C-4',
+         'section-samsung-S7-A-3',
       ],
    }),
    ...createMockResaleListings({
@@ -730,9 +993,11 @@ const mockResaleListings = [
       sellerId: 'seller-kia-002',
       listedAtSeed: '2026-04-10T03:30:00.000Z',
       seatIds: [
-         'section-stadium-kia-champions-field-519-A-1',
-         'section-stadium-kia-champions-field-520-A-1',
-         'section-stadium-kia-champions-field-521-B-1',
+         'section-stadium-kia-champions-field-519-A-3',
+         'section-stadium-kia-champions-field-520-B-4',
+         'section-stadium-kia-champions-field-521-C-3',
+         'section-stadium-kia-champions-field-J-1-A-4',
+         'section-stadium-kia-champions-field-J-2-B-3',
       ],
    }),
 ];
@@ -1069,32 +1334,61 @@ export const paymentHandlers = [
       const size = Number(url.searchParams.get('size') ?? '20');
       const keyword = (url.searchParams.get('keyword') ?? '').trim().toLowerCase();
 
-      const purchases = Array.from(ticketOrders.values())
-         .sort((left, right) => right.orderedAt.localeCompare(left.orderedAt))
+      const ticketPurchases = Array.from(ticketOrders.values()).map((order) => {
+         const matchedGame = mockGameSchedules.find((game) => game.gameId === order.gameId);
+         const seatInfos = getPurchaseSeatInfos(order);
+
+         return {
+            purchaseType: 'TICKET',
+            orderId: order.orderId,
+            orderNumber: order.orderNumber,
+            orderStatus: order.orderStatus,
+            totalQuantity: order.totalQuantity,
+            totalAmount: order.totalAmount,
+            orderedAt: order.orderedAt,
+            gameId: order.gameId,
+            stadiumId: order.stadiumId,
+            gameTitle:
+               order.homeTeamName && order.awayTeamName
+                  ? `${order.awayTeamName} vs ${order.homeTeamName}`
+                  : matchedGame
+                     ? `${matchedGame.awayTeamDisplayName} vs ${matchedGame.homeTeamDisplayName}`
+                     : 'KBO 리그 경기',
+            gameDate: order.gameStartAt ?? matchedGame?.startAt ?? order.orderedAt,
+            seatInfos,
+         };
+      });
+
+      const resalePurchases = Array.from(resaleOrders.values())
          .map((order) => {
-            const matchedGame = mockGameSchedules.find((game) => game.gameId === order.gameId);
-            const seatInfos = getPurchaseSeatInfos(order);
+            const issuedTickets = Array.from(ticketRecords.values()).filter(
+               (ticket) => ticket.orderId === order.orderId && ticket.ticketStatus === 'RESALE_ISSUED',
+            );
+            const primaryTicket = issuedTickets[0];
+
+            if (!primaryTicket) {
+               return null;
+            }
 
             return {
-               purchaseType: 'TICKET',
+               purchaseType: 'RESALE',
                orderId: order.orderId,
                orderNumber: order.orderNumber,
                orderStatus: order.orderStatus,
-               totalQuantity: order.totalQuantity,
+               totalQuantity: issuedTickets.length,
                totalAmount: order.totalAmount,
-               orderedAt: order.orderedAt,
-               gameId: order.gameId,
-               stadiumId: order.stadiumId,
-               gameTitle:
-                  order.homeTeamName && order.awayTeamName
-                     ? `${order.awayTeamName} vs ${order.homeTeamName}`
-                     : matchedGame
-                        ? `${matchedGame.awayTeamDisplayName} vs ${matchedGame.homeTeamDisplayName}`
-                        : 'KBO 리그 경기',
-               gameDate: order.gameStartAt ?? matchedGame?.startAt ?? order.orderedAt,
-               seatInfos,
+               orderedAt: primaryTicket.orderedAt,
+               gameId: primaryTicket.gameId,
+               stadiumId: '',
+               gameTitle: primaryTicket.gameTitle,
+               gameDate: primaryTicket.gameDate,
+               seatInfos: issuedTickets.map((ticket) => ticket.seatInfo),
             };
          })
+         .filter((purchase): purchase is NonNullable<typeof purchase> => purchase !== null);
+
+      const purchases = [...ticketPurchases, ...resalePurchases]
+         .sort((left, right) => right.orderedAt.localeCompare(left.orderedAt))
          .filter((purchase) => {
             if (!keyword) {
                return true;

--- a/src/shared/config/runtime.ts
+++ b/src/shared/config/runtime.ts
@@ -1,4 +1,5 @@
 const mswFlag = (import.meta.env.PUBLIC_ENABLE_MSW ?? '').trim().toLowerCase();
+const resaleDemoFlag = (import.meta.env.PUBLIC_ENABLE_RESALE_DEMO ?? '').trim().toLowerCase();
 
 const isLocalHostname = (hostname: string) => {
    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '0.0.0.0';
@@ -15,3 +16,31 @@ const canUseMswInBrowser = () => {
 // MSW는 로컬 개발 환경에서만 허용한다.
 // 배포/프리뷰 환경에서는 .env 플래그가 true여도 실제 API를 사용해야 한다.
 export const isMswEnabled = mswFlag === 'true' && canUseMswInBrowser();
+
+const RESALE_DEMO_QUERY_KEY = 'resaleDemo';
+const RESALE_DEMO_STORAGE_KEY = '__resale_demo_enabled__';
+
+const readResaleDemoQuery = () => {
+   if (typeof window === 'undefined') {
+      return false;
+   }
+
+   const value = new URLSearchParams(window.location.search).get(RESALE_DEMO_QUERY_KEY)?.trim().toLowerCase();
+
+   if (value === '1' || value === 'true') {
+      window.sessionStorage.setItem(RESALE_DEMO_STORAGE_KEY, 'true');
+      return true;
+   }
+
+   return false;
+};
+
+const readStoredResaleDemoFlag = () => {
+   if (typeof window === 'undefined') {
+      return false;
+   }
+
+   return window.sessionStorage.getItem(RESALE_DEMO_STORAGE_KEY) === 'true';
+};
+
+export const isResaleDemoEnabled = resaleDemoFlag === 'true' || readResaleDemoQuery() || readStoredResaleDemoFlag();

--- a/src/shared/config/runtime.ts
+++ b/src/shared/config/runtime.ts
@@ -44,3 +44,6 @@ const readStoredResaleDemoFlag = () => {
 };
 
 export const isResaleDemoEnabled = resaleDemoFlag === 'true' || readResaleDemoQuery() || readStoredResaleDemoFlag();
+
+// 리셀 예매는 현재 API 연동 없이 mock 기반으로만 동작시킨다.
+export const isResaleBookingMockEnabled = true;

--- a/src/shared/lib/booking-flow.ts
+++ b/src/shared/lib/booking-flow.ts
@@ -1,25 +1,6 @@
 export type BookingFlowMode = 'standard' | 'resell';
 
-const BOOKING_FLOW_QUERY_KEY = 'mode';
 export const DEFAULT_BOOKING_ENTRY_SOURCE_PATH = '/';
-
-export function getBookingFlowMode(search: string): BookingFlowMode {
-   const params = new URLSearchParams(search);
-
-   return params.get(BOOKING_FLOW_QUERY_KEY) === 'resell' ? 'resell' : 'standard';
-}
-
-export function createBookingFlowSearch(mode: BookingFlowMode): string {
-   if (mode === 'standard') {
-      return '';
-   }
-
-   const params = new URLSearchParams({
-      [BOOKING_FLOW_QUERY_KEY]: mode,
-   });
-
-   return `?${params.toString()}`;
-}
 
 export function createBookingEntrySourcePath({
    pathname,

--- a/src/shared/lib/demo/resaleDemo.ts
+++ b/src/shared/lib/demo/resaleDemo.ts
@@ -85,8 +85,33 @@ type CreateResalePaymentParams = {
 };
 
 const STORAGE_KEY = '__ballx_resale_demo_state__';
-const STORAGE_VERSION = '1';
-const DEFAULT_GAME_COUNT = 6;
+const STORAGE_VERSION = '4';
+const DEMO_RESALE_MIN_PRICE = 35_000;
+const DEMO_RESALE_MAX_PRICE = 60_000;
+const DEMO_ZONE_TARGET_COUNTS: Record<string, number> = {
+   k9: 3,
+   k8: 2,
+   'cheering-special': 3,
+   k5: 2,
+   'surprise-zone': 2,
+   'family-seat': 1,
+   party: 1,
+   'sky-picnic': 1,
+   'table-table': 2,
+   'outfield-free': 2,
+   'samsung-first-base-infield': 3,
+   'samsung-third-base-infield': 3,
+   'samsung-blue-zone': 2,
+   'samsung-away-zone': 1,
+   'samsung-sky-lower': 2,
+   'samsung-outfield': 2,
+   'samsung-grass': 1,
+   'samsung-center-table': 1,
+   'samsung-first-base-table': 1,
+   'samsung-third-base-table': 1,
+};
+const DEFAULT_GAME_COUNT = Object.values(DEMO_ZONE_TARGET_COUNTS).reduce((sum, count) => sum + count, 0);
+const DEMO_TOTAL_LISTINGS_PER_GAME = DEFAULT_GAME_COUNT;
 
 const createId = (prefix: string) => {
    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -95,6 +120,8 @@ const createId = (prefix: string) => {
 
    return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 };
+
+const clampDemoResalePrice = (value: number) => Math.min(DEMO_RESALE_MAX_PRICE, Math.max(DEMO_RESALE_MIN_PRICE, value));
 
 const createInitialState = (): DemoState => ({
    version: STORAGE_VERSION,
@@ -160,6 +187,87 @@ const getActiveListings = (state: DemoState, gameId: string) =>
          listing.isPurchasable,
    );
 
+export const getDemoResaleTargetCountForZone = (zoneId: string) => {
+   return DEMO_ZONE_TARGET_COUNTS[zoneId] ?? 0;
+};
+
+const compareSeatRow = (left: string, right: string) => {
+   return left.localeCompare(right, 'en', { numeric: true });
+};
+
+const pickDemoSeatsForZone = (seats: SeatItem[], existingSeatIds: Set<string>, limit: number) => {
+   if (limit <= 0) {
+      return [] as SeatItem[];
+   }
+
+   const seatsByBlock = seats.reduce<Record<string, SeatItem[]>>((groups, seat) => {
+      if (existingSeatIds.has(seat.id)) {
+         return groups;
+      }
+
+      const currentSeats = groups[seat.block];
+
+      if (currentSeats) {
+         currentSeats.push(seat);
+      } else {
+         groups[seat.block] = [seat];
+      }
+
+      return groups;
+   }, {});
+
+   const orderedBlockSeats = Object.entries(seatsByBlock)
+      .sort(([left], [right]) => left.localeCompare(right, 'en', { numeric: true }))
+      .map(([, blockSeats]) =>
+         [...blockSeats].sort((left, right) => {
+            const rowCompare = compareSeatRow(left.rowLabel, right.rowLabel);
+
+            if (rowCompare !== 0) {
+               return rowCompare;
+            }
+
+            const leftSeatScore = Math.abs(left.seatNumber - 4);
+            const rightSeatScore = Math.abs(right.seatNumber - 4);
+
+            if (leftSeatScore !== rightSeatScore) {
+               return leftSeatScore - rightSeatScore;
+            }
+
+            return left.seatNumber - right.seatNumber;
+         }),
+      );
+
+   const selectedSeats: SeatItem[] = [];
+   let seatCursor = 0;
+
+   while (selectedSeats.length < limit) {
+      let addedInRound = false;
+
+      for (const blockSeats of orderedBlockSeats) {
+         const candidate = blockSeats[seatCursor];
+
+         if (!candidate) {
+            continue;
+         }
+
+         selectedSeats.push(candidate);
+         addedInRound = true;
+
+         if (selectedSeats.length >= limit) {
+            break;
+         }
+      }
+
+      if (!addedInRound) {
+         break;
+      }
+
+      seatCursor += 1;
+   }
+
+   return selectedSeats;
+};
+
 export const ensureDemoListingsForZone = ({
    gameId,
    zone,
@@ -169,18 +277,51 @@ export const ensureDemoListingsForZone = ({
    stadiumName,
 }: EnsureZoneListingsParams) => {
    return updateState((state) => {
+      if (getDemoResaleTargetCountForZone(zone.id) === 0) {
+         return Object.values(state.listings).filter((listing) => listing.gameId === gameId);
+      }
+
+      const seatById = new Map(seats.map((seat) => [seat.id, seat]));
+      const defaultGradeId = zone.gradeIds?.[0] ?? `demo-grade-${zone.id}`;
+
+      Object.values(state.listings).forEach((listing) => {
+         if (listing.gameId !== gameId) {
+            return;
+         }
+
+         const matchedSeat = seatById.get(listing.seatId);
+
+         if (!matchedSeat) {
+            return;
+         }
+
+         state.listings[listing.listingId] = {
+            ...listing,
+            gradeId: defaultGradeId,
+            seatInfo: buildSeatInfo(zone, matchedSeat),
+            gameTitle: gameTitle ?? listing.gameTitle,
+            gameDate: gameDate ?? listing.gameDate,
+            stadiumName: stadiumName ?? listing.stadiumName,
+         };
+      });
+
       const existingSeats = new Set(
          Object.values(state.listings)
             .filter((listing) => listing.gameId === gameId)
             .map((listing) => listing.seatId),
       );
+      const activeGameListings = getActiveListings(state, gameId);
+      const activeZoneListings = activeGameListings.filter((listing) => seatById.has(listing.seatId));
+      const remainingGameSlots = Math.max(0, DEMO_TOTAL_LISTINGS_PER_GAME - activeGameListings.length);
+      const remainingZoneSlots = Math.max(0, getDemoResaleTargetCountForZone(zone.id) - activeZoneListings.length);
+      const seatsToCreate = pickDemoSeatsForZone(
+         seats,
+         existingSeats,
+         Math.min(remainingGameSlots, remainingZoneSlots),
+      );
 
-      const candidateSeats = seats
-         .filter((seat) => !existingSeats.has(seat.id))
-         .slice(0, Math.min(6, seats.length));
-
-      candidateSeats.forEach((seat, index) => {
-         const listedPrice = Math.max(1000, zone.price + (index % 2 === 0 ? 2000 : -1000));
+      seatsToCreate.forEach((seat, index) => {
+         const listedPrice = clampDemoResalePrice(zone.price + (index % 2 === 0 ? 2000 : -1000));
          const listingId = createId('demo-listing');
 
          state.listings[listingId] = {
@@ -189,17 +330,17 @@ export const ensureDemoListingsForZone = ({
             sellerId: `demo-seller-${zone.id}`,
             gameId,
             seatId: seat.id,
-            gradeId: zone.gradeIds?.[0] ?? `demo-grade-${zone.id}`,
+            gradeId: defaultGradeId,
             seatInfo: buildSeatInfo(zone, seat),
-            dailyBasePrice: zone.price,
+            dailyBasePrice: clampDemoResalePrice(zone.price),
             listingPrice: listedPrice,
             listingStatus: 'LISTING',
             availableStatus: 'ENABLED',
             listedAt: new Date(Date.now() - index * 60_000).toISOString(),
             isCancelable: true,
             isPurchasable: true,
-            minPrice: Math.max(1000, zone.price - 3000),
-            maxPrice: zone.price + 10000,
+            minPrice: DEMO_RESALE_MIN_PRICE,
+            maxPrice: DEMO_RESALE_MAX_PRICE,
             gameTitle,
             gameDate,
             stadiumName,
@@ -225,7 +366,7 @@ export const getDemoResaleCountsByGrades = (gameId: string, gradeIds: string[]) 
 
    return new Map(
       gradeIds.map((gradeId, index) => {
-         const count = activeListings.filter((listing) => listing.gradeId === gradeId).length;
+        const count = activeListings.filter((listing) => listing.gradeId === gradeId).length;
          return [gradeId, count > 0 ? count : Math.max(1, 3 - (index % 3))] as const;
       }),
    );
@@ -235,15 +376,96 @@ export const getDemoResaleStatusByGame = (gameId: string) => {
    return getDemoResaleCountByGame(gameId) > 0 ? 'AVAILABLE' : 'UNAVAILABLE';
 };
 
-export const getDemoResaleHistory = (range: 'HOUR' | 'DAY' | 'WEEK') => {
-   const pointCount = range === 'HOUR' ? 8 : range === 'DAY' ? 7 : 6;
-   const stepMs = range === 'HOUR' ? 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
-   const basePrice = range === 'HOUR' ? 25000 : range === 'DAY' ? 23000 : 21000;
+const roundToNearestThousand = (value: number) => Math.max(1000, Math.round(value / 1000) * 1000);
 
-   return Array.from({ length: pointCount }, (_, index) => ({
-      transactionPrice: basePrice + ((index % 3) - 1) * 2000 + index * 300,
-      confirmedAt: new Date(Date.now() - (pointCount - index) * stepMs).toISOString(),
-   }));
+const hashValue = (value: string) => {
+   let hash = 0;
+
+   for (let index = 0; index < value.length; index += 1) {
+      hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+   }
+
+   return hash;
+};
+
+const createSeededUnitValue = (seed: number, index: number) => {
+   const value = Math.sin(seed * 0.0001 + index * 12.9898) * 43758.5453;
+   return value - Math.floor(value);
+};
+
+const createHistoryPrice = ({
+   basePrice,
+   spread,
+   seed,
+   index,
+   pointCount,
+   range,
+}: {
+   basePrice: number;
+   spread: number;
+   seed: number;
+   index: number;
+   pointCount: number;
+   range: 'HOUR' | 'DAY' | 'WEEK';
+}) => {
+   const progress = pointCount === 1 ? 1 : index / (pointCount - 1);
+   const centeredProgress = progress - 0.5;
+   const primaryWave = Math.sin(progress * Math.PI * 2.35 + (seed % 13) * 0.21) * spread * 0.34;
+   const secondaryWave = Math.cos(progress * Math.PI * 5.1 + (seed % 7) * 0.43) * spread * 0.16;
+   const drift = centeredProgress * spread * (range === 'HOUR' ? 0.28 : range === 'DAY' ? 0.4 : 0.48);
+   const shock =
+      (createSeededUnitValue(seed, index) - 0.5) * spread * (range === 'HOUR' ? 0.52 : 0.36) +
+      (createSeededUnitValue(seed ^ 0x9e3779b9, index + 29) - 0.5) * 2600;
+   const swing =
+      index > 0 && index < pointCount - 1 && createSeededUnitValue(seed ^ 0x85ebca6b, index) > 0.74
+         ? (createSeededUnitValue(seed ^ 0xc2b2ae35, index) > 0.5 ? 1 : -1) * spread * 0.22
+         : 0;
+
+   return clampDemoResalePrice(roundToNearestThousand(basePrice + primaryWave + secondaryWave + drift + shock + swing));
+};
+
+export const getDemoResaleHistory = (gameId: string, gradeId: string, range: 'HOUR' | 'DAY' | 'WEEK') => {
+   const activeListings = getActiveListings(readState(), gameId);
+   const gradeListings = activeListings.filter((listing) => listing.gradeId === gradeId);
+   const sourceListings = gradeListings.length > 0 ? gradeListings : activeListings;
+   const fallbackBasePrice = 20000 + (hashValue(gradeId || gameId) % 5) * 3000;
+   const priceCandidates = sourceListings.flatMap((listing) => [
+      clampDemoResalePrice(listing.dailyBasePrice),
+      clampDemoResalePrice(listing.listingPrice),
+   ]);
+   const basePrice =
+      priceCandidates.length > 0
+         ? roundToNearestThousand(priceCandidates.reduce((sum, price) => sum + price, 0) / priceCandidates.length)
+         : clampDemoResalePrice(fallbackBasePrice);
+   const recentPrice = clampDemoResalePrice(sourceListings[0]?.listingPrice ?? basePrice);
+   const minPrice = priceCandidates.length > 0 ? Math.min(...priceCandidates) : Math.max(DEMO_RESALE_MIN_PRICE, basePrice - 7000);
+   const maxPrice = priceCandidates.length > 0 ? Math.max(...priceCandidates) : Math.min(DEMO_RESALE_MAX_PRICE, basePrice + 7000);
+   const spread = Math.max(
+      6000,
+      roundToNearestThousand(
+         Math.max(maxPrice - minPrice, range === 'HOUR' ? basePrice * 0.16 : range === 'DAY' ? basePrice * 0.22 : basePrice * 0.28),
+      ),
+   );
+   const pointCount = range === 'HOUR' ? 16 : range === 'DAY' ? 10 : 8;
+   const stepMs = range === 'HOUR' ? 15 * 60 * 1000 : 24 * 60 * 60 * 1000;
+   const seed = hashValue(`${gameId}:${gradeId}:${range}`);
+
+   return Array.from({ length: pointCount }, (_, index) => {
+      const isLast = index === pointCount - 1;
+      const syntheticPrice = createHistoryPrice({
+         basePrice,
+         spread,
+         seed,
+         index,
+         pointCount,
+         range,
+      });
+
+      return {
+         transactionPrice: isLast ? roundToNearestThousand(recentPrice) : syntheticPrice,
+         confirmedAt: new Date(Date.now() - (pointCount - 1 - index) * stepMs).toISOString(),
+      };
+   });
 };
 
 export const createDemoResaleHold = (listingId: string, queueTokenJti: string) => {

--- a/src/shared/lib/demo/resaleDemo.ts
+++ b/src/shared/lib/demo/resaleDemo.ts
@@ -1,0 +1,406 @@
+import type { ZoneItem, SeatItem } from '@/pages/books/model/types';
+
+type DemoListingStatus = 'LISTING' | 'HOLD' | 'SOLD' | 'SETTLED' | 'CANCEL_REQUESTED' | 'CANCELED';
+type DemoAvailableStatus = 'ENABLED' | 'DISABLED';
+type DemoOrderStatus = 'PENDING' | 'COMPLETED';
+type DemoPaymentMethod = 'CARD' | 'ACCOUNT_TRANSFER';
+
+type DemoListing = {
+   listingId: string;
+   ticketId: string;
+   sellerId: string;
+   gameId: string;
+   seatId: string;
+   gradeId: string;
+   seatInfo: string;
+   dailyBasePrice: number;
+   listingPrice: number;
+   listingStatus: DemoListingStatus;
+   availableStatus: DemoAvailableStatus;
+   listedAt: string;
+   isCancelable: boolean;
+   isPurchasable: boolean;
+   minPrice: number;
+   maxPrice: number;
+   gameTitle?: string;
+   gameDate?: string;
+   stadiumName?: string;
+};
+
+type DemoHold = {
+   holdId: string;
+   listingId: string;
+   queueTokenJti: string;
+   createdAt: string;
+};
+
+type DemoOrder = {
+   orderId: string;
+   orderNumber: string;
+   orderStatus: DemoOrderStatus;
+   holdIds: string[];
+   transactionIds: string[];
+   totalQuantity: number;
+   totalAmount: number;
+   buyerId: string;
+};
+
+type DemoPayment = {
+   paymentId: string;
+   orderId: string;
+   paymentType: 'PAYMENT';
+   paymentMethod: DemoPaymentMethod;
+   paymentAmount: number;
+   pgProvider: string;
+   pgTid: string;
+   paymentStatus: 'SUCCESS';
+   paidAt: string;
+};
+
+type DemoState = {
+   version: string;
+   listings: Record<string, DemoListing>;
+   holds: Record<string, DemoHold>;
+   orders: Record<string, DemoOrder>;
+   payments: Record<string, DemoPayment>;
+};
+
+type EnsureZoneListingsParams = {
+   gameId: string;
+   zone: ZoneItem;
+   seats: SeatItem[];
+   gameTitle?: string;
+   gameDate?: string;
+   stadiumName?: string;
+};
+
+type CreateResaleOrderParams = {
+   holdIds: string[];
+   buyerId: string;
+};
+
+type CreateResalePaymentParams = {
+   orderId: string;
+   paymentMethod: DemoPaymentMethod;
+};
+
+const STORAGE_KEY = '__ballx_resale_demo_state__';
+const STORAGE_VERSION = '1';
+const DEFAULT_GAME_COUNT = 6;
+
+const createId = (prefix: string) => {
+   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `${prefix}-${crypto.randomUUID()}`;
+   }
+
+   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+};
+
+const createInitialState = (): DemoState => ({
+   version: STORAGE_VERSION,
+   listings: {},
+   holds: {},
+   orders: {},
+   payments: {},
+});
+
+const readState = (): DemoState => {
+   if (typeof window === 'undefined') {
+      return createInitialState();
+   }
+
+   try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+
+      if (!raw) {
+         return createInitialState();
+      }
+
+      const parsed = JSON.parse(raw) as Partial<DemoState>;
+
+      if (parsed.version !== STORAGE_VERSION) {
+         return createInitialState();
+      }
+
+      return {
+         version: STORAGE_VERSION,
+         listings: parsed.listings ?? {},
+         holds: parsed.holds ?? {},
+         orders: parsed.orders ?? {},
+         payments: parsed.payments ?? {},
+      };
+   } catch {
+      return createInitialState();
+   }
+};
+
+const writeState = (state: DemoState) => {
+   if (typeof window === 'undefined') {
+      return;
+   }
+
+   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+};
+
+const updateState = <T>(updater: (state: DemoState) => T): T => {
+   const state = readState();
+   const result = updater(state);
+   writeState(state);
+   return result;
+};
+
+const buildSeatInfo = (zone: ZoneItem, seat: SeatItem) => `${zone.name} ${seat.block}구역 ${seat.rowLabel} ${seat.seatNumber}번`;
+
+const getActiveListings = (state: DemoState, gameId: string) =>
+   Object.values(state.listings).filter(
+      (listing) =>
+         listing.gameId === gameId &&
+         listing.listingStatus === 'LISTING' &&
+         listing.availableStatus === 'ENABLED' &&
+         listing.isPurchasable,
+   );
+
+export const ensureDemoListingsForZone = ({
+   gameId,
+   zone,
+   seats,
+   gameTitle,
+   gameDate,
+   stadiumName,
+}: EnsureZoneListingsParams) => {
+   return updateState((state) => {
+      const existingSeats = new Set(
+         Object.values(state.listings)
+            .filter((listing) => listing.gameId === gameId)
+            .map((listing) => listing.seatId),
+      );
+
+      const candidateSeats = seats
+         .filter((seat) => !existingSeats.has(seat.id))
+         .slice(0, Math.min(6, seats.length));
+
+      candidateSeats.forEach((seat, index) => {
+         const listedPrice = Math.max(1000, zone.price + (index % 2 === 0 ? 2000 : -1000));
+         const listingId = createId('demo-listing');
+
+         state.listings[listingId] = {
+            listingId,
+            ticketId: `demo-ticket-${seat.id}`,
+            sellerId: `demo-seller-${zone.id}`,
+            gameId,
+            seatId: seat.id,
+            gradeId: zone.gradeIds?.[0] ?? `demo-grade-${zone.id}`,
+            seatInfo: buildSeatInfo(zone, seat),
+            dailyBasePrice: zone.price,
+            listingPrice: listedPrice,
+            listingStatus: 'LISTING',
+            availableStatus: 'ENABLED',
+            listedAt: new Date(Date.now() - index * 60_000).toISOString(),
+            isCancelable: true,
+            isPurchasable: true,
+            minPrice: Math.max(1000, zone.price - 3000),
+            maxPrice: zone.price + 10000,
+            gameTitle,
+            gameDate,
+            stadiumName,
+         };
+      });
+
+      return Object.values(state.listings).filter((listing) => listing.gameId === gameId);
+   });
+};
+
+export const getDemoResaleListings = () => {
+   return Object.values(readState().listings);
+};
+
+export const getDemoResaleCountByGame = (gameId: string) => {
+   const count = getActiveListings(readState(), gameId).length;
+   return count > 0 ? count : DEFAULT_GAME_COUNT;
+};
+
+export const getDemoResaleCountsByGrades = (gameId: string, gradeIds: string[]) => {
+   const state = readState();
+   const activeListings = getActiveListings(state, gameId);
+
+   return new Map(
+      gradeIds.map((gradeId, index) => {
+         const count = activeListings.filter((listing) => listing.gradeId === gradeId).length;
+         return [gradeId, count > 0 ? count : Math.max(1, 3 - (index % 3))] as const;
+      }),
+   );
+};
+
+export const getDemoResaleStatusByGame = (gameId: string) => {
+   return getDemoResaleCountByGame(gameId) > 0 ? 'AVAILABLE' : 'UNAVAILABLE';
+};
+
+export const getDemoResaleHistory = (range: 'HOUR' | 'DAY' | 'WEEK') => {
+   const pointCount = range === 'HOUR' ? 8 : range === 'DAY' ? 7 : 6;
+   const stepMs = range === 'HOUR' ? 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
+   const basePrice = range === 'HOUR' ? 25000 : range === 'DAY' ? 23000 : 21000;
+
+   return Array.from({ length: pointCount }, (_, index) => ({
+      transactionPrice: basePrice + ((index % 3) - 1) * 2000 + index * 300,
+      confirmedAt: new Date(Date.now() - (pointCount - index) * stepMs).toISOString(),
+   }));
+};
+
+export const createDemoResaleHold = (listingId: string, queueTokenJti: string) => {
+   return updateState((state) => {
+      const listing = state.listings[listingId];
+
+      if (!listing || listing.listingStatus !== 'LISTING' || !listing.isPurchasable) {
+         throw new Error('리셀 좌석을 점유할 수 없습니다.');
+      }
+
+      const holdId = createId('demo-hold');
+      state.holds[holdId] = {
+         holdId,
+         listingId,
+         queueTokenJti,
+         createdAt: new Date().toISOString(),
+      };
+      state.listings[listingId] = {
+         ...listing,
+         listingStatus: 'HOLD',
+      };
+
+      return { holdId };
+   });
+};
+
+const releaseDemoResaleHoldInternal = (holdId: string) => {
+   return updateState((state) => {
+      const hold = state.holds[holdId];
+
+      if (!hold) {
+         return { holdId };
+      }
+
+      const listing = state.listings[hold.listingId];
+
+      if (listing && listing.listingStatus === 'HOLD') {
+         state.listings[hold.listingId] = {
+            ...listing,
+            listingStatus: 'LISTING',
+         };
+      }
+
+      delete state.holds[holdId];
+
+      return { holdId };
+   });
+};
+
+export const releaseDemoResaleHold = (holdId: string) => releaseDemoResaleHoldInternal(holdId);
+
+export const releaseDemoResaleHoldSync = (holdId: string) => {
+   releaseDemoResaleHoldInternal(holdId);
+};
+
+export const createDemoResaleOrder = ({ holdIds, buyerId }: CreateResaleOrderParams) => {
+   return updateState((state) => {
+      const holds = holdIds.map((holdId) => state.holds[holdId]).filter(Boolean);
+
+      if (holds.length !== holdIds.length || holds.length === 0) {
+         throw new Error('리셀 주문을 생성할 점유 정보가 없습니다.');
+      }
+
+      const listings = holds.map((hold) => state.listings[hold.listingId]).filter(Boolean);
+      const orderId = createId('demo-resale-order');
+      const transactionIds = listings.map(() => createId('demo-transaction'));
+
+      state.orders[orderId] = {
+         orderId,
+         orderNumber: `RSL-${orderId.replace(/^demo-resale-order-/i, '').slice(0, 8).toUpperCase()}`,
+         orderStatus: 'PENDING',
+         holdIds,
+         transactionIds,
+         totalQuantity: listings.length,
+         totalAmount: listings.reduce((sum, listing) => sum + listing.listingPrice, 0),
+         buyerId,
+      };
+
+      return state.orders[orderId];
+   });
+};
+
+export const getDemoResaleTransactions = (orderId: string) => {
+   const order = readState().orders[orderId];
+   return order?.transactionIds ?? [];
+};
+
+export const createDemoResalePayment = ({ orderId, paymentMethod }: CreateResalePaymentParams) => {
+   return updateState((state) => {
+      const order = state.orders[orderId];
+
+      if (!order) {
+         throw new Error('리셀 주문 정보를 찾을 수 없습니다.');
+      }
+
+      const paymentId = createId('demo-resale-payment');
+      state.payments[paymentId] = {
+         paymentId,
+         orderId,
+         paymentType: 'PAYMENT',
+         paymentMethod,
+         paymentAmount: order.totalAmount,
+         pgProvider: 'DEMO',
+         pgTid: createId('demo-pg'),
+         paymentStatus: 'SUCCESS',
+         paidAt: new Date().toISOString(),
+      };
+
+      return state.payments[paymentId];
+   });
+};
+
+export const completeDemoResaleOrder = (orderId: string) => {
+   return updateState((state) => {
+      const order = state.orders[orderId];
+
+      if (!order) {
+         throw new Error('완료 처리할 리셀 주문이 없습니다.');
+      }
+
+      const items = order.holdIds.map((holdId, index) => {
+         const hold = state.holds[holdId];
+         const listing = hold ? state.listings[hold.listingId] : undefined;
+
+         if (!hold || !listing) {
+            throw new Error('리셀 주문 완료 처리 중 좌석 정보를 찾을 수 없습니다.');
+         }
+
+         state.listings[listing.listingId] = {
+            ...listing,
+            listingStatus: 'SOLD',
+            availableStatus: 'DISABLED',
+            isPurchasable: false,
+            isCancelable: false,
+         };
+         delete state.holds[holdId];
+
+         return {
+            transactionId: order.transactionIds[index] ?? createId('demo-transaction'),
+            listingId: listing.listingId,
+            seatInfo: listing.seatInfo,
+            price: listing.listingPrice,
+         };
+      });
+
+      state.orders[orderId] = {
+         ...order,
+         orderStatus: 'COMPLETED',
+      };
+
+      return {
+         orderId: order.orderId,
+         orderNumber: order.orderNumber,
+         buyerId: order.buyerId,
+         totalAmount: order.totalAmount,
+         orderStatus: 'COMPLETED' as const,
+         items,
+      };
+   });
+};

--- a/src/shared/lib/use-booking-entry-flow.tsx
+++ b/src/shared/lib/use-booking-entry-flow.tsx
@@ -3,7 +3,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import {
   createBookingEntrySourcePath,
-  createBookingFlowSearch,
   type BookingFlowMode,
 } from '@/shared/lib/booking-flow';
 import { logBookingFlow, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
@@ -14,6 +13,7 @@ import type { ApiLeagueType } from '@/shared/types/game';
 import BookingGuideDialog from '@/shared/ui/booking-guide-dialog';
 
 export type OpenBookingEntryOptions = {
+  bookingFlowMode?: BookingFlowMode;
   entrySourcePath?: string;
   homeTeamId?: string;
   serverHomeTeamId?: string;
@@ -32,6 +32,7 @@ const createBookingEntryState = (options?: OpenBookingEntryOptions): BookingEntr
   return {
     requireCaptcha: true,
     forceNewSession: true,
+    bookingFlowMode: options?.bookingFlowMode ?? 'standard',
     entrySourcePath: options?.entrySourcePath,
     homeTeamId: options?.homeTeamId,
     serverHomeTeamId: options?.serverHomeTeamId,
@@ -68,6 +69,7 @@ export function useBookingEntryFlow() {
   const openEntryWithGuide = (mode: BookingFlowMode, options?: OpenBookingEntryOptions) => {
     const nextEntryState = createBookingEntryState({
       ...options,
+      bookingFlowMode: mode,
       userId: options?.userId ?? currentUserId ?? resolveUserIdFromJwt(accessToken) ?? undefined,
       entrySourcePath: createBookingEntrySourcePath(location),
     });
@@ -134,10 +136,7 @@ export function useBookingEntryFlow() {
           nextEntryState: summarizeBookingEntry(nextEntryState),
         });
         setBookingEntry(nextEntryState);
-        navigate(
-          { pathname: '/queue', search: createBookingFlowSearch(pendingEntry?.mode ?? 'standard') },
-          { state: nextEntryState },
-        );
+        navigate('/queue', { state: nextEntryState });
       }}
     />
   );

--- a/src/shared/lib/useBookingEntryStore.ts
+++ b/src/shared/lib/useBookingEntryStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
 import type { ZoneItem } from '@/pages/books/model/types';
+import type { BookingFlowMode } from '@/shared/lib/booking-flow';
 import { logBookingFlow, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
 import type { ApiLeagueType } from '@/shared/types/game';
 import type { BotReport } from '@/shared/lib/botDetector';
@@ -16,6 +17,7 @@ export type BookingEntryState = {
    stadiumId?: string;
    leagueType?: ApiLeagueType;
    gameDate?: string;
+   bookingFlowMode?: BookingFlowMode;
    queueTokenJti?: string;
    userId?: string;
    matchTitle?: string;
@@ -42,8 +44,9 @@ export const mergeBookingEntryState = (
    }
 
    return {
-      ...routeEntry,
       ...storedEntry,
+      // 현재 라우트 진입 정보가 이전 세션보다 우선해야 일반/리셀 플로우가 뒤섞이지 않는다.
+      ...routeEntry,
    };
 };
 

--- a/src/shared/widgets/layout/books/BooksHeader.tsx
+++ b/src/shared/widgets/layout/books/BooksHeader.tsx
@@ -121,7 +121,9 @@ const BooksHeader = ({
    const clearBookingEntry = useBookingEntryStore((store) => store.clearEntry);
    const bookingTeamConfig = getBookingTeamConfig(bookingEntryState?.homeTeamId);
    const [bookingEntryGameFallback, setBookingEntryGameFallback] = useState<BookingHeaderGameFallback | null>(null);
-   const resolvedCurrentStepIndex = currentStepIndex ?? (pathname.includes('/books/seats/') ? 1 : 0);
+   const resolvedCurrentStepIndex =
+      currentStepIndex ??
+      (pathname.includes('/books/seats/') || pathname.includes('/resell-books/seats/') ? 1 : 0);
    const shouldShowBackButton = showBackButton ?? resolvedCurrentStepIndex > 0;
    const [isExitDialogOpen, setIsExitDialogOpen] = useState(false);
    const [isTimeoutDialogOpen, setIsTimeoutDialogOpen] = useState(false);


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #208
- #216

<br/>

 ## 🔎 개요

  리셀 예매를 일반 예매와 분리된 전용 경로로 구성하고, 현재 백엔드 연동 없이도 mock 기반으로 대기열 진입, 좌석 선택, 결제 완료, 마이페이지 구매 내역 반
  영까지 이어지도록 정리했습니다.

  <br/>

  ## 📋 작업 내용

  - `/resell-books`, `/resell-books/seats/:zoneId` 전용 라우트를 추가하고 리셀 예매 화면을 일반 예매 플로우와 분리했습니다.
  - 예매 진입 상태를 query string 대신 store/route state 기준으로 관리하도록 정리해 일반 예매와 리셀 예매 상태가 섞이지 않도록 수정했습니다.
  - 리셀 예매에서 mock 기반 대기열 응답, 좌석 hold, 리셀 주문/결제/완료 흐름이 동작하도록 queue/payment/resale API 분기를 연결했습니다.
  - 리셀 mock 좌석 데이터와 구역 매칭 로직을 보완하고, mock 좌석맵에서도 좌석 선택과 가격 추이 UI가 자연스럽게 동작하도록 수정했습니다.
  - 결제 mock 데이터에 좌석 등급/가격 정책을 확장해 리셀 예매 화면에서 사용할 수 있는 데이터 폭을 넓혔습니다.
  - 결제 완료 후 `myOrders` query를 갱신하고, 저장된 결제 완료 이력을 마이페이지 구매 내역에 합쳐 리셀 구매 이력이 누락되지 않도록 수정했습니다.
  - 마이페이지에서 리셀 구매 건은 재판매/취소 가능 조건을 분리하고, 모바일 티켓 QR 진입은 가능하도록 버튼 노출 조건을 보정했습니다.