### PR TITLE
[bug] 리셀/ 일반 예매 분리 리팩토링 이후 일부 인증 필요 api 인증 헤더 누락 버그

### DIFF
--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -29,7 +29,6 @@ const shouldKeepSessionAlivePathPrefixes = ["/books", "/resell-books", "/tickets
 const PUBLIC_API_PATH_PATTERNS = [
   /^\/api\/v1\/games(?:\/|$)/,
   /^\/api\/v1\/baseball-teams(?:\/|$)/,
-  /^\/api\/v1\/queue(?:\/|$)/,
   /^\/api\/v1\/seat-reservations(?:\/|$)/,
   // 예매/리셀 플로우 API는 queue token / hold 기반으로 동작하므로
   // 로그인 쿠키 세션을 같이 보내면 RBAC 게이트웨이에 막힐 수 있다.
@@ -129,6 +128,10 @@ const shouldSkipAuthorizationHeader = (config: AxiosRequestConfig) => {
 
   try {
     const { pathname } = new URL(requestUrl, window.location.origin);
+    if (/^\/api\/v1\/queue\/[^/]+\/global-status$/.test(pathname)) {
+      return true;
+    }
+
     if (PUBLIC_API_PATH_PATTERNS.some((pattern) => pattern.test(pathname))) {
       return true;
     }
@@ -179,6 +182,10 @@ const shouldSkipCredentials = (config: AxiosRequestConfig) => {
 
   try {
     const { pathname } = new URL(requestUrl, window.location.origin);
+    if (/^\/api\/v1\/queue\/[^/]+\/global-status$/.test(pathname)) {
+      return true;
+    }
+
     return PUBLIC_API_PATH_PATTERNS.some((pattern) => pattern.test(pathname));
   } catch {
     return false;

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -29,7 +29,6 @@ const shouldKeepSessionAlivePathPrefixes = ["/books", "/resell-books", "/tickets
 const PUBLIC_API_PATH_PATTERNS = [
   /^\/api\/v1\/games(?:\/|$)/,
   /^\/api\/v1\/baseball-teams(?:\/|$)/,
-  /^\/api\/v1\/seat-reservations(?:\/|$)/,
   // 예매/리셀 플로우 API는 queue token / hold 기반으로 동작하므로
   // 로그인 쿠키 세션을 같이 보내면 RBAC 게이트웨이에 막힐 수 있다.
   /^\/api\/v1\/orders(?:\/|$)/,


### PR DESCRIPTION
## #️⃣ 관련 이슈
리셀/ 일반 예매 분리 리팩토링 이후 일부 인증 필요 api 인증 헤더 누락 버그
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->

<br/>

## 🔎 개요
리셀/ 일반 예매 분리 리팩토링 이후 일부 인증 필요 api 인증 헤더 누락 버그 수정
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>

## 📋 작업 내용
-apiClient에서 무인가 api 목록에서 대기열 및 좌석 예약 api 제외
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

<br/>
