### PR TITLE
[bug] 마이페이지 구매/리셀 처리 및 API 연동 개선

### DIFF
--- a/src/pages/mypage/model/useMypageData.ts
+++ b/src/pages/mypage/model/useMypageData.ts
@@ -4,9 +4,7 @@ import { useAuthStore } from '@/entities/auth/model/authStore';
 import { fetchMyProfile, fetchMyProfileSummary } from '@/entities/user/api/memberApi';
 import {
    fetchMyTicketInfo,
-   fetchTicketDetail,
    type MyTicketInfo,
-   type TicketDetail,
 } from '@/entities/ticket/api/ticketApi';
 import {
    fetchMyResaleListingSummary,
@@ -108,7 +106,6 @@ const mapSaleStatus = (status: ResaleListingItem['listingStatus']): SaleStatus =
 type EnrichedOrderListItem = {
    order: PaymentPurchaseHistoryItem;
    ticketIds: string[];
-   primaryTicketDetail?: TicketDetail;
 };
 
 type EnrichedResaleListingItem = ResaleListingItem & {
@@ -116,26 +113,14 @@ type EnrichedResaleListingItem = ResaleListingItem & {
    orderNumber: string;
    orderStatus: ResaleListingOrderStatus;
    orderCreatedAt: string;
-   ticketDetail?: TicketDetail;
 };
 
 const fetchMyOrderSummaries = async (): Promise<EnrichedOrderListItem[]> => {
-   // purchases?size=100 응답의 ticketIds 필드 사용 (GET /api/v1/orders/{id}/tickets 제거)
    const purchaseHistory = await fetchPurchaseHistory({ size: 100 });
-   const orders: PaymentPurchaseHistoryItem[] = purchaseHistory.list;
-
-   return Promise.all(
-      orders.map(async (order) => {
-         const ticketIds = order.ticketIds ?? [];
-         const primaryTicketId = ticketIds[0];
-         try {
-            const primaryTicketDetail = primaryTicketId ? await fetchTicketDetail(primaryTicketId) : undefined;
-            return { order, ticketIds, primaryTicketDetail };
-         } catch {
-            return { order, ticketIds, primaryTicketDetail: undefined };
-         }
-      }),
-   );
+   return purchaseHistory.list.map((order) => ({
+      order,
+      ticketIds: order.ticketIds ?? [],
+   }));
 };
 
 const mapStoredPaymentCompleteItemToPurchaseHistory = (item: StoredPaymentCompleteItem): PurchaseHistoryItem => {
@@ -176,30 +161,13 @@ const fetchMyResaleListingsWithGameInfo = async (): Promise<EnrichedResaleListin
          try {
             const listings = await fetchResaleListingOrderDetails(order.orderId);
 
-            return Promise.all(
-               listings.map(async (listing) => {
-                  try {
-                     const ticketDetail = await fetchTicketDetail(listing.ticketId);
-
-                     return {
-                        ...listing,
-                        orderId: order.orderId,
-                        orderNumber: order.orderNumber,
-                        orderStatus: order.orderStatus,
-                        orderCreatedAt: order.createdAt,
-                        ticketDetail,
-                     };
-                  } catch {
-                     return {
-                        ...listing,
-                        orderId: order.orderId,
-                        orderNumber: order.orderNumber,
-                        orderStatus: order.orderStatus,
-                        orderCreatedAt: order.createdAt,
-                     };
-                  }
-               }),
-            );
+            return listings.map((listing) => ({
+               ...listing,
+               orderId: order.orderId,
+               orderNumber: order.orderNumber,
+               orderStatus: order.orderStatus,
+               orderCreatedAt: order.createdAt,
+            }));
          } catch {
             return [];
          }
@@ -254,15 +222,10 @@ export const useMyOrdersData = () => {
          : [];
 
    const data = useMemo((): PurchaseHistoryItem[] => {
-      const apiOrders = (query.data ?? []).map(({ order, ticketIds, primaryTicketDetail }) => {
-         const displaySeatInfos = order.seatInfos.length > 0
-            ? order.seatInfos
-            : primaryTicketDetail?.seatInfo
-               ? [primaryTicketDetail.seatInfo]
-               : [];
+      const apiOrders = (query.data ?? []).map(({ order, ticketIds }) => {
+         const displaySeatInfos = order.seatInfos ?? [];
          const primarySeatInfo = displaySeatInfos[0];
-         const sectionLabel = primaryTicketDetail?.seatGradeName
-            ?? (primarySeatInfo ? parseGradeName(primarySeatInfo) : '좌석 정보');
+         const sectionLabel = primarySeatInfo ? parseGradeName(primarySeatInfo) : '좌석 정보';
          const seats = displaySeatInfos.length > 0
             ? displaySeatInfos.map((seatInfo) => parseSeatDetail(seatInfo))
             : Array.from({ length: order.totalQuantity }, (_, i) => `좌석${i + 1}`);
@@ -270,11 +233,10 @@ export const useMyOrdersData = () => {
             ? Math.round(order.totalAmount / order.totalQuantity)
             : 0;
          const seatPrices = ticketIds.map(() => unitPrice);
-         const gameTitle = order.gameTitle ?? primaryTicketDetail?.gameTitle ?? 'KBO 리그 경기';
-         const stadiumName = primaryTicketDetail?.stadiumName
-            ?? (order.stadiumId ? STADIUM_REFERENCES[order.stadiumId]?.displayName : undefined)
+         const gameTitle = order.gameTitle ?? 'KBO 리그 경기';
+         const stadiumName = (order.stadiumId ? STADIUM_REFERENCES[order.stadiumId]?.displayName : undefined)
             ?? '야구장';
-         const gameDate = order.gameDate ?? primaryTicketDetail?.gameDate;
+         const gameDate = order.gameDate;
 
          return {
             id: ticketIds[0] ?? order.orderId,
@@ -342,24 +304,21 @@ export const useMyResaleListData = () => {
       return data.map((listing) => ({
            id: listing.listingId,
             ticketId: listing.ticketId,
-            orderId: formatTicketNumber(listing.orderNumber ?? listing.ticketDetail?.ticketNumber ?? listing.ticketNumber ?? listing.ticketId, 'resale'),
+            orderId: formatTicketNumber(listing.orderNumber ?? listing.ticketNumber ?? listing.ticketId, 'resale'),
             orderDate: formatDate(listing.orderCreatedAt ?? listing.listedAt),
             soldAt: listing.soldAt ? formatDateTime(listing.soldAt) : undefined,
             canceledAt: listing.canceledAt ? formatDateTime(listing.canceledAt) : undefined,
             type: '리셀' as TicketType,
             game: {
-               teams: listing.ticketDetail?.gameTitle || listing.gameTitle || 'KBO 리그 경기',
-               venue: listing.ticketDetail?.stadiumName || listing.stadiumName || '야구장',
-               datetime: listing.ticketDetail?.gameDate
-                  ? formatDate(listing.ticketDetail.gameDate)
-                  : listing.gameDate
-                     ? formatDate(listing.gameDate)
-                     : formatDate(listing.orderCreatedAt ?? listing.listedAt),
+               teams: listing.gameTitle || 'KBO 리그 경기',
+               venue: listing.stadiumName || '야구장',
+               datetime: listing.gameDate
+                  ? formatDate(listing.gameDate)
+                  : formatDate(listing.orderCreatedAt ?? listing.listedAt),
                quantity: 1,
                section:
-                  listing.ticketDetail?.seatGradeName
-                  ?? (parseGradeName(listing.ticketDetail?.seatInfo ?? listing.seatInfo) || '정보 없음'),
-               seats: [parseSeatDetail(listing.ticketDetail?.seatInfo ?? listing.seatInfo)],
+                  parseGradeName(listing.seatInfo) || '정보 없음',
+               seats: [parseSeatDetail(listing.seatInfo)],
             },
             salePrice: listing.listingPrice,
             saleStatus: mapSaleStatus(listing.listingStatus),

--- a/src/pages/mypage/ui/ResellRegisterDialog.tsx
+++ b/src/pages/mypage/ui/ResellRegisterDialog.tsx
@@ -37,6 +37,19 @@ const formatGameDateTime = (value: string) => {
    return `${year}.${month}.${day} (${weekday}) ${hours}:${minutes}`;
 };
 
+const getAllowedResalePriceRange = (basePrice: number) => {
+   const minPrice = Math.floor(basePrice * 0.7);
+   const maxPrice = Math.ceil(basePrice * 1.3);
+
+   return { minPrice, maxPrice };
+};
+
+const formatAllowedResalePriceRangeText = (basePrice: number) => {
+   const { minPrice, maxPrice } = getAllowedResalePriceRange(basePrice);
+
+   return `판매 가능 금액: ${minPrice.toLocaleString()}원 ~ ${maxPrice.toLocaleString()}원`;
+};
+
 // ─── 체크박스 아이콘 ────────────────────────────────────────────────
 function CheckboxIcon({ checked }: { checked: boolean }) {
    if (checked) {
@@ -161,6 +174,23 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
          return;
       }
 
+      const invalidRequest = requests.find(({ listingPrice }, requestIndex) => {
+         const seatIndex = indices[requestIndex];
+         const basePrice = seatPrices[seatIndex] ?? unitPrice;
+         const { minPrice, maxPrice } = getAllowedResalePriceRange(basePrice);
+
+         return listingPrice < minPrice || listingPrice > maxPrice;
+      });
+
+      if (invalidRequest) {
+         const invalidSeatIndex = indices[requests.indexOf(invalidRequest)];
+         const basePrice = seatPrices[invalidSeatIndex] ?? unitPrice;
+         const { minPrice, maxPrice } = getAllowedResalePriceRange(basePrice);
+
+         alert(`판매가는 ${minPrice.toLocaleString()}원 ~ ${maxPrice.toLocaleString()}원 이내여야 합니다.`);
+         return;
+      }
+
       setIsSubmitting(true);
       try {
          const response = await createResaleListings({ listings: requests });
@@ -266,7 +296,14 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
                               </button>
                            </div>
                            {/* 토글 On: 통합 가격 입력 */}
-                           {bulkToggle && <PriceInput value={bulkPrice} onChange={setBulkPrice} />}
+                           {bulkToggle && (
+                              <div className="flex flex-col gap-2">
+                                 <PriceInput value={bulkPrice} onChange={setBulkPrice} />
+                                 <p className="text-[12px] text-[#646f7c] leading-[1.45]">
+                                    선택한 좌석별 구매가 기준으로 70% ~ 130% 범위에서 입력할 수 있습니다.
+                                 </p>
+                              </div>
+                           )}
                         </div>
                      )}
 
@@ -307,6 +344,9 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
                                                 value={prices[idx] ?? ''}
                                                 onChange={v => setPrices(prev => ({ ...prev, [idx]: v }))}
                                              />
+                                             <p className="mt-2 text-[12px] text-[#646f7c] leading-[1.45]">
+                                                {formatAllowedResalePriceRangeText(seatPrice)}
+                                             </p>
                                           </div>
                                        )}
                                     </div>


### PR DESCRIPTION
## #️⃣ 관련 이슈

  - #186
  - #343

  <br/>

  ## 🔎 개요

  마이페이지 구매내역/리셀 판매 등록 흐름에서 발생하던 연동 오류를 수정하고, 목록 화면에서 불필요하게 많이 발생하던 API 요청을 줄였습니다.
  추가로 리셀 판매 등록 시 허용 가능한 판매가 범위를 사용자에게 사전에 안내하도록 보완했습니다.

  <br/>

  ## 📋 작업 내용

  - `GET /api/v1/payments/purchases` 응답의 `ticketIds`를 기준으로 구매이력 데이터를 안정적으로 반영하도록 수정
  - 리셀 구매 건이 일반 티켓처럼 판매 가능 상태로 처리되지 않도록 마이페이지 카드 분기 보정
  - 리셀 결제 mock API에서 주문 생성/결제 완료 응답 구조를 현재 프론트 흐름에 맞게 수정
  - 리셀 주문 생성 시 구매자 정보와 실제 리스팅 합산 금액을 반영하도록 mock 로직 수정
  - 마이페이지 메인 목록에서 구매/판매 건마다 추가 `ticket detail` 요청이 발생하던 N+1 구조 제거
  - 리셀 판매 등록 다이얼로그에 좌석별 판매 가능 금액 범위 안내 추가
  - 리셀 판매 등록 시 프론트에서도 구매가 기준 70% ~ 130% 범위를 먼저 검증하도록 보완