### PR TITLE
[bug] 리셀 판매내역 및 마이페이지 요약 로컬 데이터 fallback 반영

### DIFF
--- a/src/pages/mypage/model/useMypageData.ts
+++ b/src/pages/mypage/model/useMypageData.ts
@@ -261,16 +261,26 @@ export const useMyTicketInfoData = () => {
    return useQuery<MyTicketInfo>({
       queryKey: ['myTicketInfo', accessToken, currentUserId],
       queryFn: async () => {
-         const apiInfo = await fetchMyTicketInfo();
          const storedListingSummary = getStoredResaleListingSummary(currentUserId);
          const storedResalePurchaseTicketCount = getStoredResalePurchaseTicketCount();
 
-         return {
-            ownedTicketCount: apiInfo.ownedTicketCount + storedResalePurchaseTicketCount,
-            listingCount: apiInfo.listingCount + storedListingSummary.listingCount,
-            soldCount: apiInfo.soldCount + storedListingSummary.soldCount,
-            unsettledAmount: apiInfo.unsettledAmount + storedListingSummary.unsettledAmount,
-         };
+         try {
+            const apiInfo = await fetchMyTicketInfo();
+
+            return {
+               ownedTicketCount: apiInfo.ownedTicketCount + storedResalePurchaseTicketCount,
+               listingCount: apiInfo.listingCount + storedListingSummary.listingCount,
+               soldCount: apiInfo.soldCount + storedListingSummary.soldCount,
+               unsettledAmount: apiInfo.unsettledAmount + storedListingSummary.unsettledAmount,
+            };
+         } catch {
+            return {
+               ownedTicketCount: storedResalePurchaseTicketCount,
+               listingCount: storedListingSummary.listingCount,
+               soldCount: storedListingSummary.soldCount,
+               unsettledAmount: storedListingSummary.unsettledAmount,
+            };
+         }
       },
       enabled: Boolean(accessToken),
    });
@@ -371,12 +381,8 @@ export const useMyResaleListData = () => {
       queryFn: async () => {
          try {
             return await fetchMyResaleListingsWithGameInfo();
-         } catch (error) {
-            if (readStoredResaleListings(currentUserId).length > 0) {
-               return [];
-            }
-
-            throw error;
+         } catch {
+            return readStoredResaleListings(currentUserId);
          }
       },
       enabled: Boolean(accessToken),

--- a/src/pages/mypage/model/useMypageData.ts
+++ b/src/pages/mypage/model/useMypageData.ts
@@ -27,6 +27,7 @@ import { parseDateValue } from './purchaseDetailHelpers';
 import { STADIUM_REFERENCES } from '@/entities/game/model/schedule';
 import { formatBookingCardDateTime, parseBookingDateTime } from '@/shared/lib/bookingDateTime';
 import { readStoredPaymentCompleteItems, type StoredPaymentCompleteItem } from '@/shared/lib/paymentCompleteStorage';
+import { readStoredResaleListings, type StoredResaleListingItem } from '@/shared/lib/resaleListingStorage';
 import { isResaleBookingMockEnabled, isResaleDemoEnabled } from '@/shared/config/runtime';
 
 const formatDate = (dateStr: string) => {
@@ -113,6 +114,62 @@ type EnrichedResaleListingItem = ResaleListingItem & {
    orderNumber: string;
    orderStatus: ResaleListingOrderStatus;
    orderCreatedAt: string;
+};
+
+const mergeResaleListings = (
+   apiListings: EnrichedResaleListingItem[],
+   storedListings: StoredResaleListingItem[],
+): EnrichedResaleListingItem[] => {
+   const merged = new Map<string, EnrichedResaleListingItem>();
+
+   for (const listing of storedListings) {
+      merged.set(listing.listingId, listing);
+   }
+
+   for (const listing of apiListings) {
+      merged.set(listing.listingId, listing);
+   }
+
+   return Array.from(merged.values()).sort((left, right) =>
+      (right.orderCreatedAt ?? right.listedAt).localeCompare(left.orderCreatedAt ?? left.listedAt),
+   );
+};
+
+const getStoredResalePurchaseTicketCount = () => {
+   return readStoredPaymentCompleteItems()
+      .filter((item) => item.orderType === 'resale')
+      .reduce((sum, item) => sum + (item.issuedTicketCount ?? item.quantity ?? 0), 0);
+};
+
+const getStoredResaleListingSummary = (userId?: string | null) => {
+   const storedListings = readStoredResaleListings(userId);
+
+   return storedListings.reduce(
+      (summary, listing) => {
+         switch (listing.listingStatus) {
+            case 'LISTING':
+            case 'HOLD':
+               summary.listingCount += 1;
+               break;
+            case 'SOLD':
+               summary.soldCount += 1;
+               summary.unsettledAmount += listing.listingPrice;
+               break;
+            case 'SETTLED':
+               summary.soldCount += 1;
+               break;
+            default:
+               break;
+         }
+
+         return summary;
+      },
+      {
+         listingCount: 0,
+         soldCount: 0,
+         unsettledAmount: 0,
+      },
+   );
 };
 
 const fetchMyOrderSummaries = async (): Promise<EnrichedOrderListItem[]> => {
@@ -295,14 +352,27 @@ export const useMyOrdersData = () => {
 
 export const useMyResaleListData = () => {
    const accessToken = useAuthStore(s => s.accessToken);
+   const currentUserId = useAuthStore(s => s.currentUserId);
 
    return useQuery({
-      queryKey: ['myResales', accessToken],
-      queryFn: fetchMyResaleListingsWithGameInfo,
+      queryKey: ['myResales', accessToken, currentUserId],
+      queryFn: async () => {
+         try {
+            return await fetchMyResaleListingsWithGameInfo();
+         } catch (error) {
+            if (readStoredResaleListings(currentUserId).length > 0) {
+               return [];
+            }
+
+            throw error;
+         }
+      },
       enabled: Boolean(accessToken),
       select: (data): SaleHistoryItem[] => {
-      return data.map((listing) => ({
-           id: listing.listingId,
+         const mergedListings = mergeResaleListings(data, readStoredResaleListings(currentUserId));
+
+         return mergedListings.map((listing) => ({
+            id: listing.listingId,
             ticketId: listing.ticketId,
             orderId: formatTicketNumber(listing.orderNumber ?? listing.ticketNumber ?? listing.ticketId, 'resale'),
             orderDate: formatDate(listing.orderCreatedAt ?? listing.listedAt),

--- a/src/pages/mypage/model/useMypageData.ts
+++ b/src/pages/mypage/model/useMypageData.ts
@@ -256,10 +256,22 @@ export const useMyProfileSummaryData = () => {
 
 export const useMyTicketInfoData = () => {
    const accessToken = useAuthStore(s => s.accessToken);
+   const currentUserId = useAuthStore(s => s.currentUserId);
 
    return useQuery<MyTicketInfo>({
-      queryKey: ['myTicketInfo', accessToken],
-      queryFn: fetchMyTicketInfo,
+      queryKey: ['myTicketInfo', accessToken, currentUserId],
+      queryFn: async () => {
+         const apiInfo = await fetchMyTicketInfo();
+         const storedListingSummary = getStoredResaleListingSummary(currentUserId);
+         const storedResalePurchaseTicketCount = getStoredResalePurchaseTicketCount();
+
+         return {
+            ownedTicketCount: apiInfo.ownedTicketCount + storedResalePurchaseTicketCount,
+            listingCount: apiInfo.listingCount + storedListingSummary.listingCount,
+            soldCount: apiInfo.soldCount + storedListingSummary.soldCount,
+            unsettledAmount: apiInfo.unsettledAmount + storedListingSummary.unsettledAmount,
+         };
+      },
       enabled: Boolean(accessToken),
    });
 };

--- a/src/pages/mypage/ui/HistoryCard.tsx
+++ b/src/pages/mypage/ui/HistoryCard.tsx
@@ -14,6 +14,8 @@ import CancelBookingDialog from './CancelBookingDialog';
 import NoAccountDialog from './NoAccountDialog';
 import ActionStatusDialog from './ActionStatusDialog';
 import { cancelResaleListing } from '@/entities/resale/api/resaleApi';
+import { useAuthStore } from '@/entities/auth/model/authStore';
+import { markStoredResaleListingCanceled } from '@/shared/lib/resaleListingStorage';
 
 export type PurchaseStatus = '입금 대기' | '예매 완료' | '부분 처리' | '관람 완료' | '취소/환불';
 export type SaleStatus = '판매 중' | '판매 완료' | '정산 대기' | '판매 취소 대기' | '취소 대기' | '취소 완료';
@@ -81,6 +83,7 @@ const isPurchaseHistoryItem = (
 export default function HistoryCard(props: HistoryCardProps) {
    const navigate = useNavigate();
    const queryClient = useQueryClient();
+   const currentUserId = useAuthStore(s => s.currentUserId);
    const [expanded, setExpanded] = useState(false);
    const [resellOpen, setResellOpen] = useState(false);
    const [cancelOpen, setCancelOpen] = useState(false);
@@ -132,6 +135,7 @@ export default function HistoryCard(props: HistoryCardProps) {
    const { mutate: cancelSale, isPending: isCancelingSale } = useMutation({
       mutationFn: () => cancelResaleListing(item.id),
       onSuccess: () => {
+         markStoredResaleListingCanceled(currentUserId, item.id);
          void queryClient.invalidateQueries({ queryKey: ['myResales'] });
          void queryClient.invalidateQueries({ queryKey: ['myResaleUnsettledAmount'] });
          setSaleCancelDialogType('success');

--- a/src/pages/mypage/ui/ResellRegisterDialog.tsx
+++ b/src/pages/mypage/ui/ResellRegisterDialog.tsx
@@ -3,9 +3,11 @@ import { createPortal } from 'react-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { X } from 'lucide-react';
 
+import { useAuthStore } from '@/entities/auth/model/authStore';
 import { createResaleListings } from '@/entities/resale/api/resaleApi';
 import { useResellRegisterInsights } from '@/features/resale/model/useResellRegisterInsights';
 import { formatPrice } from '@/pages/books/model/zoneData';
+import { createStoredResaleListings } from '@/shared/lib/resaleListingStorage';
 import ResellPriceChart from '@/pages/books/ui/components/ResellPriceChart';
 import { getErrorMessage } from '@/shared/lib/error/getErrorMessage';
 import { Button } from '@/shared/ui/button';
@@ -101,6 +103,7 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
    const [createdSaleId, setCreatedSaleId] = useState<string | null>(null);
    const [isSubmitting, setIsSubmitting] = useState(false);
    const queryClient = useQueryClient();
+   const currentUserId = useAuthStore(s => s.currentUserId);
    const seatPrices = item.seatPrices ?? [];
    const unitPrice =
       seatPrices.length > 0
@@ -194,6 +197,17 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
       setIsSubmitting(true);
       try {
          const response = await createResaleListings({ listings: requests });
+
+         createStoredResaleListings({
+            currentUserId,
+            orders: response.orders,
+            listings: response.listings,
+            fallbackOrderCreatedAt: new Date().toISOString(),
+            fallbackGameTitle: item.game.teams,
+            fallbackGameDate: item.rawOrderDate ?? item.game.datetime,
+            fallbackStadiumName: item.game.venue,
+         });
+
          setCreatedSaleId(response.listings[0]?.listingId ?? null);
 
          await Promise.all([

--- a/src/pages/mypage/ui/SaleDetailPage.tsx
+++ b/src/pages/mypage/ui/SaleDetailPage.tsx
@@ -6,7 +6,9 @@ import { AlertCircle } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import { Separator } from '@/shared/ui/separator';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuthStore } from '@/entities/auth/model/authStore';
 import { cancelResaleListing } from '@/entities/resale/api/resaleApi';
+import { markStoredResaleListingCanceled } from '@/shared/lib/resaleListingStorage';
 import { useMyResaleListData } from '../model/useMypageData';
 import StatusBadge from './StatusBadge';
 import type { BadgeVariant } from './StatusBadge';
@@ -48,6 +50,7 @@ export default function SaleDetailPage() {
    const { id } = useParams<{ id: string }>();
    const navigate = useNavigate();
    const queryClient = useQueryClient();
+   const currentUserId = useAuthStore(s => s.currentUserId);
    const resaleListQuery = useMyResaleListData();
    const apiDetail = (resaleListQuery.data ?? []).find((item) => item.id === id);
    const [cancelDialogType, setCancelDialogType] = useState<'success' | 'error' | null>(null);
@@ -55,6 +58,7 @@ export default function SaleDetailPage() {
    const { mutate: cancelListing, isPending: isCanceling } = useMutation({
       mutationFn: () => cancelResaleListing(id!),
       onSuccess: () => {
+         markStoredResaleListingCanceled(currentUserId, id!);
          void queryClient.invalidateQueries({ queryKey: ['myResales'] });
          void queryClient.invalidateQueries({ queryKey: ['myResaleSummary'] });
          void queryClient.invalidateQueries({ queryKey: ['myResaleUnsettledAmount'] });

--- a/src/shared/lib/resaleListingStorage.ts
+++ b/src/shared/lib/resaleListingStorage.ts
@@ -1,0 +1,155 @@
+import type { ResaleListingItem, ResaleListingOrderStatus, ResaleListingOrderSummary } from '@/entities/resale/api/resaleApi';
+
+const RESALE_LISTING_STORAGE_KEY = 'ballx.resale-listings';
+
+export interface StoredResaleListingItem extends ResaleListingItem {
+   orderId: string;
+   orderNumber: string;
+   orderStatus: ResaleListingOrderStatus;
+   orderCreatedAt: string;
+}
+
+interface StoredResaleListingStore {
+   version: 1;
+   users: Record<string, StoredResaleListingItem[]>;
+}
+
+const getStorage = () => {
+   if (typeof window === 'undefined') {
+      return null;
+   }
+
+   return window.localStorage;
+};
+
+const normalizeUserKey = (userId?: string | null) => userId?.trim() || 'anonymous';
+
+const readStore = (): StoredResaleListingStore => {
+   const storage = getStorage();
+
+   if (!storage) {
+      return { version: 1, users: {} };
+   }
+
+   const rawValue = storage.getItem(RESALE_LISTING_STORAGE_KEY);
+
+   if (!rawValue) {
+      return { version: 1, users: {} };
+   }
+
+   try {
+      const parsed = JSON.parse(rawValue) as Partial<StoredResaleListingStore>;
+
+      return {
+         version: 1,
+         users: typeof parsed.users === 'object' && parsed.users !== null ? parsed.users : {},
+      };
+   } catch {
+      return { version: 1, users: {} };
+   }
+};
+
+const writeStore = (store: StoredResaleListingStore) => {
+   const storage = getStorage();
+
+   if (!storage) {
+      return;
+   }
+
+   storage.setItem(RESALE_LISTING_STORAGE_KEY, JSON.stringify(store));
+};
+
+export const readStoredResaleListings = (userId?: string | null): StoredResaleListingItem[] => {
+   const store = readStore();
+   const userKey = normalizeUserKey(userId);
+   const listings = store.users[userKey];
+
+   return Array.isArray(listings) ? listings : [];
+};
+
+export const saveStoredResaleListings = (
+   userId: string | null | undefined,
+   listings: StoredResaleListingItem[],
+) => {
+   const store = readStore();
+   const userKey = normalizeUserKey(userId);
+   const merged = new Map<string, StoredResaleListingItem>();
+
+   for (const listing of readStoredResaleListings(userId)) {
+      merged.set(listing.listingId, listing);
+   }
+
+   for (const listing of listings) {
+      merged.set(listing.listingId, listing);
+   }
+
+   store.users[userKey] = Array.from(merged.values()).sort((left, right) =>
+      (right.orderCreatedAt || right.listedAt).localeCompare(left.orderCreatedAt || left.listedAt),
+   );
+
+   writeStore(store);
+};
+
+export const markStoredResaleListingCanceled = (userId: string | null | undefined, listingId: string) => {
+   const store = readStore();
+   const userKey = normalizeUserKey(userId);
+   const listings = store.users[userKey];
+
+   if (!Array.isArray(listings)) {
+      return;
+   }
+
+   store.users[userKey] = listings.map((listing) =>
+      listing.listingId === listingId
+         ? {
+              ...listing,
+              listingStatus: 'CANCELED',
+              canceledAt: new Date().toISOString(),
+              isCancelable: false,
+              isPurchasable: false,
+           }
+         : listing,
+   );
+
+   writeStore(store);
+};
+
+export const createStoredResaleListings = ({
+   currentUserId,
+   orders,
+   listings,
+   fallbackOrderCreatedAt,
+   fallbackGameTitle,
+   fallbackGameDate,
+   fallbackStadiumName,
+}: {
+   currentUserId?: string | null;
+   orders: ResaleListingOrderSummary[];
+   listings: ResaleListingItem[];
+   fallbackOrderCreatedAt: string;
+   fallbackGameTitle: string;
+   fallbackGameDate: string;
+   fallbackStadiumName: string;
+}) => {
+   const orderById = new Map(orders.map((order) => [order.orderId, order]));
+
+   const storedListings = listings.map<StoredResaleListingItem>((listing, index) => {
+      const matchedOrder = listing.orderId ? orderById.get(listing.orderId) : undefined;
+      const fallbackOrderId = matchedOrder?.orderId ?? listing.orderId ?? `local-order-${listing.listingId}-${index}`;
+
+      return {
+         ...listing,
+         orderId: fallbackOrderId,
+         orderNumber: matchedOrder?.orderNumber ?? `LOCAL-${listing.listingId.slice(0, 8).toUpperCase()}`,
+         orderStatus: 'LISTING',
+         orderCreatedAt: listing.listedAt ?? fallbackOrderCreatedAt,
+         gameTitle: listing.gameTitle || fallbackGameTitle,
+         gameDate: listing.gameDate || fallbackGameDate,
+         stadiumName: listing.stadiumName || fallbackStadiumName,
+      };
+   });
+
+   saveStoredResaleListings(currentUserId, storedListings);
+
+   return storedListings;
+};


### PR DESCRIPTION
 ## #️⃣ 관련 이슈

  - #186

  <br/>

  ## 🔎 개요

  백엔드 리셀 판매 그룹 조회 API가 500을 반환하는 상황에서도,
  리셀 등록 성공 건과 리셀 예매 완료 건을 로컬 저장 데이터로 보완해
  마이페이지 판매내역/요약이 끊기지 않도록 수정했습니다.

  <br/>

  ## 📋 작업 내용

  - 리셀 등록 성공 응답의 `orders[]`, `listings[]`를 `localStorage`에 저장하도록 추가했습니다.
  - 마이페이지 판매내역 조회 시 서버 응답과 로컬 저장된 리셀 판매내역을 `listingId` 기준으로 병합하도록 변경했습니다.
  - 리셀 판매 그룹 조회 API가 실패하더라도 로컬 저장된 판매내역이 있으면 목록/상세를 계속 노출하도록 처리했습니다.
  - 판매 취소 성공 시 로컬에 저장된 리셀 판매 상태도 `CANCELED`로 함께 갱신되도록 반영했습니다.
  - 마이페이지 요약 카드에서 서버 `tickets/myinfo` 응답에 로컬 리셀 판매내역 요약을 합산하도록 변경했습니다.
  - 세션에 저장된 리셀 예매 완료 데이터를 이용해 `전체 소지` 수치에도 리셀 예매 발급 수량이 반영되도록 수정했습니다.