### PR TITLE
[bug] 초기 렌더링 시 좌석 선택 활성화가 되지 않는 버그 수정

### DIFF
--- a/src/pages/books/model/useBooksPageEntry.ts
+++ b/src/pages/books/model/useBooksPageEntry.ts
@@ -19,6 +19,25 @@ export function useBooksPageEntry(): UseBooksPageEntryResult {
    const clearBookingEntry = useBookingEntryStore(state => state.clearEntry);
    const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
 
+   const isSameBookingEntryState = (left: BookingEntryState | null, right: BookingEntryState | null) => {
+      if (left === right) {
+         return true;
+      }
+
+      if (!left || !right) {
+         return false;
+      }
+
+      const leftKeys = Object.keys(left) as Array<keyof BookingEntryState>;
+      const rightKeys = Object.keys(right) as Array<keyof BookingEntryState>;
+
+      if (leftKeys.length !== rightKeys.length) {
+         return false;
+      }
+
+      return leftKeys.every((key) => left[key] === right[key]);
+   };
+
    useEffect(() => {
       logBookingFlow('useBooksPageEntry', 'resolved bookingEntryState', {
          routeBookingEntryState: summarizeBookingEntry(routeBookingEntryState),
@@ -28,11 +47,11 @@ export function useBooksPageEntry(): UseBooksPageEntryResult {
    }, [bookingEntryState, routeBookingEntryState, storedBookingEntryState]);
 
    useEffect(() => {
-      if (routeBookingEntryState) {
-         logBookingFlow('useBooksPageEntry', 'sync route state to store', summarizeBookingEntry(routeBookingEntryState));
-         setBookingEntry(routeBookingEntryState);
+      if (routeBookingEntryState && bookingEntryState && !isSameBookingEntryState(storedBookingEntryState, bookingEntryState)) {
+         logBookingFlow('useBooksPageEntry', 'sync merged bookingEntryState to store', summarizeBookingEntry(bookingEntryState));
+         setBookingEntry(bookingEntryState);
       }
-   }, [routeBookingEntryState, setBookingEntry]);
+   }, [bookingEntryState, routeBookingEntryState, setBookingEntry, storedBookingEntryState]);
 
    return {
       bookingEntryState,

--- a/src/pages/books/model/useBooksPageEntry.ts
+++ b/src/pages/books/model/useBooksPageEntry.ts
@@ -2,7 +2,12 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { logBookingFlow, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
-import { mergeBookingEntryState, useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
+import {
+   isSameBookingEntryState,
+   mergeBookingEntryState,
+   useBookingEntryStore,
+   type BookingEntryState,
+} from '@/shared/lib/useBookingEntryStore';
 
 type UseBooksPageEntryResult = {
    bookingEntryState: BookingEntryState | null;
@@ -18,25 +23,6 @@ export function useBooksPageEntry(): UseBooksPageEntryResult {
    const patchBookingEntry = useBookingEntryStore(state => state.patchEntry);
    const clearBookingEntry = useBookingEntryStore(state => state.clearEntry);
    const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
-
-   const isSameBookingEntryState = (left: BookingEntryState | null, right: BookingEntryState | null) => {
-      if (left === right) {
-         return true;
-      }
-
-      if (!left || !right) {
-         return false;
-      }
-
-      const leftKeys = Object.keys(left) as Array<keyof BookingEntryState>;
-      const rightKeys = Object.keys(right) as Array<keyof BookingEntryState>;
-
-      if (leftKeys.length !== rightKeys.length) {
-         return false;
-      }
-
-      return leftKeys.every((key) => left[key] === right[key]);
-   };
 
    useEffect(() => {
       logBookingFlow('useBooksPageEntry', 'resolved bookingEntryState', {

--- a/src/pages/books/model/useSeatsPageEntry.ts
+++ b/src/pages/books/model/useSeatsPageEntry.ts
@@ -2,7 +2,12 @@ import { useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import type { BookingFlowMode } from '@/shared/lib/booking-flow';
-import { mergeBookingEntryState, useBookingEntryStore, type BookingEntryState } from '@/shared/lib/useBookingEntryStore';
+import {
+   isSameBookingEntryState,
+   mergeBookingEntryState,
+   useBookingEntryStore,
+   type BookingEntryState,
+} from '@/shared/lib/useBookingEntryStore';
 import { getBookingZones, getStadiumName, getZoneOverviewImage } from './zoneData';
 
 export function useSeatsPageEntry(zoneId: string) {
@@ -13,25 +18,6 @@ export function useSeatsPageEntry(zoneId: string) {
    const storedBookingEntryState = useBookingEntryStore(state => state.entry);
    const setBookingEntry = useBookingEntryStore(state => state.setEntry);
    const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
-
-   const isSameBookingEntryState = (left: BookingEntryState | null, right: BookingEntryState | null) => {
-      if (left === right) {
-         return true;
-      }
-
-      if (!left || !right) {
-         return false;
-      }
-
-      const leftKeys = Object.keys(left) as Array<keyof BookingEntryState>;
-      const rightKeys = Object.keys(right) as Array<keyof BookingEntryState>;
-
-      if (leftKeys.length !== rightKeys.length) {
-         return false;
-      }
-
-      return leftKeys.every((key) => left[key] === right[key]);
-   };
 
    useEffect(() => {
       if (routeBookingEntryState && bookingEntryState && !isSameBookingEntryState(storedBookingEntryState, bookingEntryState)) {

--- a/src/pages/books/model/useSeatsPageEntry.ts
+++ b/src/pages/books/model/useSeatsPageEntry.ts
@@ -14,11 +14,30 @@ export function useSeatsPageEntry(zoneId: string) {
    const setBookingEntry = useBookingEntryStore(state => state.setEntry);
    const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
 
-   useEffect(() => {
-      if (routeBookingEntryState) {
-         setBookingEntry(routeBookingEntryState);
+   const isSameBookingEntryState = (left: BookingEntryState | null, right: BookingEntryState | null) => {
+      if (left === right) {
+         return true;
       }
-   }, [routeBookingEntryState, setBookingEntry]);
+
+      if (!left || !right) {
+         return false;
+      }
+
+      const leftKeys = Object.keys(left) as Array<keyof BookingEntryState>;
+      const rightKeys = Object.keys(right) as Array<keyof BookingEntryState>;
+
+      if (leftKeys.length !== rightKeys.length) {
+         return false;
+      }
+
+      return leftKeys.every((key) => left[key] === right[key]);
+   };
+
+   useEffect(() => {
+      if (routeBookingEntryState && bookingEntryState && !isSameBookingEntryState(storedBookingEntryState, bookingEntryState)) {
+         setBookingEntry(bookingEntryState);
+      }
+   }, [bookingEntryState, routeBookingEntryState, setBookingEntry, storedBookingEntryState]);
 
    const bookingZones = useMemo(
       () => bookingEntryState?.bookingZones ?? getBookingZones(bookingEntryState?.homeTeamId),

--- a/src/shared/lib/useBookingEntryStore.ts
+++ b/src/shared/lib/useBookingEntryStore.ts
@@ -27,6 +27,18 @@ export type BookingEntryState = {
    botData?: BotReport;
 };
 
+const ROUTE_CLEARABLE_ENTRY_KEYS: Array<keyof BookingEntryState> = ['requireCaptcha', 'forceNewSession', 'bookingZones'];
+
+const mergeRouteEntryValue = (
+   mergedEntry: BookingEntryState,
+   key: keyof BookingEntryState,
+   value: BookingEntryState[keyof BookingEntryState],
+) => {
+   if (value !== undefined || ROUTE_CLEARABLE_ENTRY_KEYS.includes(key)) {
+      mergedEntry[key] = value;
+   }
+};
+
 export const mergeBookingEntryState = (
    routeEntry: BookingEntryState | null | undefined,
    storedEntry: BookingEntryState | null | undefined,
@@ -43,11 +55,14 @@ export const mergeBookingEntryState = (
       return routeEntry;
    }
 
-   return {
-      ...storedEntry,
-      // 현재 라우트 진입 정보가 이전 세션보다 우선해야 일반/리셀 플로우가 뒤섞이지 않는다.
-      ...routeEntry,
-   };
+   const mergedEntry = { ...storedEntry };
+
+   // 현재 라우트 진입 정보가 이전 세션보다 우선해야 일반/리셀 플로우가 뒤섞이지 않는다.
+   (Object.keys(routeEntry) as Array<keyof BookingEntryState>).forEach((key) => {
+      mergeRouteEntryValue(mergedEntry, key, routeEntry[key]);
+   });
+
+   return mergedEntry;
 };
 
 type BookingEntryStore = {

--- a/src/shared/lib/useBookingEntryStore.ts
+++ b/src/shared/lib/useBookingEntryStore.ts
@@ -39,6 +39,25 @@ const mergeRouteEntryValue = (
    }
 };
 
+export const isSameBookingEntryState = (left: BookingEntryState | null, right: BookingEntryState | null) => {
+   if (left === right) {
+      return true;
+   }
+
+   if (!left || !right) {
+      return false;
+   }
+
+   const leftKeys = Object.keys(left) as Array<keyof BookingEntryState>;
+   const rightKeys = Object.keys(right) as Array<keyof BookingEntryState>;
+
+   if (leftKeys.length !== rightKeys.length) {
+      return false;
+   }
+
+   return leftKeys.every((key) => left[key] === right[key]);
+};
+
 export const mergeBookingEntryState = (
    routeEntry: BookingEntryState | null | undefined,
    storedEntry: BookingEntryState | null | undefined,


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #363

 ## 🔎 개요

  예매 좌석 페이지 초기 진입 시 좌석 상태 API가 호출되지 않아 좌석 선택이 비활성화되던 문제를 수정했습니다.
  예매 진입 상태를 병합하고 store에 동기화하는 과정에서 `stadiumId` 같은 필수 값이 유실되던 흐름을 보정했습니다.

  <br/>

  ## 📋 작업 내용

  - `mergeBookingEntryState`에서 `route state`의 `undefined` 값이 기존 store 값을 덮어쓰지 않도록 병합 규칙을 수정했습니다.
  - `requireCaptcha`, `forceNewSession`, `bookingZones`처럼 명시적으로 비워야 하는 필드는 예외적으로 `undefined` 반영이 가능하도록 처리했습니다.
  - `useBooksPageEntry`에서 raw route state 대신 병합된 최신 예매 상태만 store에 동기화하도록 수정했습니다.
  - `useSeatsPageEntry`에서도 동일하게 병합 결과 기준으로 store를 갱신하도록 수정했습니다.
  - 이 변경으로 초기 진입 시에도 `stadiumId`, `bookingZones` 등 좌석 상태 조회에 필요한 값이 유지되어 좌석 상태 API가 정상 호출되도록 했습니다.

  <br/>