### PR TITLE
[bug] 리셀 티켓 구매이력 판매등록 및 에약 취소 버튼 ui 수정

### DIFF
--- a/src/pages/mypage/model/useMypageData.ts
+++ b/src/pages/mypage/model/useMypageData.ts
@@ -27,11 +27,16 @@ import {
 import type { PurchaseHistoryItem, SaleHistoryItem, PurchaseStatus, SaleStatus } from './historyCard';
 import type { TicketType } from '../ui/TicketTypeBadge';
 import { formatTicketNumber } from './ticketNumber';
+import { parseDateValue } from './purchaseDetailHelpers';
+import { formatBookingCardDateTime, parseBookingDateTime } from '@/shared/lib/bookingDateTime';
 import { readStoredPaymentCompleteItems, type StoredPaymentCompleteItem } from '@/shared/lib/paymentCompleteStorage';
 import { isResaleBookingMockEnabled, isResaleDemoEnabled } from '@/shared/config/runtime';
 
 const formatDate = (dateStr: string) => {
-   const date = new Date(dateStr);
+   const date = parseDateValue(dateStr) ?? parseBookingDateTime(dateStr);
+   if (!date) {
+      return dateStr;
+   }
    const y = date.getFullYear();
    const m = String(date.getMonth() + 1).padStart(2, '0');
    const d = String(date.getDate()).padStart(2, '0');
@@ -39,7 +44,10 @@ const formatDate = (dateStr: string) => {
 };
 
 const formatDateTime = (dateStr: string) => {
-   const date = new Date(dateStr);
+   const date = parseDateValue(dateStr);
+   if (!date) {
+      return formatBookingCardDateTime(dateStr);
+   }
    const y = date.getFullYear();
    const m = String(date.getMonth() + 1).padStart(2, '0');
    const d = String(date.getDate()).padStart(2, '0');

--- a/src/pages/mypage/ui/HistoryCard.tsx
+++ b/src/pages/mypage/ui/HistoryCard.tsx
@@ -134,17 +134,13 @@ export default function HistoryCard(props: HistoryCardProps) {
    const priceLabel = isPurchase ? '구매가' : '판매가';
    const price = isPurchase ? (item as PurchaseHistoryItem).price : (item as SaleHistoryItem).salePrice;
    const status = isPurchase ? (item as PurchaseHistoryItem).paymentStatus : (item as SaleHistoryItem).saleStatus;
-   const isResalePurchase = isPurchase && purchaseItem?.type === '리셀';
-
    const hasPurchaseOrder = Boolean(purchaseOrderId);
    const isCancelablePurchaseStatus =
-      !isResalePurchase &&
       (purchaseItem?.paymentStatus === '입금 대기' ||
          purchaseItem?.paymentStatus === '예매 완료' ||
          purchaseItem?.paymentStatus === '부분 처리');
    const isSellablePurchaseStatus =
-      !isResalePurchase &&
-      (purchaseItem?.paymentStatus === '예매 완료' || purchaseItem?.paymentStatus === '부분 처리');
+      purchaseItem?.paymentStatus === '예매 완료' || purchaseItem?.paymentStatus === '부분 처리';
    const actionTickets = actionTicketsQuery.data ?? [];
    const requestedTicketIds = new Set((purchaseItem?.ticketIds ?? []).filter(Boolean));
    const requestedSeatDetails = new Set(purchaseItem?.game.seats ?? []);
@@ -167,7 +163,7 @@ export default function HistoryCard(props: HistoryCardProps) {
    const showQrBtn =
       hasPurchaseOrder &&
       item.deliveryType === '모바일 티켓' &&
-      (isResalePurchase || isSellablePurchaseStatus);
+      isSellablePurchaseStatus;
    const showDash =
       isPurchase && (purchaseItem?.paymentStatus === '취소/환불' || purchaseItem?.paymentStatus === '관람 완료');
    const canCancelSale = !isPurchase && (item as SaleHistoryItem).canCancel;

--- a/src/pages/mypage/ui/PurchaseDetailPage.tsx
+++ b/src/pages/mypage/ui/PurchaseDetailPage.tsx
@@ -89,6 +89,7 @@ export default function PurchaseDetailPage() {
          return item.ticketId === orderId || item.orderId === orderId || item.orderNumber === orderId;
       });
    }, [orderId]);
+   const isMockResalePurchase = locationStateItem?.type === '리셀' || storedPaymentDetail?.orderType === 'resale';
 
    const resolvedOrderId = useMemo(() => {
       if (locationStateItem?.rawOrderId) return locationStateItem.rawOrderId;
@@ -99,7 +100,7 @@ export default function PurchaseDetailPage() {
    const orderTicketsQuery = useQuery({
       queryKey: ['orderTickets', resolvedOrderId],
       queryFn: () => fetchOrderTickets(resolvedOrderId!),
-      enabled: Boolean(resolvedOrderId),
+      enabled: Boolean(resolvedOrderId) && !isMockResalePurchase,
       retry: false,
    });
 
@@ -109,14 +110,14 @@ export default function PurchaseDetailPage() {
    const ticketDetailQuery = useQuery({
       queryKey: ['ticketDetail', primaryTicketId],
       queryFn: () => fetchTicketDetail(primaryTicketId!),
-      enabled: Boolean(primaryTicketId),
+      enabled: Boolean(primaryTicketId) && !isMockResalePurchase,
       retry: false,
    });
 
    const orderPaymentQuery = useQuery({
       queryKey: ['orderPaymentDetail', resolvedOrderId],
       queryFn: () => fetchOrderPaymentDetail(resolvedOrderId!),
-      enabled: Boolean(resolvedOrderId),
+      enabled: Boolean(resolvedOrderId) && !isMockResalePurchase,
       retry: false,
    });
 
@@ -135,14 +136,14 @@ export default function PurchaseDetailPage() {
    });
 
    const apiDetail = ticketDetailQuery.data;
-   const isLoading = orderTicketsQuery.isLoading || (Boolean(primaryTicketId) && ticketDetailQuery.isLoading);
+   const isLoading = !isMockResalePurchase && (orderTicketsQuery.isLoading || (Boolean(primaryTicketId) && ticketDetailQuery.isLoading));
    // fetchOrderTickets(GET /orders/{id}/tickets)가 백엔드 미구현 상태이므로
    // location.state 또는 storedPaymentDetail로 fallback 가능한 경우 에러로 처리하지 않음
    const hasLocationFallback = Boolean(locationStateItem) || Boolean(storedPaymentDetail);
    const isError =
-      (orderTicketsQuery.isError && !hasLocationFallback) ||
-      (!primaryTicketId && !orderTicketsQuery.isLoading && !hasLocationFallback) ||
-      (Boolean(primaryTicketId) && ticketDetailQuery.isError);
+      (!isMockResalePurchase && orderTicketsQuery.isError && !hasLocationFallback) ||
+      (!isMockResalePurchase && !primaryTicketId && !orderTicketsQuery.isLoading && !hasLocationFallback) ||
+      (!isMockResalePurchase && Boolean(primaryTicketId) && ticketDetailQuery.isError);
 
    useEffect(() => {
       if ((location.state as { showCancelSuccess?: boolean } | null)?.showCancelSuccess) {
@@ -161,7 +162,9 @@ export default function PurchaseDetailPage() {
             if (s === '관람 완료') return 'USED';
             return 'ISSUED';
          };
-         const ticketStatus = paymentStatusToTicketStatus(locationStateItem.paymentStatus);
+         const ticketStatus = locationStateItem.type === '리셀'
+            ? 'RESALE_ISSUED'
+            : paymentStatusToTicketStatus(locationStateItem.paymentStatus);
          const unitPrice = Math.round(locationStateItem.price / Math.max(locationStateItem.game.quantity, 1));
          const seatItems: PurchaseSeatItem[] = locationStateItem.game.seats.map((seat, index) => ({
             ticketId: locationStateItem.ticketIds?.[index] ?? `${locationStateItem.rawOrderId ?? locationStateItem.id}-${index}`,
@@ -214,7 +217,7 @@ export default function PurchaseDetailPage() {
                date: paidAt,
             } : undefined,
             canCancel: ticketStatus !== 'INVALID',
-            canSell: locationStateItem.canSell,
+            canSell: locationStateItem.type === '리셀' ? ticketStatus !== 'INVALID' : locationStateItem.canSell,
             deliveryMethod: '모바일 QR',
          };
       }
@@ -377,6 +380,7 @@ export default function PurchaseDetailPage() {
       orderTickets,
       stadiumQuery.data,
       storedPaymentDetail,
+      isMockResalePurchase,
    ]);
 
    if (isLoading) return <div className="py-24 text-center text-body-1-regular">정보를 불러오는 중입니다...</div>;


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #208

<br/>

## 🔎 개요
리셀 티켓 구매이력 판매등록 및 에약 취소 버튼이 나타나도록 ui 수정을 하고 리셀 티켓 구매이력에서 경기 날짜 데이터가 포맷에 맞지 않아 깨지는 현상 수정
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>

## 📋 작업 내용
- 리셀 티켓 구매이력 판매등록 및 에약 취소 버튼 ui 드러나도록 수정
- 리셀 티켓 구매이력에서 경기 날짜 데이터가 포맷에 맞지 않아 깨지는 현상 수정
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

<br/>
