### PR TITLE
[feat] 마우스 트래킹 구현과 안정화 및 매크로 대시보드 리팩토링

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -4,6 +4,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 const apiTarget = (process.env.PUBLIC_API_BASE_URL ?? 'https://dev.go-ti.shop').trim();
 const mlTarget = (process.env.PUBLIC_MOUSE_ML_URL ?? 'https://api.go-ti.shop').replace(/\/$/, '');
+const dashboardTarget = (process.env.PUBLIC_MACRO_DASHBOARD_API_URL ?? 'https://go-ti.shop').trim();
 
 // Rsbuild configuration — https://rsbuild.rs/config/
 export default defineConfig({
@@ -33,6 +34,15 @@ export default defineConfig({
             changeOrigin: true,
             secure: true,
          },
+         // Go 대시보드 서버 — /api 보다 먼저 선언해야 우선 매칭됨
+         // 기본값: go-ti.shop (EKS), .env에서 PUBLIC_MACRO_DASHBOARD_API_URL 오버라이드 가능
+         '/api/v1/dashboard': { target: dashboardTarget, changeOrigin: true, secure: true },
+         '/api/v1/detections': { target: dashboardTarget, changeOrigin: true, secure: true },
+         '/api/v1/stats': { target: dashboardTarget, changeOrigin: true, secure: true },
+         '/api/v1/mouse-macro': { target: dashboardTarget, changeOrigin: true, secure: true },
+         '/api/v1/interventions': { target: dashboardTarget, changeOrigin: true, secure: true },
+         '/api/v1/analysis': { target: dashboardTarget, changeOrigin: true, secure: true },
+         '/api/v1/alerts': { target: dashboardTarget, changeOrigin: true, secure: true },
          '/api': {
             target: apiTarget,
             changeOrigin: true,

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -4,7 +4,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 const apiTarget = (process.env.PUBLIC_API_BASE_URL ?? 'https://dev.go-ti.shop').trim();
 
-// Docs: https://rsbuild.rs/config/
+// Rsbuild configuration — https://rsbuild.rs/config/
 export default defineConfig({
    plugins: [pluginReact()],
    html: {

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       },
    },
    performance: {
-      removeConsole: ['log', 'info', 'warn'],
+      removeConsole: process.env.NODE_ENV === 'production' ? ['log', 'info', 'warn'] : false,
    },
    server: {
       proxy: {

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -16,6 +16,15 @@ export default defineConfig({
          '@': path.resolve(__dirname, 'src'),
       },
    },
+   output: {
+      sourceMap: {
+         js: false,
+         css: false,
+      },
+   },
+   performance: {
+      removeConsole: ['log', 'info', 'warn'],
+   },
    server: {
       proxy: {
          '/api': {

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const apiTarget = (process.env.PUBLIC_API_BASE_URL ?? 'https://dev.go-ti.shop').trim();
+const mlTarget = (process.env.PUBLIC_MOUSE_ML_URL ?? 'https://api.go-ti.shop').replace(/\/$/, '');
 
 // Rsbuild configuration — https://rsbuild.rs/config/
 export default defineConfig({
@@ -27,6 +28,11 @@ export default defineConfig({
    },
    server: {
       proxy: {
+         '/api/v1/mouse': {
+            target: mlTarget,
+            changeOrigin: true,
+            secure: true,
+         },
          '/api': {
             target: apiTarget,
             changeOrigin: true,

--- a/src/app/providers/router/ui/AppRouter.tsx
+++ b/src/app/providers/router/ui/AppRouter.tsx
@@ -44,6 +44,7 @@ import AuthSessionController from './AuthSessionController';
 import BookingFlowStateGuard from './BookingFlowStateGuard';
 import OAuthMessageListener from './OAuthMessageListener';
 import SessionExpiredPage from '@/pages/session-expired/ui/SessionExpiredPage';
+import MacroDashboardPage from '@/pages/macro-dashboard';
 
 const AppRouter = () => {
    return (
@@ -103,6 +104,7 @@ const AppRouter = () => {
             <Route path="/chip" element={<Chip />} />
             <Route path="/session-expired" element={<SessionExpiredPage />} />
             <Route path="/queue" element={<QueuePage />} />
+            <Route path="/macro-dashboard" element={<MacroDashboardPage />} />
             <Route path="*" element={<Navigate to="/error/404" replace />} />
          </Routes>
       </BrowserRouter>

--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -11,6 +11,7 @@ import { getBookingTeamConfig } from '@/pages/books/model/zoneData';
 import { logBookingFlow, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
 import { useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
 import type { BookingEntryState } from '@/shared/lib/useBookingEntryStore';
+import { useMouseEventTracker } from '@/shared/lib/useMouseEventTracker';
 import BooksExitDialog from '@/shared/widgets/layout/books/BooksExitDialog';
 import { releaseQueueSession } from '@/pages/queue/api/queueApi';
 
@@ -31,6 +32,15 @@ const BooksPage = () => {
       [bookingEntryState?.homeTeamId],
    );
    const requiresCaptcha = Boolean(bookingEntryState?.requireCaptcha);
+   const exitBookingFlowRef = useRef<() => void>(() => {});
+   useMouseEventTracker({
+      userId: bookingEntryState?.userId,
+      onMacroDetected: () => {
+         logBookingFlow('BooksPage', 'mouseML macro detected — blocking booking');
+         window.alert('매크로 사용이 감지되었습니다. 예매에 접근할 수 없습니다.');
+         exitBookingFlowRef.current();
+      },
+   });
    const { zones, isSeatGradeBotBlocked } = useBookingZones({
       bookingEntryState,
       bookingFlowMode,
@@ -97,6 +107,7 @@ const BooksPage = () => {
       clearBookingEntry();
       navigate('/', { replace: true });
    };
+   exitBookingFlowRef.current = () => void exitBookingFlow();
 
    const captcha = useBookingCaptcha({
       requiresCaptcha,

--- a/src/pages/books/ui/BooksPage.tsx
+++ b/src/pages/books/ui/BooksPage.tsx
@@ -11,7 +11,7 @@ import { getBookingTeamConfig } from '@/pages/books/model/zoneData';
 import { logBookingFlow, summarizeBookingEntry } from '@/shared/lib/bookingFlowDebug';
 import { useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
 import type { BookingEntryState } from '@/shared/lib/useBookingEntryStore';
-import { useMouseEventTracker } from '@/shared/lib/useMouseEventTracker';
+
 import BooksExitDialog from '@/shared/widgets/layout/books/BooksExitDialog';
 import { releaseQueueSession } from '@/pages/queue/api/queueApi';
 
@@ -32,15 +32,6 @@ const BooksPage = () => {
       [bookingEntryState?.homeTeamId],
    );
    const requiresCaptcha = Boolean(bookingEntryState?.requireCaptcha);
-   const exitBookingFlowRef = useRef<() => void>(() => {});
-   useMouseEventTracker({
-      userId: bookingEntryState?.userId,
-      onMacroDetected: () => {
-         logBookingFlow('BooksPage', 'mouseML macro detected — blocking booking');
-         window.alert('매크로 사용이 감지되었습니다. 예매에 접근할 수 없습니다.');
-         exitBookingFlowRef.current();
-      },
-   });
    const { zones, isSeatGradeBotBlocked } = useBookingZones({
       bookingEntryState,
       bookingFlowMode,
@@ -107,7 +98,6 @@ const BooksPage = () => {
       clearBookingEntry();
       navigate('/', { replace: true });
    };
-   exitBookingFlowRef.current = () => void exitBookingFlow();
 
    const captcha = useBookingCaptcha({
       requiresCaptcha,

--- a/src/pages/macro-dashboard/api/dashboardApi.ts
+++ b/src/pages/macro-dashboard/api/dashboardApi.ts
@@ -1,0 +1,147 @@
+import axios from 'axios';
+
+const BASE_URL = (import.meta.env.PUBLIC_MACRO_DASHBOARD_API_URL ?? '').trim();
+
+const client = axios.create({ baseURL: BASE_URL });
+
+// ─── 타입 정의 ───────────────────────────────
+
+export interface StatsSummary {
+  total_access: number;
+  total_access_delta: string;
+  unique_users: number;
+  unique_users_delta: string;
+  blocked_count: number;
+  blocked_delta: string;
+  block_rate: number;
+  block_rate_delta: string;
+  mouse_macro_count: number;
+}
+
+export interface BlockedEventRow {
+  event_id: string;
+  session_id: string;
+  access_date: string;
+  access_time: string;
+  ip_address: string;
+  detection_type: string;
+  status: string;
+  risk_score: number;
+  reason_codes: string[];
+  user_id: string;
+  blocked_at: string;
+}
+
+export interface MouseEventItem {
+  timestamp: number;  // Unix ms
+  event_type: number; // 1=release 2=move 3=wheel 4=drag 5=click
+  screen_x: number;
+  screen_y: number;
+}
+
+export interface MouseMacroSessionRow {
+  session_id: string;
+  user_id: string;
+  probability: number;
+  confidence: number;
+  event_count: number;
+  events: MouseEventItem[];
+  detected_at: string;
+}
+
+export interface DetectionTypeItem {
+  type: string;
+  count: number;
+}
+
+export interface HourlyTrendItem {
+  hour: string;
+  count: number;
+}
+
+export interface RiskDistributionItem {
+  range: string;
+  count: number;
+}
+
+export interface AlertItem {
+  alert_id: string;
+  session_id: string;
+  user_id: string;
+  alert_type: string;
+  severity: 'critical' | 'high' | 'medium';
+  risk_score: number;
+  message: string;
+  triggered_at: string;
+}
+
+export interface DashboardOverview {
+  stats: StatsSummary;
+  detection_types: DetectionTypeItem[];
+  hourly_trend: HourlyTrendItem[];
+  risk_distribution: RiskDistributionItem[];
+  recent_guardrail: BlockedEventRow[];
+  recent_mouse_macro: MouseMacroSessionRow[];
+}
+
+// ─── API 함수 ────────────────────────────────
+
+export const fetchDashboardOverview = async (): Promise<DashboardOverview> => {
+  const res = await client.get<DashboardOverview>('/api/v1/dashboard/overview');
+  return res.data;
+};
+
+export const fetchDetections = async (limit = 100): Promise<BlockedEventRow[]> => {
+  const res = await client.get<BlockedEventRow[]>('/api/v1/detections', { params: { limit } });
+  return res.data;
+};
+
+export const fetchMouseMacroSessions = async (limit = 50): Promise<MouseMacroSessionRow[]> => {
+  const res = await client.get<MouseMacroSessionRow[]>('/api/v1/mouse-macro/sessions', { params: { limit } });
+  return res.data;
+};
+
+export const fetchAlerts = async (limit = 30): Promise<AlertItem[]> => {
+  const res = await client.get<AlertItem[]>('/api/v1/alerts', { params: { limit } });
+  return res.data;
+};
+
+export const updateEventAction = async (eventId: string, action: 'Blocked' | 'Passed') => {
+  const res = await client.post(`/api/v1/interventions/${encodeURIComponent(eventId)}/action`, { action });
+  return res.data;
+};
+
+export interface IPSummaryItem {
+  ip_address: string;
+  total_events: number;
+  blocked_count: number;
+  max_risk: number;        // 0~100
+  first_seen: string;
+  last_seen: string;
+  detection_types: string; // comma-separated
+}
+
+export interface AnalysisResponse {
+  event_id: string;
+  analysis: string;
+}
+
+export const analyzeGuardrailEvent = async (eventId: string): Promise<AnalysisResponse> => {
+  const res = await client.post<AnalysisResponse>(`/api/v1/analysis/guardrail/${encodeURIComponent(eventId)}`);
+  return res.data;
+};
+
+export const analyzeMouseMacroSession = async (sessionId: string): Promise<AnalysisResponse> => {
+  const res = await client.post<AnalysisResponse>(`/api/v1/analysis/mouse-macro/${encodeURIComponent(sessionId)}`);
+  return res.data;
+};
+
+export const fetchIPSummary = async (): Promise<IPSummaryItem[]> => {
+  const res = await client.get<IPSummaryItem[]>('/api/v1/analysis/ip-summary');
+  return res.data;
+};
+
+export const analyzeIPViolations = async (ipAddress: string): Promise<AnalysisResponse> => {
+  const res = await client.post<AnalysisResponse>(`/api/v1/analysis/ip/${encodeURIComponent(ipAddress)}`);
+  return res.data;
+};

--- a/src/pages/macro-dashboard/index.ts
+++ b/src/pages/macro-dashboard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ui/MacroDashboardPage';

--- a/src/pages/macro-dashboard/ui/MacroDashboardPage.tsx
+++ b/src/pages/macro-dashboard/ui/MacroDashboardPage.tsx
@@ -1,861 +1,79 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
-  BarChart, Bar, LineChart, Line,
-  ScatterChart, Scatter,
-  XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, Legend,
-} from 'recharts';
-import {
-  ShieldAlert, ShieldCheck, Activity, MousePointer2,
-  RefreshCw, AlertTriangle, Clock, Wifi, Sparkles, X, Loader2, BarChart2,
-  Globe, ClipboardList, Ban, CheckCircle2,
+  Activity,
+  ClipboardList,
+  Clock,
+  Globe,
+  MousePointer2,
+  RefreshCw,
+  ShieldAlert,
+  ShieldCheck,
+  Wifi,
 } from 'lucide-react';
+
 import {
+  analyzeGuardrailEvent,
+  analyzeIPViolations,
+  analyzeMouseMacroSession,
+  fetchAlerts,
   fetchDashboardOverview,
   fetchDetections,
-  fetchMouseMacroSessions,
-  fetchAlerts,
   fetchIPSummary,
-  updateEventAction,
-  analyzeGuardrailEvent,
-  analyzeMouseMacroSession,
-  analyzeIPViolations,
-  type BlockedEventRow,
-  type AlertItem,
+  fetchMouseMacroSessions,
   type MouseMacroSessionRow,
-  type MouseEventItem,
-  type IPSummaryItem,
+  updateEventAction,
 } from '../api/dashboardApi';
+import AlertBanner from './components/AlertBanner';
+import AlertList from './components/AlertList';
+import AnalysisModal from './components/AnalysisModal';
+import DashboardCharts from './components/DashboardCharts';
+import DetectionsTable from './components/DetectionsTable';
+import IPAnalysisTab from './components/IPAnalysisTab';
+import MouseSessionsTable from './components/MouseSessionsTable';
+import ReviewTab from './components/ReviewTab';
+import StatCard from './components/StatCard';
+import TrajectoryModal from './components/TrajectoryModal';
+import { REFETCH_MS } from './lib/dashboardConstants';
+import { formatDashboardUpdateTime } from './lib/dashboardFormat';
+import type { DashboardTabKey, ReviewRow } from './types';
 
-// ─── 상수 ────────────────────────────────────
-
-const REFETCH_MS = 15_000;
-
-const STATUS_STYLE: Record<string, string> = {
-  Blocked: 'bg-red-100 text-red-700',
-  Passed:  'bg-green-100 text-green-700',
-  Pending: 'bg-yellow-100 text-yellow-700',
-};
-
-const SEVERITY_STYLE: Record<string, string> = {
-  critical: 'border-red-500 bg-red-50',
-  high:     'border-orange-400 bg-orange-50',
-  medium:   'border-yellow-400 bg-yellow-50',
-};
-
-const SEVERITY_ICON_CLASS: Record<string, string> = {
-  critical: 'text-red-600',
-  high:     'text-orange-500',
-  medium:   'text-yellow-500',
-};
-
-const CHART_COLORS = ['#6366f1', '#14b8a6', '#f59e0b', '#ef4444'];
-
-// 이벤트 타입별 색상 / 이름
-const EVENT_TYPE_META: Record<number, { label: string; color: string }> = {
-  1: { label: '릴리즈',  color: '#94a3b8' },
-  2: { label: '이동',    color: '#6366f1' },
-  3: { label: '휠',      color: '#14b8a6' },
-  4: { label: '드래그',  color: '#f59e0b' },
-  5: { label: '클릭',    color: '#ef4444' },
-};
-
-// ─── 유틸 ────────────────────────────────────
-
-function toKST(utcStr: string): string {
-  if (!utcStr) return '-';
-  try {
-    return new Date(utcStr).toLocaleString('ko-KR', {
-      timeZone: 'Asia/Seoul',
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      hour12: false,
-    });
-  } catch {
-    return utcStr.slice(0, 19).replace('T', ' ');
-  }
-}
-
-// ─── 서브 컴포넌트 ────────────────────────────
-
-function StatCard({
-  label, value, unit, delta, icon,
-}: {
-  label: string;
-  value: number | string;
-  unit?: string;
-  delta?: string;
-  icon: React.ReactNode;
-}) {
-  return (
-    <div className="flex flex-col gap-2 rounded-2xl border border-[var(--neutral-200)] bg-white p-5 shadow-sm">
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-medium text-[var(--text-tertiary)]">{label}</span>
-        <span className="text-[var(--text-tertiary)]">{icon}</span>
-      </div>
-      <div className="flex items-end gap-1">
-        <span className="text-3xl font-bold tracking-tight text-[var(--text-primary)]">
-          {typeof value === 'number' ? value.toLocaleString() : value}
-        </span>
-        {unit && <span className="mb-0.5 text-sm text-[var(--text-tertiary)]">{unit}</span>}
-      </div>
-      {delta && (
-        <span className="text-xs font-medium text-[var(--text-tertiary)]">{delta}</span>
-      )}
-    </div>
-  );
-}
-
-function AlertBanner({ alerts }: { alerts: AlertItem[] }) {
-  if (alerts.length === 0) return null;
-  const critical = alerts.filter(a => a.severity === 'critical');
-  const label = critical.length > 0
-    ? `위험 알림 ${critical.length}건 — 즉시 확인이 필요합니다`
-    : `주의 알림 ${alerts.length}건이 발생했습니다`;
-
-  return (
-    <div className={`flex items-center gap-3 rounded-xl border-l-4 p-4 ${
-      critical.length > 0 ? 'border-red-500 bg-red-50' : 'border-yellow-400 bg-yellow-50'
-    }`}>
-      <AlertTriangle className={`size-5 shrink-0 ${critical.length > 0 ? 'text-red-600' : 'text-yellow-600'}`} />
-      <span className="text-sm font-semibold text-[var(--text-primary)]">{label}</span>
-    </div>
-  );
-}
-
-function AlertList({ alerts }: { alerts: AlertItem[] }) {
-  if (alerts.length === 0) {
-    return (
-      <p className="py-6 text-center text-sm text-[var(--text-tertiary)]">
-        현재 활성 알림이 없습니다.
-      </p>
-    );
-  }
-  return (
-    <ul className="flex flex-col gap-2">
-      {alerts.map(a => (
-        <li
-          key={a.alert_id}
-          className={`flex items-start gap-3 rounded-xl border-l-4 p-4 ${SEVERITY_STYLE[a.severity]}`}
-        >
-          <AlertTriangle className={`mt-0.5 size-4 shrink-0 ${SEVERITY_ICON_CLASS[a.severity]}`} />
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-semibold text-[var(--text-primary)]">{a.message}</p>
-            <p className="mt-1 text-xs text-[var(--text-tertiary)]">
-              {a.alert_type} · Risk {a.risk_score}% · {toKST(a.triggered_at)}
-            </p>
-          </div>
-          <span className="shrink-0 rounded-full bg-white/80 px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-[var(--text-secondary)]">
-            {a.severity}
-          </span>
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-function DetectionsTable({
-  rows,
-  onAction,
-  actionLoading,
-  onAnalyze,
-}: {
-  rows: BlockedEventRow[];
-  onAction: (eventId: string, action: 'Blocked' | 'Passed') => void;
-  actionLoading: string | null;
-  onAnalyze: (eventId: string) => void;
-}) {
-  if (rows.length === 0) {
-    return (
-      <p className="py-6 text-center text-sm text-[var(--text-tertiary)]">
-        탐지된 이벤트가 없습니다.
-      </p>
-    );
-  }
-
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-left text-sm">
-        <thead>
-          <tr className="border-b border-[var(--neutral-200)] text-xs font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
-            <th className="py-2 pr-4">Event ID</th>
-            <th className="py-2 pr-4">탐지 시각 (KST)</th>
-            <th className="py-2 pr-4">IP 주소</th>
-            <th className="py-2 pr-4">탐지 유형</th>
-            <th className="py-2 pr-4">Risk</th>
-            <th className="py-2 pr-4">상태</th>
-            <th className="py-2 pr-4">심사</th>
-            <th className="py-2">AI 분석</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-[var(--neutral-100)]">
-          {rows.map(row => (
-            <tr key={row.event_id} className="hover:bg-[var(--neutral-50)]">
-              <td className="py-2.5 pr-4 font-mono text-xs text-[var(--text-secondary)]">
-                {row.event_id.slice(0, 14)}
-              </td>
-              <td className="py-2.5 pr-4 text-[var(--text-secondary)]">
-                <span className="flex items-center gap-1">
-                  <Clock className="size-3 shrink-0" />
-                  {toKST(row.blocked_at)}
-                </span>
-              </td>
-              <td className="py-2.5 pr-4 font-mono text-xs text-[var(--text-secondary)]">
-                {row.ip_address || '-'}
-              </td>
-              <td className="py-2.5 pr-4 text-[var(--text-secondary)]">{row.detection_type}</td>
-              <td className="py-2.5 pr-4">
-                <div className="flex items-center gap-2">
-                  <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--neutral-200)]">
-                    <div
-                      className={`h-full rounded-full ${row.risk_score >= 80 ? 'bg-red-500' : row.risk_score >= 50 ? 'bg-yellow-500' : 'bg-green-500'}`}
-                      style={{ width: `${row.risk_score}%` }}
-                    />
-                  </div>
-                  <span className="text-xs font-semibold text-[var(--text-secondary)]">{row.risk_score}%</span>
-                </div>
-              </td>
-              <td className="py-2.5 pr-4">
-                <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${STATUS_STYLE[row.status] ?? 'bg-gray-100 text-gray-700'}`}>
-                  {row.status}
-                </span>
-              </td>
-              <td className="py-2.5 pr-4">
-                <div className="flex gap-1">
-                  <button
-                    disabled={row.status === 'Passed' || actionLoading === row.event_id}
-                    className="rounded-lg bg-green-100 px-2 py-1 text-xs font-semibold text-green-700 hover:bg-green-200 disabled:cursor-not-allowed disabled:opacity-40"
-                    onClick={() => onAction(row.event_id, 'Passed')}
-                  >
-                    통과
-                  </button>
-                  <button
-                    disabled={row.status === 'Blocked' || actionLoading === row.event_id}
-                    className="rounded-lg bg-red-100 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-200 disabled:cursor-not-allowed disabled:opacity-40"
-                    onClick={() => onAction(row.event_id, 'Blocked')}
-                  >
-                    차단
-                  </button>
-                </div>
-              </td>
-              <td className="py-2.5">
-                <button
-                  className="flex items-center gap-1 rounded-lg bg-[#ede9fe] px-2 py-1 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
-                  onClick={() => onAnalyze(row.event_id)}
-                >
-                  <Sparkles className="size-3" />
-                  분석
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-// ─── 마우스 궤적 시각화 ───────────────────────
-
-function MouseTrajectoryChart({ events }: { events: MouseEventItem[] }) {
-  if (!events || events.length === 0) {
-    return (
-      <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">
-        이벤트 데이터가 없습니다.
-      </p>
-    );
-  }
-
-  // 이벤트 타입별 그룹핑
-  const grouped = [1, 2, 3, 4, 5].map(type => ({
-    type,
-    meta: EVENT_TYPE_META[type],
-    data: events
-      .filter(e => e.event_type === type)
-      .map(e => ({ x: Math.round(e.screen_x), y: Math.round(e.screen_y) })),
-  })).filter(g => g.data.length > 0);
-
-  // 이동 궤적 (move 이벤트만 시간 순으로)
-  const trajectory = [...events]
-    .filter(e => e.event_type === 2)
-    .sort((a, b) => a.timestamp - b.timestamp)
-    .map(e => ({ x: Math.round(e.screen_x), y: Math.round(e.screen_y) }));
-
-  // 이벤트 타입 집계
-  const typeCounts = [1, 2, 3, 4, 5].map(type => ({
-    name: EVENT_TYPE_META[type].label,
-    count: events.filter(e => e.event_type === type).length,
-    fill: EVENT_TYPE_META[type].color,
-  })).filter(t => t.count > 0);
-
-  // 시간대별 이벤트 밀도 (100ms 단위)
-  const minTs = Math.min(...events.map(e => e.timestamp));
-  const bucketMs = 500;
-  const buckets: Record<number, number> = {};
-  events.forEach(e => {
-    const bucket = Math.floor((e.timestamp - minTs) / bucketMs);
-    buckets[bucket] = (buckets[bucket] ?? 0) + 1;
-  });
-  const densityData = Object.entries(buckets)
-    .sort(([a], [b]) => Number(a) - Number(b))
-    .map(([k, v]) => ({ t: `${(Number(k) * bucketMs / 1000).toFixed(1)}s`, count: v }));
-
-  return (
-    <div className="space-y-6">
-      {/* 궤적 산점도 */}
-      <div>
-        <p className="mb-2 text-xs font-semibold text-[var(--text-secondary)]">마우스 궤적 (화면 좌표)</p>
-        <ResponsiveContainer width="100%" height={300}>
-          <ScatterChart margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
-            <XAxis
-              type="number"
-              dataKey="x"
-              name="X"
-              tick={{ fontSize: 10 }}
-              label={{ value: 'screen_x', position: 'insideBottom', offset: -4, fontSize: 10 }}
-            />
-            <YAxis
-              type="number"
-              dataKey="y"
-              name="Y"
-              reversed
-              tick={{ fontSize: 10 }}
-              label={{ value: 'screen_y', angle: -90, position: 'insideLeft', fontSize: 10 }}
-            />
-            <Tooltip
-              cursor={{ strokeDasharray: '3 3' }}
-              contentStyle={{ fontSize: 11, borderRadius: 8 }}
-              formatter={(val, name) => [val, name === 'x' ? 'X' : 'Y']}
-            />
-            <Legend
-              iconType="circle"
-              iconSize={8}
-              wrapperStyle={{ fontSize: 11 }}
-            />
-            {/* 이동 궤적 라인 */}
-            {trajectory.length > 1 && (
-              <Scatter
-                name="이동경로"
-                data={trajectory}
-                line={{ stroke: '#6366f1', strokeWidth: 1, strokeOpacity: 0.3 }}
-                lineType="joint"
-                fill="transparent"
-                legendType="none"
-              />
-            )}
-            {/* 타입별 점 */}
-            {grouped.map(g => (
-              <Scatter
-                key={g.type}
-                name={g.meta.label}
-                data={g.data}
-                fill={g.meta.color}
-                opacity={0.8}
-              />
-            ))}
-          </ScatterChart>
-        </ResponsiveContainer>
-      </div>
-
-      {/* 이벤트 타입 분포 + 시간별 밀도 */}
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <p className="mb-2 text-xs font-semibold text-[var(--text-secondary)]">이벤트 타입 분포</p>
-          <ResponsiveContainer width="100%" height={140}>
-            <BarChart data={typeCounts} layout="vertical" margin={{ left: 8 }}>
-              <XAxis type="number" tick={{ fontSize: 10 }} />
-              <YAxis type="category" dataKey="name" width={50} tick={{ fontSize: 10 }} />
-              <Tooltip contentStyle={{ fontSize: 11, borderRadius: 8 }} formatter={v => [`${v}회`]} />
-              <Bar dataKey="count" radius={[0, 4, 4, 0]}>
-                {typeCounts.map((t, i) => (
-                  <Cell key={i} fill={t.fill} />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-
-        <div>
-          <p className="mb-2 text-xs font-semibold text-[var(--text-secondary)]">시간대별 이벤트 밀도 (0.5s)</p>
-          <ResponsiveContainer width="100%" height={140}>
-            <LineChart data={densityData} margin={{ left: 0, right: 8 }}>
-              <XAxis dataKey="t" tick={{ fontSize: 9 }} interval="preserveStartEnd" />
-              <YAxis tick={{ fontSize: 10 }} />
-              <Tooltip contentStyle={{ fontSize: 11, borderRadius: 8 }} formatter={v => [`${v}회`]} />
-              <Line
-                type="monotone"
-                dataKey="count"
-                stroke="#6366f1"
-                strokeWidth={1.5}
-                dot={false}
-              />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── IP 분석 탭 ──────────────────────────────
-
-function IPAnalysisTab({
-  items,
-  onAnalyze,
-}: {
-  items: IPSummaryItem[];
-  onAnalyze: (ip: string) => void;
-}) {
-  if (items.length === 0) {
-    return (
-      <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">
-        IP 데이터가 없습니다. 가드레일 차단 이벤트에 IP가 포함되면 여기에 표시됩니다.
-      </p>
-    );
-  }
-
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-left text-sm">
-        <thead>
-          <tr className="border-b border-[var(--neutral-200)] text-xs font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
-            <th className="py-2 pr-4">IP 주소</th>
-            <th className="py-2 pr-4">탐지 건수</th>
-            <th className="py-2 pr-4">차단 건수</th>
-            <th className="py-2 pr-4">최대 Risk</th>
-            <th className="py-2 pr-4">탐지 유형</th>
-            <th className="py-2 pr-4">첫 탐지 (KST)</th>
-            <th className="py-2 pr-4">최근 탐지 (KST)</th>
-            <th className="py-2">AI 분석</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-[var(--neutral-100)]">
-          {items.map(item => (
-            <tr key={item.ip_address} className="hover:bg-[var(--neutral-50)]">
-              <td className="py-2.5 pr-4 font-mono text-xs font-semibold text-[var(--text-primary)]">
-                {item.ip_address}
-              </td>
-              <td className="py-2.5 pr-4 text-center text-[var(--text-secondary)]">
-                {item.total_events}
-              </td>
-              <td className="py-2.5 pr-4 text-center">
-                <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">
-                  {item.blocked_count}
-                </span>
-              </td>
-              <td className="py-2.5 pr-4">
-                <div className="flex items-center gap-2">
-                  <div className="h-1.5 w-14 overflow-hidden rounded-full bg-[var(--neutral-200)]">
-                    <div
-                      className={`h-full rounded-full ${item.max_risk >= 80 ? 'bg-red-500' : item.max_risk >= 50 ? 'bg-yellow-500' : 'bg-green-500'}`}
-                      style={{ width: `${item.max_risk}%` }}
-                    />
-                  </div>
-                  <span className="text-xs font-semibold text-[var(--text-secondary)]">{Math.round(item.max_risk)}%</span>
-                </div>
-              </td>
-              <td className="py-2.5 pr-4 text-xs text-[var(--text-secondary)]">
-                {item.detection_types || '-'}
-              </td>
-              <td className="py-2.5 pr-4 text-xs text-[var(--text-secondary)]">
-                {toKST(item.first_seen)}
-              </td>
-              <td className="py-2.5 pr-4 text-xs text-[var(--text-secondary)]">
-                {toKST(item.last_seen)}
-              </td>
-              <td className="py-2.5">
-                <button
-                  className="flex items-center gap-1 rounded-lg bg-[#ede9fe] px-2 py-1 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
-                  onClick={() => onAnalyze(item.ip_address)}
-                >
-                  <Sparkles className="size-3" />
-                  분석
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-// ─── 수동 심사 탭 ─────────────────────────────
-
-type ReviewSource = 'guardrail' | 'mouse';
-
-export interface ReviewRow {
-  id: string;
-  source: ReviewSource;
-  userId: string;
-  ipAddress: string;
-  riskScore: number;
-  reasons: string;
-  status: string;
-  detectedAt: string;
-}
-
-function ReviewTab({
-  detections,
-  mouseSessions,
-  onAnalyze,
-  onAction,
-  actionLoading,
-}: {
-  detections: BlockedEventRow[];
-  mouseSessions: MouseMacroSessionRow[];
-  onAnalyze: (row: ReviewRow) => void;
-  onAction: (id: string, action: 'Blocked' | 'Passed') => void;
-  actionLoading: string | null;
-}) {
-  const [sourceFilter, setSourceFilter] = useState<'all' | ReviewSource>('all');
-  const [statusFilter, setStatusFilter] = useState<'all' | 'Blocked' | 'Passed' | 'Pending'>('all');
-  const [blockedIPs, setBlockedIPs] = useState<Set<string>>(new Set());
-
-  const rows: ReviewRow[] = [
-    ...detections.map(e => ({
-      id: e.event_id,
-      source: 'guardrail' as ReviewSource,
-      userId: e.user_id || '-',
-      ipAddress: e.ip_address || '-',
-      riskScore: e.risk_score,
-      reasons: e.reason_codes?.join(', ') || e.detection_type || '-',
-      status: e.status,
-      detectedAt: e.blocked_at,
-    })),
-    ...mouseSessions.map(s => ({
-      id: s.session_id,
-      source: 'mouse' as ReviewSource,
-      userId: s.user_id || '-',
-      ipAddress: '-',
-      riskScore: Math.round(s.probability * 100),
-      reasons: `Mouse Macro (확률 ${(s.probability * 100).toFixed(1)}%, 신뢰도 ${(s.confidence * 100).toFixed(1)}%)`,
-      status: 'Blocked',
-      detectedAt: s.detected_at,
-    })),
-  ].sort((a, b) => b.detectedAt.localeCompare(a.detectedAt));
-
-  const filtered = rows.filter(r => {
-    if (sourceFilter !== 'all' && r.source !== sourceFilter) return false;
-    if (statusFilter !== 'all' && r.status !== statusFilter) return false;
-    return true;
-  });
-
-  const handleMockBlockIP = (ip: string) => {
-    if (ip === '-') return;
-    setBlockedIPs(prev => new Set([...prev, ip]));
-  };
-
-  if (rows.length === 0) {
-    return (
-      <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">
-        심사할 탐지 이벤트가 없습니다.
-      </p>
-    );
-  }
-
-  return (
-    <div className="space-y-4">
-      {/* 필터 */}
-      <div className="flex flex-wrap gap-3">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-semibold text-[var(--text-tertiary)]">출처</span>
-          {(['all', 'guardrail', 'mouse'] as const).map(v => (
-            <button
-              key={v}
-              onClick={() => setSourceFilter(v)}
-              className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
-                sourceFilter === v
-                  ? 'bg-[var(--primary-normal)] text-white'
-                  : 'bg-[var(--neutral-100)] text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]'
-              }`}
-            >
-              {v === 'all' ? '전체' : v === 'guardrail' ? '가드레일' : '마우스 매크로'}
-            </button>
-          ))}
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-semibold text-[var(--text-tertiary)]">상태</span>
-          {(['all', 'Blocked', 'Passed', 'Pending'] as const).map(v => (
-            <button
-              key={v}
-              onClick={() => setStatusFilter(v)}
-              className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
-                statusFilter === v
-                  ? 'bg-[var(--primary-normal)] text-white'
-                  : 'bg-[var(--neutral-100)] text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]'
-              }`}
-            >
-              {v === 'all' ? '전체' : v}
-            </button>
-          ))}
-        </div>
-        <span className="ml-auto text-xs text-[var(--text-tertiary)]">
-          {filtered.length}건 표시 / 전체 {rows.length}건
-        </span>
-      </div>
-
-      {/* 이벤트 카드 목록 */}
-      <div className="space-y-3">
-        {filtered.map(row => {
-          const isIPBlocked = row.ipAddress !== '-' && blockedIPs.has(row.ipAddress);
-          return (
-            <div
-              key={row.id}
-              className={`rounded-xl border p-4 transition-colors ${
-                row.riskScore >= 80
-                  ? 'border-red-200 bg-red-50/40'
-                  : row.riskScore >= 50
-                  ? 'border-orange-200 bg-orange-50/40'
-                  : 'border-[var(--neutral-200)] bg-white'
-              }`}
-            >
-              {/* 상단: 이벤트 정보 3열 */}
-              <div className="grid grid-cols-3 gap-4 text-sm">
-                <div>
-                  <p className="text-xs font-semibold text-[var(--text-tertiary)] mb-1">이벤트</p>
-                  <p className="font-mono text-xs text-[var(--text-primary)]">{row.id.slice(0, 20)}</p>
-                  <p className="mt-0.5">
-                    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-semibold ${
-                      row.source === 'guardrail'
-                        ? 'bg-purple-100 text-purple-700'
-                        : 'bg-blue-100 text-blue-700'
-                    }`}>
-                      {row.source === 'guardrail' ? '가드레일' : '마우스 매크로'}
-                    </span>
-                  </p>
-                </div>
-                <div>
-                  <p className="text-xs font-semibold text-[var(--text-tertiary)] mb-1">사용자 / IP</p>
-                  <p className="text-xs text-[var(--text-primary)]">User: {row.userId}</p>
-                  <p className="text-xs text-[var(--text-secondary)] font-mono flex items-center gap-1 mt-0.5">
-                    <Globe className="size-3" />
-                    {row.ipAddress}
-                    {isIPBlocked && (
-                      <span className="ml-1 rounded-full bg-red-600 px-1.5 py-0.5 text-white text-[10px] font-bold">차단됨</span>
-                    )}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-xs font-semibold text-[var(--text-tertiary)] mb-1">위험도 / 시각</p>
-                  <div className="flex items-center gap-2 mb-0.5">
-                    <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--neutral-200)]">
-                      <div
-                        className={`h-full rounded-full ${row.riskScore >= 80 ? 'bg-red-500' : row.riskScore >= 50 ? 'bg-yellow-500' : 'bg-green-500'}`}
-                        style={{ width: `${row.riskScore}%` }}
-                      />
-                    </div>
-                    <span className="text-xs font-semibold text-[var(--text-secondary)]">{row.riskScore}%</span>
-                  </div>
-                  <p className="text-xs text-[var(--text-secondary)]">{toKST(row.detectedAt)}</p>
-                </div>
-              </div>
-
-              {/* 탐지 사유 */}
-              <p className="mt-2 text-xs text-[var(--text-tertiary)] bg-[var(--neutral-50)] rounded-lg px-3 py-2">
-                탐지 사유: {row.reasons}
-              </p>
-
-              {/* 액션 버튼 */}
-              <div className="mt-3 flex flex-wrap items-center gap-2">
-                {/* AI 심사 의견 */}
-                <button
-                  className="flex items-center gap-1.5 rounded-lg bg-[#ede9fe] px-3 py-1.5 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
-                  onClick={() => onAnalyze(row)}
-                >
-                  <Sparkles className="size-3" />
-                  AI 심사 의견
-                </button>
-
-                {/* 가드레일 이벤트만 차단/통과 가능 */}
-                {row.source === 'guardrail' && (
-                  <>
-                    <button
-                      disabled={row.status === 'Passed' || actionLoading === row.id}
-                      className="flex items-center gap-1.5 rounded-lg bg-green-100 px-3 py-1.5 text-xs font-semibold text-green-700 hover:bg-green-200 disabled:cursor-not-allowed disabled:opacity-40"
-                      onClick={() => onAction(row.id, 'Passed')}
-                    >
-                      <CheckCircle2 className="size-3" />
-                      통과
-                    </button>
-                    <button
-                      disabled={row.status === 'Blocked' || actionLoading === row.id}
-                      className="flex items-center gap-1.5 rounded-lg bg-red-100 px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-200 disabled:cursor-not-allowed disabled:opacity-40"
-                      onClick={() => onAction(row.id, 'Blocked')}
-                    >
-                      <Ban className="size-3" />
-                      차단
-                    </button>
-                  </>
-                )}
-
-                {/* IP 모의 차단 (실제 차단 없이 UI 표시만) */}
-                {row.ipAddress !== '-' && (
-                  <button
-                    className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors ${
-                      isIPBlocked
-                        ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-                        : 'bg-orange-100 text-orange-700 hover:bg-orange-200'
-                    }`}
-                    onClick={() => !isIPBlocked && handleMockBlockIP(row.ipAddress)}
-                    disabled={isIPBlocked}
-                    title="시뮬레이션 — 실제 네트워크 차단은 적용되지 않습니다"
-                  >
-                    <Globe className="size-3" />
-                    {isIPBlocked ? 'IP 차단됨' : 'IP 차단 (모의)'}
-                  </button>
-                )}
-
-                {/* 현재 상태 뱃지 */}
-                <span className={`ml-auto rounded-full px-2 py-0.5 text-xs font-semibold ${
-                  STATUS_STYLE[row.status] ?? 'bg-gray-100 text-gray-700'
-                }`}>
-                  {row.status}
-                </span>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-// ─── AI 분석 모달 ─────────────────────────────
-
-function AnalysisModal({
-  title,
-  analysis,
-  isLoading,
-  error,
-  onClose,
-}: {
+type AnalysisModalState = {
+  open: boolean;
   title: string;
   analysis: string | null;
   isLoading: boolean;
   error: string | null;
-  onClose: () => void;
-}) {
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-2xl rounded-2xl bg-white shadow-2xl">
-        <div className="flex items-center justify-between border-b border-[var(--neutral-200)] px-6 py-4">
-          <div className="flex items-center gap-2">
-            <Sparkles className="size-5 text-[#6366f1]" />
-            <h2 className="text-base font-semibold text-[var(--text-primary)]">{title}</h2>
-          </div>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-1.5 hover:bg-[var(--neutral-100)] text-[var(--text-tertiary)]"
-          >
-            <X className="size-4" />
-          </button>
-        </div>
+};
 
-        <div className="px-6 py-5 min-h-[200px]">
-          {isLoading && (
-            <div className="flex flex-col items-center justify-center gap-3 py-10">
-              <Loader2 className="size-8 animate-spin text-[#6366f1]" />
-              <p className="text-sm text-[var(--text-tertiary)]">Upstage Solar가 분석 중입니다...</p>
-            </div>
-          )}
-          {error && (
-            <div className="flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4">
-              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-red-600" />
-              <p className="text-sm text-red-700">{error}</p>
-            </div>
-          )}
-          {analysis && !isLoading && (
-            <div className="prose prose-sm max-w-none">
-              {analysis.split('\n').map((line, i) => {
-                if (line.startsWith('##')) {
-                  return <p key={i} className="mt-3 mb-1 text-sm font-bold text-[var(--text-primary)]">{line.replace(/^##\s*/, '')}</p>;
-                }
-                if (/^\d+\./.test(line) || line.startsWith('- ') || line.startsWith('• ')) {
-                  return <p key={i} className="ml-3 text-sm text-[var(--text-secondary)] leading-relaxed">{line}</p>;
-                }
-                if (line.trim() === '') return <div key={i} className="h-2" />;
-                return <p key={i} className="text-sm text-[var(--text-secondary)] leading-relaxed">{line}</p>;
-              })}
-            </div>
-          )}
-        </div>
+const DEFAULT_ANALYSIS_MODAL_STATE: AnalysisModalState = {
+  open: false,
+  title: '',
+  analysis: null,
+  isLoading: false,
+  error: null,
+};
 
-        <div className="flex justify-end border-t border-[var(--neutral-200)] px-6 py-3">
-          <p className="mr-auto text-xs text-[var(--text-tertiary)]">Powered by Upstage Solar</p>
-          <button
-            onClick={onClose}
-            className="rounded-xl bg-[var(--neutral-100)] px-4 py-2 text-sm font-semibold text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]"
-          >
-            닫기
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
+const TAB_ITEMS: Array<{ key: DashboardTabKey; label: string; countKey: 'detections' | 'mouse' | 'ip' | 'review' }> = [
+  { key: 'guardrail', label: '가드레일 탐지', countKey: 'detections' },
+  { key: 'mouse', label: '마우스 매크로', countKey: 'mouse' },
+  { key: 'ip', label: 'IP 분석', countKey: 'ip' },
+  { key: 'review', label: '수동 심사', countKey: 'review' },
+];
 
-// ─── 마우스 궤적 모달 ─────────────────────────
-
-function TrajectoryModal({
-  session,
-  onClose,
-}: {
-  session: MouseMacroSessionRow;
-  onClose: () => void;
-}) {
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-3xl rounded-2xl bg-white shadow-2xl">
-        <div className="flex items-center justify-between border-b border-[var(--neutral-200)] px-6 py-4">
-          <div className="flex items-center gap-2">
-            <BarChart2 className="size-5 text-[#6366f1]" />
-            <div>
-              <h2 className="text-base font-semibold text-[var(--text-primary)]">
-                마우스 궤적 분석
-              </h2>
-              <p className="text-xs text-[var(--text-tertiary)]">
-                {session.session_id.slice(0, 20)} · 확률 {(session.probability * 100).toFixed(1)}% · {toKST(session.detected_at)}
-              </p>
-            </div>
-          </div>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-1.5 hover:bg-[var(--neutral-100)] text-[var(--text-tertiary)]"
-          >
-            <X className="size-4" />
-          </button>
-        </div>
-
-        <div className="px-6 py-5">
-          <MouseTrajectoryChart events={session.events ?? []} />
-        </div>
-
-        <div className="flex items-center justify-between border-t border-[var(--neutral-200)] px-6 py-3">
-          <p className="text-xs text-[var(--text-tertiary)]">
-            총 {session.event_count.toLocaleString()}개 이벤트 · 신뢰도 {(session.confidence * 100).toFixed(1)}%
-          </p>
-          <button
-            onClick={onClose}
-            className="rounded-xl bg-[var(--neutral-100)] px-4 py-2 text-sm font-semibold text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]"
-          >
-            닫기
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── 메인 페이지 ──────────────────────────────
+const TAB_ICONS = {
+  guardrail: <ShieldAlert className="size-3.5" />,
+  mouse: <MousePointer2 className="size-3.5" />,
+  ip: <Globe className="size-3.5" />,
+  review: <ClipboardList className="size-3.5" />,
+} satisfies Record<DashboardTabKey, React.ReactNode>;
 
 const MacroDashboardPage = () => {
   const queryClient = useQueryClient();
-  const [tab, setTab] = useState<'guardrail' | 'mouse' | 'ip' | 'review'>('guardrail');
+  const [tab, setTab] = useState<DashboardTabKey>('guardrail');
+  const [trajectorySession, setTrajectorySession] = useState<MouseMacroSessionRow | null>(null);
+  const [analysisModal, setAnalysisModal] = useState<AnalysisModalState>(DEFAULT_ANALYSIS_MODAL_STATE);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
 
   const { data: overview, isLoading, isError, dataUpdatedAt } = useQuery({
     queryKey: ['macro-dashboard-overview'],
@@ -887,78 +105,6 @@ const MacroDashboardPage = () => {
     refetchInterval: REFETCH_MS,
   });
 
-  // ── AI 분석 모달 상태 ──
-  const [analysisModal, setAnalysisModal] = useState<{
-    open: boolean;
-    title: string;
-    analysis: string | null;
-    isLoading: boolean;
-    error: string | null;
-  }>({ open: false, title: '', analysis: null, isLoading: false, error: null });
-
-  const openAnalysis = (title: string) => {
-    setAnalysisModal({ open: true, title, analysis: null, isLoading: true, error: null });
-  };
-  const closeAnalysis = () => {
-    setAnalysisModal(prev => ({ ...prev, open: false }));
-  };
-
-  // ── 궤적 모달 상태 ──
-  const [trajectorySession, setTrajectorySession] = useState<MouseMacroSessionRow | null>(null);
-
-  const handleAnalyzeGuardrail = (eventId: string) => {
-    openAnalysis(`가드레일 차단 분석 — ${eventId.slice(0, 14)}`);
-    analyzeGuardrailEvent(eventId)
-      .then(res => setAnalysisModal(prev => ({ ...prev, isLoading: false, analysis: res.analysis })))
-      .catch(err => setAnalysisModal(prev => ({
-        ...prev,
-        isLoading: false,
-        error: (err as Error).message ?? '분석 실패',
-      })));
-  };
-
-  const handleAnalyzeMouseMacro = (sessionId: string) => {
-    openAnalysis(`마우스 매크로 분석 — ${sessionId.slice(0, 16)}`);
-    analyzeMouseMacroSession(sessionId)
-      .then(res => setAnalysisModal(prev => ({ ...prev, isLoading: false, analysis: res.analysis })))
-      .catch(err => setAnalysisModal(prev => ({
-        ...prev,
-        isLoading: false,
-        error: (err as Error).message ?? '분석 실패',
-      })));
-  };
-
-  const handleAnalyzeIP = (ipAddress: string) => {
-    openAnalysis(`IP 종합 분석 — ${ipAddress}`);
-    analyzeIPViolations(ipAddress)
-      .then(res => setAnalysisModal(prev => ({ ...prev, isLoading: false, analysis: res.analysis })))
-      .catch(err => setAnalysisModal(prev => ({
-        ...prev,
-        isLoading: false,
-        error: (err as Error).message ?? '분석 실패',
-      })));
-  };
-
-  const handleReviewAnalyze = (row: ReviewRow) => {
-    const label = row.source === 'guardrail'
-      ? `심사 의견 — ${row.id.slice(0, 14)} (가드레일)`
-      : `심사 의견 — ${row.id.slice(0, 14)} (마우스 매크로)`;
-    openAnalysis(label);
-
-    const analyzePromise = row.source === 'guardrail'
-      ? analyzeGuardrailEvent(row.id)
-      : analyzeMouseMacroSession(row.id);
-
-    analyzePromise
-      .then(res => setAnalysisModal(prev => ({ ...prev, isLoading: false, analysis: res.analysis })))
-      .catch(err => setAnalysisModal(prev => ({
-        ...prev,
-        isLoading: false,
-        error: (err as Error).message ?? '분석 실패',
-      })));
-  };
-
-  const [actionLoading, setActionLoading] = useState<string | null>(null);
   const { mutate: doAction } = useMutation({
     mutationFn: ({ id, action }: { id: string; action: 'Blocked' | 'Passed' }) =>
       updateEventAction(id, action),
@@ -970,12 +116,69 @@ const MacroDashboardPage = () => {
     },
   });
 
-  const lastUpdated = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString('ko-KR', {
-        timeZone: 'Asia/Seoul',
-        hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
-      })
-    : '-';
+  const openAnalysis = (title: string) => {
+    setAnalysisModal({
+      open: true,
+      title,
+      analysis: null,
+      isLoading: true,
+      error: null,
+    });
+  };
+
+  const closeAnalysis = () => {
+    setAnalysisModal((prev) => ({ ...prev, open: false }));
+  };
+
+  const applyAnalysisSuccess = (analysis: string) => {
+    setAnalysisModal((prev) => ({ ...prev, isLoading: false, analysis }));
+  };
+
+  const applyAnalysisError = (error: unknown) => {
+    setAnalysisModal((prev) => ({
+      ...prev,
+      isLoading: false,
+      error: (error as Error).message ?? '분석 실패',
+    }));
+  };
+
+  const handleAnalyzeGuardrail = (eventId: string) => {
+    openAnalysis(`가드레일 차단 분석 — ${eventId.slice(0, 14)}`);
+    analyzeGuardrailEvent(eventId).then((res) => applyAnalysisSuccess(res.analysis)).catch(applyAnalysisError);
+  };
+
+  const handleAnalyzeMouseMacro = (sessionId: string) => {
+    openAnalysis(`마우스 매크로 분석 — ${sessionId.slice(0, 16)}`);
+    analyzeMouseMacroSession(sessionId).then((res) => applyAnalysisSuccess(res.analysis)).catch(applyAnalysisError);
+  };
+
+  const handleAnalyzeIp = (ipAddress: string) => {
+    openAnalysis(`IP 종합 분석 — ${ipAddress}`);
+    analyzeIPViolations(ipAddress).then((res) => applyAnalysisSuccess(res.analysis)).catch(applyAnalysisError);
+  };
+
+  const handleReviewAnalyze = (row: ReviewRow) => {
+    const title =
+      row.source === 'guardrail'
+        ? `심사 의견 — ${row.id.slice(0, 14)} (가드레일)`
+        : `심사 의견 — ${row.id.slice(0, 14)} (마우스 매크로)`;
+
+    openAnalysis(title);
+
+    const request =
+      row.source === 'guardrail' ? analyzeGuardrailEvent(row.id) : analyzeMouseMacroSession(row.id);
+
+    request.then((res) => applyAnalysisSuccess(res.analysis)).catch(applyAnalysisError);
+  };
+
+  const lastUpdated = formatDashboardUpdateTime(dataUpdatedAt);
+  const stats = overview?.stats;
+  const tabCounts = {
+    detections: detections.length,
+    mouse: mouseSessions.length,
+    ip: ipSummary.length,
+    review: detections.length + mouseSessions.length,
+  };
 
   if (isError) {
     return (
@@ -995,290 +198,144 @@ const MacroDashboardPage = () => {
     );
   }
 
-  const stats = overview?.stats;
-
   return (
     <>
-    {analysisModal.open && (
-      <AnalysisModal
-        title={analysisModal.title}
-        analysis={analysisModal.analysis}
-        isLoading={analysisModal.isLoading}
-        error={analysisModal.error}
-        onClose={closeAnalysis}
-      />
-    )}
-    {trajectorySession && (
-      <TrajectoryModal
-        session={trajectorySession}
-        onClose={() => setTrajectorySession(null)}
-      />
-    )}
-    <main className="min-h-screen bg-[var(--background-surface)] p-6">
-      <div className="mx-auto max-w-7xl space-y-6">
+      {analysisModal.open && (
+        <AnalysisModal
+          title={analysisModal.title}
+          analysis={analysisModal.analysis}
+          isLoading={analysisModal.isLoading}
+          error={analysisModal.error}
+          onClose={closeAnalysis}
+        />
+      )}
+      {trajectorySession && (
+        <TrajectoryModal session={trajectorySession} onClose={() => setTrajectorySession(null)} />
+      )}
 
-        {/* ── 헤더 ── */}
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight text-[var(--text-primary)]">
-              AI 매크로 보안 대시보드
-            </h1>
-            <p className="mt-1 text-sm text-[var(--text-tertiary)]">
-              가드레일 · 마우스 매크로 실시간 탐지 현황
-            </p>
+      <main className="min-h-screen bg-[var(--background-surface)] p-6">
+        <div className="mx-auto max-w-7xl space-y-6">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight text-[var(--text-primary)]">
+                AI 매크로 보안 대시보드
+              </h1>
+              <p className="mt-1 text-sm text-[var(--text-tertiary)]">
+                가드레일 · 마우스 매크로 실시간 탐지 현황
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="flex items-center gap-1.5 text-xs text-[var(--text-tertiary)]">
+                <Clock className="size-3.5" />
+                마지막 업데이트: {lastUpdated} KST
+              </span>
+              <button
+                className="flex items-center gap-1.5 rounded-xl border border-[var(--neutral-200)] bg-white px-4 py-2 text-sm font-semibold text-[var(--text-secondary)] shadow-sm hover:bg-[var(--neutral-50)]"
+                onClick={() => void queryClient.invalidateQueries()}
+              >
+                <RefreshCw className="size-4" />
+                새로고침
+              </button>
+            </div>
           </div>
-          <div className="flex items-center gap-3">
-            <span className="flex items-center gap-1.5 text-xs text-[var(--text-tertiary)]">
-              <Clock className="size-3.5" />
-              마지막 업데이트: {lastUpdated} KST
-            </span>
-            <button
-              className="flex items-center gap-1.5 rounded-xl border border-[var(--neutral-200)] bg-white px-4 py-2 text-sm font-semibold text-[var(--text-secondary)] shadow-sm hover:bg-[var(--neutral-50)]"
-              onClick={() => void queryClient.invalidateQueries()}
-            >
-              <RefreshCw className="size-4" />
-              새로고침
-            </button>
-          </div>
-        </div>
 
-        {/* ── 알림 배너 ── */}
-        <AlertBanner alerts={alerts} />
+          <AlertBanner alerts={alerts} />
 
-        {/* ── 통계 카드 ── */}
-        {isLoading ? (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-            {[...Array(4)].map((_, i) => (
-              <div key={i} className="h-28 animate-pulse rounded-2xl bg-[var(--neutral-200)]" />
-            ))}
-          </div>
-        ) : (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-            <StatCard
-              label="가드레일 차단 건수"
-              value={stats?.blocked_count ?? 0}
-              unit="건"
-              delta={stats?.blocked_delta}
-              icon={<ShieldAlert className="size-5" />}
-            />
-            <StatCard
-              label="마우스 매크로 탐지"
-              value={stats?.mouse_macro_count ?? 0}
-              unit="건"
-              icon={<MousePointer2 className="size-5" />}
-            />
-            <StatCard
-              label="총 탐지 건수"
-              value={stats?.total_access ?? 0}
-              unit="건"
-              delta={stats?.total_access_delta}
-              icon={<Activity className="size-5" />}
-            />
-            <StatCard
-              label="차단율"
-              value={stats?.block_rate?.toFixed(1) ?? '0'}
-              unit="%"
-              delta={stats?.block_rate_delta}
-              icon={<ShieldCheck className="size-5" />}
-            />
-          </div>
-        )}
+          {isLoading ? (
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              {[...Array(4)].map((_, index) => (
+                <div key={index} className="h-28 animate-pulse rounded-2xl bg-[var(--neutral-200)]" />
+              ))}
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <StatCard
+                label="가드레일 차단 건수"
+                value={stats?.blocked_count ?? 0}
+                unit="건"
+                delta={stats?.blocked_delta}
+                icon={<ShieldAlert className="size-5" />}
+              />
+              <StatCard
+                label="마우스 매크로 탐지"
+                value={stats?.mouse_macro_count ?? 0}
+                unit="건"
+                icon={<MousePointer2 className="size-5" />}
+              />
+              <StatCard
+                label="총 탐지 건수"
+                value={stats?.total_access ?? 0}
+                unit="건"
+                delta={stats?.total_access_delta}
+                icon={<Activity className="size-5" />}
+              />
+              <StatCard
+                label="차단율"
+                value={stats?.block_rate?.toFixed(1) ?? '0'}
+                unit="%"
+                delta={stats?.block_rate_delta}
+                icon={<ShieldCheck className="size-5" />}
+              />
+            </div>
+          )}
 
-        {/* ── 차트 2열 ── */}
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <div className="rounded-2xl border border-[var(--neutral-200)] bg-white p-5 shadow-sm">
-            <h2 className="mb-4 text-sm font-semibold text-[var(--text-primary)]">탐지 유형 분포</h2>
-            {(overview?.detection_types?.length ?? 0) === 0 ? (
-              <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">데이터 없음</p>
-            ) : (
-              <ResponsiveContainer width="100%" height={200}>
-                <BarChart data={overview!.detection_types} layout="vertical" margin={{ left: 16 }}>
-                  <XAxis type="number" tick={{ fontSize: 11 }} />
-                  <YAxis type="category" dataKey="type" width={90} tick={{ fontSize: 11 }} />
-                  <Tooltip
-                    contentStyle={{ fontSize: 12, borderRadius: 8 }}
-                    formatter={(v) => [`${v}건`, '탐지 수']}
-                  />
-                  <Bar dataKey="count" radius={[0, 4, 4, 0]}>
-                    {overview!.detection_types.map((_, i) => (
-                      <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
-                    ))}
-                  </Bar>
-                </BarChart>
-              </ResponsiveContainer>
-            )}
+          <DashboardCharts overview={overview} />
+
+          <div className="rounded-2xl border border-[var(--neutral-200)] bg-white shadow-sm">
+            <div className="flex items-center gap-1 overflow-x-auto border-b border-[var(--neutral-200)] px-5 pt-4">
+              {TAB_ITEMS.map((item) => (
+                <button
+                  key={item.key}
+                  onClick={() => setTab(item.key)}
+                  className={`flex items-center gap-1.5 whitespace-nowrap rounded-t-lg px-4 py-2 text-sm font-semibold transition-colors ${
+                    tab === item.key
+                      ? 'border-b-2 border-[var(--primary-normal)] text-[var(--primary-normal)]'
+                      : 'text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]'
+                  }`}
+                >
+                  {TAB_ICONS[item.key]}
+                  {item.label} ({tabCounts[item.countKey]})
+                </button>
+              ))}
+            </div>
+
+            <div className="p-5">
+              {tab === 'guardrail' && (
+                <DetectionsTable
+                  rows={detections}
+                  onAction={(id, action) => doAction({ id, action })}
+                  actionLoading={actionLoading}
+                  onAnalyze={handleAnalyzeGuardrail}
+                />
+              )}
+              {tab === 'mouse' && (
+                <MouseSessionsTable
+                  sessions={mouseSessions}
+                  onAnalyze={handleAnalyzeMouseMacro}
+                  onOpenTrajectory={setTrajectorySession}
+                />
+              )}
+              {tab === 'ip' && <IPAnalysisTab items={ipSummary} onAnalyze={handleAnalyzeIp} />}
+              {tab === 'review' && (
+                <ReviewTab
+                  detections={detections}
+                  mouseSessions={mouseSessions}
+                  onAnalyze={handleReviewAnalyze}
+                  onAction={(id, action) => doAction({ id, action })}
+                  actionLoading={actionLoading}
+                />
+              )}
+            </div>
           </div>
 
           <div className="rounded-2xl border border-[var(--neutral-200)] bg-white p-5 shadow-sm">
             <h2 className="mb-4 text-sm font-semibold text-[var(--text-primary)]">
-              최근 24시간 탐지 트렌드 (KST)
+              활성 알림 (Risk ≥ 80%)
             </h2>
-            {(overview?.hourly_trend?.length ?? 0) === 0 ? (
-              <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">데이터 없음</p>
-            ) : (
-              <ResponsiveContainer width="100%" height={200}>
-                <LineChart data={overview!.hourly_trend} margin={{ left: 0, right: 8 }}>
-                  <XAxis
-                    dataKey="hour"
-                    tick={{ fontSize: 11 }}
-                    tickFormatter={h => `${((Number(h) + 9) % 24).toString().padStart(2, '0')}시`}
-                  />
-                  <YAxis tick={{ fontSize: 11 }} />
-                  <Tooltip
-                    contentStyle={{ fontSize: 12, borderRadius: 8 }}
-                    formatter={(v) => [`${v}건`, '탐지']}
-                    labelFormatter={h => `${((Number(h) + 9) % 24).toString().padStart(2, '0')}시 (KST)`}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="count"
-                    stroke="#6366f1"
-                    strokeWidth={2}
-                    dot={{ r: 3 }}
-                    activeDot={{ r: 5 }}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            )}
+            <AlertList alerts={alerts} />
           </div>
         </div>
-
-        {/* ── 탐지 이벤트 테이블 (탭) ── */}
-        <div className="rounded-2xl border border-[var(--neutral-200)] bg-white shadow-sm">
-          <div className="flex items-center gap-1 border-b border-[var(--neutral-200)] px-5 pt-4 overflow-x-auto">
-            {([
-              { key: 'guardrail', label: `가드레일 탐지 (${detections.length})`, icon: <ShieldAlert className="size-3.5" /> },
-              { key: 'mouse',     label: `마우스 매크로 (${mouseSessions.length})`, icon: <MousePointer2 className="size-3.5" /> },
-              { key: 'ip',        label: `IP 분석 (${ipSummary.length})`, icon: <Globe className="size-3.5" /> },
-              { key: 'review',    label: `수동 심사 (${detections.length + mouseSessions.length})`, icon: <ClipboardList className="size-3.5" /> },
-            ] as const).map(t => (
-              <button
-                key={t.key}
-                onClick={() => setTab(t.key)}
-                className={`flex items-center gap-1.5 whitespace-nowrap rounded-t-lg px-4 py-2 text-sm font-semibold transition-colors ${
-                  tab === t.key
-                    ? 'border-b-2 border-[var(--primary-normal)] text-[var(--primary-normal)]'
-                    : 'text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]'
-                }`}
-              >
-                {t.icon}
-                {t.label}
-              </button>
-            ))}
-          </div>
-
-          <div className="p-5">
-            {tab === 'guardrail' ? (
-              <DetectionsTable
-                rows={detections}
-                onAction={(id, action) => doAction({ id, action })}
-                actionLoading={actionLoading}
-                onAnalyze={handleAnalyzeGuardrail}
-              />
-            ) : tab === 'ip' ? (
-              <IPAnalysisTab
-                items={ipSummary}
-                onAnalyze={handleAnalyzeIP}
-              />
-            ) : tab === 'review' ? (
-              <ReviewTab
-                detections={detections}
-                mouseSessions={mouseSessions}
-                onAnalyze={handleReviewAnalyze}
-                onAction={(id, action) => doAction({ id, action })}
-                actionLoading={actionLoading}
-              />
-            ) : (
-              mouseSessions.length === 0 ? (
-                <p className="py-6 text-center text-sm text-[var(--text-tertiary)]">
-                  수신된 마우스 매크로 세션이 없습니다.
-                </p>
-              ) : (
-                <div className="overflow-x-auto">
-                  <table className="w-full text-left text-sm">
-                    <thead>
-                      <tr className="border-b border-[var(--neutral-200)] text-xs font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
-                        <th className="py-2 pr-4">Session ID</th>
-                        <th className="py-2 pr-4">User ID</th>
-                        <th className="py-2 pr-4">탐지 시각 (KST)</th>
-                        <th className="py-2 pr-4">이벤트 수</th>
-                        <th className="py-2 pr-4">매크로 확률</th>
-                        <th className="py-2 pr-4">신뢰도</th>
-                        <th className="py-2 pr-4">궤적</th>
-                        <th className="py-2">AI 분석</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-[var(--neutral-100)]">
-                      {mouseSessions.map(s => (
-                        <tr key={s.session_id} className="hover:bg-[var(--neutral-50)]">
-                          <td className="py-2.5 pr-4 font-mono text-xs text-[var(--text-secondary)]">
-                            {s.session_id.slice(0, 16)}
-                          </td>
-                          <td className="py-2.5 pr-4 text-[var(--text-secondary)]">
-                            {s.user_id || '-'}
-                          </td>
-                          <td className="py-2.5 pr-4 text-[var(--text-secondary)]">
-                            {toKST(s.detected_at)}
-                          </td>
-                          <td className="py-2.5 pr-4 text-[var(--text-secondary)]">
-                            {s.event_count.toLocaleString()}개
-                          </td>
-                          <td className="py-2.5 pr-4">
-                            <div className="flex items-center gap-2">
-                              <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--neutral-200)]">
-                                <div
-                                  className="h-full rounded-full bg-[#6366f1]"
-                                  style={{ width: `${Math.round(s.probability * 100)}%` }}
-                                />
-                              </div>
-                              <span className="text-xs font-semibold text-[var(--text-secondary)]">
-                                {(s.probability * 100).toFixed(1)}%
-                              </span>
-                            </div>
-                          </td>
-                          <td className="py-2.5 pr-4">
-                            <span className="text-xs font-medium text-[var(--text-secondary)]">
-                              {(s.confidence * 100).toFixed(1)}%
-                            </span>
-                          </td>
-                          <td className="py-2.5 pr-4">
-                            <button
-                              className="flex items-center gap-1 rounded-lg bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-600 hover:bg-blue-100"
-                              onClick={() => setTrajectorySession(s)}
-                            >
-                              <BarChart2 className="size-3" />
-                              궤적
-                            </button>
-                          </td>
-                          <td className="py-2.5">
-                            <button
-                              className="flex items-center gap-1 rounded-lg bg-[#ede9fe] px-2 py-1 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
-                              onClick={() => handleAnalyzeMouseMacro(s.session_id)}
-                            >
-                              <Sparkles className="size-3" />
-                              분석
-                            </button>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              )
-            )}
-          </div>
-        </div>
-
-        {/* ── 활성 알림 목록 ── */}
-        <div className="rounded-2xl border border-[var(--neutral-200)] bg-white p-5 shadow-sm">
-          <h2 className="mb-4 text-sm font-semibold text-[var(--text-primary)]">
-            활성 알림 (Risk ≥ 80%)
-          </h2>
-          <AlertList alerts={alerts} />
-        </div>
-
-      </div>
-    </main>
+      </main>
     </>
   );
 };

--- a/src/pages/macro-dashboard/ui/MacroDashboardPage.tsx
+++ b/src/pages/macro-dashboard/ui/MacroDashboardPage.tsx
@@ -1,0 +1,1286 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  BarChart, Bar, LineChart, Line,
+  ScatterChart, Scatter,
+  XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, Legend,
+} from 'recharts';
+import {
+  ShieldAlert, ShieldCheck, Activity, MousePointer2,
+  RefreshCw, AlertTriangle, Clock, Wifi, Sparkles, X, Loader2, BarChart2,
+  Globe, ClipboardList, Ban, CheckCircle2,
+} from 'lucide-react';
+import {
+  fetchDashboardOverview,
+  fetchDetections,
+  fetchMouseMacroSessions,
+  fetchAlerts,
+  fetchIPSummary,
+  updateEventAction,
+  analyzeGuardrailEvent,
+  analyzeMouseMacroSession,
+  analyzeIPViolations,
+  type BlockedEventRow,
+  type AlertItem,
+  type MouseMacroSessionRow,
+  type MouseEventItem,
+  type IPSummaryItem,
+} from '../api/dashboardApi';
+
+// ─── 상수 ────────────────────────────────────
+
+const REFETCH_MS = 15_000;
+
+const STATUS_STYLE: Record<string, string> = {
+  Blocked: 'bg-red-100 text-red-700',
+  Passed:  'bg-green-100 text-green-700',
+  Pending: 'bg-yellow-100 text-yellow-700',
+};
+
+const SEVERITY_STYLE: Record<string, string> = {
+  critical: 'border-red-500 bg-red-50',
+  high:     'border-orange-400 bg-orange-50',
+  medium:   'border-yellow-400 bg-yellow-50',
+};
+
+const SEVERITY_ICON_CLASS: Record<string, string> = {
+  critical: 'text-red-600',
+  high:     'text-orange-500',
+  medium:   'text-yellow-500',
+};
+
+const CHART_COLORS = ['#6366f1', '#14b8a6', '#f59e0b', '#ef4444'];
+
+// 이벤트 타입별 색상 / 이름
+const EVENT_TYPE_META: Record<number, { label: string; color: string }> = {
+  1: { label: '릴리즈',  color: '#94a3b8' },
+  2: { label: '이동',    color: '#6366f1' },
+  3: { label: '휠',      color: '#14b8a6' },
+  4: { label: '드래그',  color: '#f59e0b' },
+  5: { label: '클릭',    color: '#ef4444' },
+};
+
+// ─── 유틸 ────────────────────────────────────
+
+function toKST(utcStr: string): string {
+  if (!utcStr) return '-';
+  try {
+    return new Date(utcStr).toLocaleString('ko-KR', {
+      timeZone: 'Asia/Seoul',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+  } catch {
+    return utcStr.slice(0, 19).replace('T', ' ');
+  }
+}
+
+// ─── 서브 컴포넌트 ────────────────────────────
+
+function StatCard({
+  label, value, unit, delta, icon,
+}: {
+  label: string;
+  value: number | string;
+  unit?: string;
+  delta?: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl border border-[var(--neutral-200)] bg-white p-5 shadow-sm">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-[var(--text-tertiary)]">{label}</span>
+        <span className="text-[var(--text-tertiary)]">{icon}</span>
+      </div>
+      <div className="flex items-end gap-1">
+        <span className="text-3xl font-bold tracking-tight text-[var(--text-primary)]">
+          {typeof value === 'number' ? value.toLocaleString() : value}
+        </span>
+        {unit && <span className="mb-0.5 text-sm text-[var(--text-tertiary)]">{unit}</span>}
+      </div>
+      {delta && (
+        <span className="text-xs font-medium text-[var(--text-tertiary)]">{delta}</span>
+      )}
+    </div>
+  );
+}
+
+function AlertBanner({ alerts }: { alerts: AlertItem[] }) {
+  if (alerts.length === 0) return null;
+  const critical = alerts.filter(a => a.severity === 'critical');
+  const label = critical.length > 0
+    ? `위험 알림 ${critical.length}건 — 즉시 확인이 필요합니다`
+    : `주의 알림 ${alerts.length}건이 발생했습니다`;
+
+  return (
+    <div className={`flex items-center gap-3 rounded-xl border-l-4 p-4 ${
+      critical.length > 0 ? 'border-red-500 bg-red-50' : 'border-yellow-400 bg-yellow-50'
+    }`}>
+      <AlertTriangle className={`size-5 shrink-0 ${critical.length > 0 ? 'text-red-600' : 'text-yellow-600'}`} />
+      <span className="text-sm font-semibold text-[var(--text-primary)]">{label}</span>
+    </div>
+  );
+}
+
+function AlertList({ alerts }: { alerts: AlertItem[] }) {
+  if (alerts.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-[var(--text-tertiary)]">
+        현재 활성 알림이 없습니다.
+      </p>
+    );
+  }
+  return (
+    <ul className="flex flex-col gap-2">
+      {alerts.map(a => (
+        <li
+          key={a.alert_id}
+          className={`flex items-start gap-3 rounded-xl border-l-4 p-4 ${SEVERITY_STYLE[a.severity]}`}
+        >
+          <AlertTriangle className={`mt-0.5 size-4 shrink-0 ${SEVERITY_ICON_CLASS[a.severity]}`} />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold text-[var(--text-primary)]">{a.message}</p>
+            <p className="mt-1 text-xs text-[var(--text-tertiary)]">
+              {a.alert_type} · Risk {a.risk_score}% · {toKST(a.triggered_at)}
+            </p>
+          </div>
+          <span className="shrink-0 rounded-full bg-white/80 px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-[var(--text-secondary)]">
+            {a.severity}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function DetectionsTable({
+  rows,
+  onAction,
+  actionLoading,
+  onAnalyze,
+}: {
+  rows: BlockedEventRow[];
+  onAction: (eventId: string, action: 'Blocked' | 'Passed') => void;
+  actionLoading: string | null;
+  onAnalyze: (eventId: string) => void;
+}) {
+  if (rows.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-[var(--text-tertiary)]">
+        탐지된 이벤트가 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-[var(--neutral-200)] text-xs font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
+            <th className="py-2 pr-4">Event ID</th>
+            <th className="py-2 pr-4">탐지 시각 (KST)</th>
+            <th className="py-2 pr-4">IP 주소</th>
+            <th className="py-2 pr-4">탐지 유형</th>
+            <th className="py-2 pr-4">Risk</th>
+            <th className="py-2 pr-4">상태</th>
+            <th className="py-2 pr-4">심사</th>
+            <th className="py-2">AI 분석</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[var(--neutral-100)]">
+          {rows.map(row => (
+            <tr key={row.event_id} className="hover:bg-[var(--neutral-50)]">
+              <td className="py-2.5 pr-4 font-mono text-xs text-[var(--text-secondary)]">
+                {row.event_id.slice(0, 14)}
+              </td>
+              <td className="py-2.5 pr-4 text-[var(--text-secondary)]">
+                <span className="flex items-center gap-1">
+                  <Clock className="size-3 shrink-0" />
+                  {toKST(row.blocked_at)}
+                </span>
+              </td>
+              <td className="py-2.5 pr-4 font-mono text-xs text-[var(--text-secondary)]">
+                {row.ip_address || '-'}
+              </td>
+              <td className="py-2.5 pr-4 text-[var(--text-secondary)]">{row.detection_type}</td>
+              <td className="py-2.5 pr-4">
+                <div className="flex items-center gap-2">
+                  <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--neutral-200)]">
+                    <div
+                      className={`h-full rounded-full ${row.risk_score >= 80 ? 'bg-red-500' : row.risk_score >= 50 ? 'bg-yellow-500' : 'bg-green-500'}`}
+                      style={{ width: `${row.risk_score}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-semibold text-[var(--text-secondary)]">{row.risk_score}%</span>
+                </div>
+              </td>
+              <td className="py-2.5 pr-4">
+                <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${STATUS_STYLE[row.status] ?? 'bg-gray-100 text-gray-700'}`}>
+                  {row.status}
+                </span>
+              </td>
+              <td className="py-2.5 pr-4">
+                <div className="flex gap-1">
+                  <button
+                    disabled={row.status === 'Passed' || actionLoading === row.event_id}
+                    className="rounded-lg bg-green-100 px-2 py-1 text-xs font-semibold text-green-700 hover:bg-green-200 disabled:cursor-not-allowed disabled:opacity-40"
+                    onClick={() => onAction(row.event_id, 'Passed')}
+                  >
+                    통과
+                  </button>
+                  <button
+                    disabled={row.status === 'Blocked' || actionLoading === row.event_id}
+                    className="rounded-lg bg-red-100 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-200 disabled:cursor-not-allowed disabled:opacity-40"
+                    onClick={() => onAction(row.event_id, 'Blocked')}
+                  >
+                    차단
+                  </button>
+                </div>
+              </td>
+              <td className="py-2.5">
+                <button
+                  className="flex items-center gap-1 rounded-lg bg-[#ede9fe] px-2 py-1 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
+                  onClick={() => onAnalyze(row.event_id)}
+                >
+                  <Sparkles className="size-3" />
+                  분석
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ─── 마우스 궤적 시각화 ───────────────────────
+
+function MouseTrajectoryChart({ events }: { events: MouseEventItem[] }) {
+  if (!events || events.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">
+        이벤트 데이터가 없습니다.
+      </p>
+    );
+  }
+
+  // 이벤트 타입별 그룹핑
+  const grouped = [1, 2, 3, 4, 5].map(type => ({
+    type,
+    meta: EVENT_TYPE_META[type],
+    data: events
+      .filter(e => e.event_type === type)
+      .map(e => ({ x: Math.round(e.screen_x), y: Math.round(e.screen_y) })),
+  })).filter(g => g.data.length > 0);
+
+  // 이동 궤적 (move 이벤트만 시간 순으로)
+  const trajectory = [...events]
+    .filter(e => e.event_type === 2)
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .map(e => ({ x: Math.round(e.screen_x), y: Math.round(e.screen_y) }));
+
+  // 이벤트 타입 집계
+  const typeCounts = [1, 2, 3, 4, 5].map(type => ({
+    name: EVENT_TYPE_META[type].label,
+    count: events.filter(e => e.event_type === type).length,
+    fill: EVENT_TYPE_META[type].color,
+  })).filter(t => t.count > 0);
+
+  // 시간대별 이벤트 밀도 (100ms 단위)
+  const minTs = Math.min(...events.map(e => e.timestamp));
+  const bucketMs = 500;
+  const buckets: Record<number, number> = {};
+  events.forEach(e => {
+    const bucket = Math.floor((e.timestamp - minTs) / bucketMs);
+    buckets[bucket] = (buckets[bucket] ?? 0) + 1;
+  });
+  const densityData = Object.entries(buckets)
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .map(([k, v]) => ({ t: `${(Number(k) * bucketMs / 1000).toFixed(1)}s`, count: v }));
+
+  return (
+    <div className="space-y-6">
+      {/* 궤적 산점도 */}
+      <div>
+        <p className="mb-2 text-xs font-semibold text-[var(--text-secondary)]">마우스 궤적 (화면 좌표)</p>
+        <ResponsiveContainer width="100%" height={300}>
+          <ScatterChart margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+            <XAxis
+              type="number"
+              dataKey="x"
+              name="X"
+              tick={{ fontSize: 10 }}
+              label={{ value: 'screen_x', position: 'insideBottom', offset: -4, fontSize: 10 }}
+            />
+            <YAxis
+              type="number"
+              dataKey="y"
+              name="Y"
+              reversed
+              tick={{ fontSize: 10 }}
+              label={{ value: 'screen_y', angle: -90, position: 'insideLeft', fontSize: 10 }}
+            />
+            <Tooltip
+              cursor={{ strokeDasharray: '3 3' }}
+              contentStyle={{ fontSize: 11, borderRadius: 8 }}
+              formatter={(val, name) => [val, name === 'x' ? 'X' : 'Y']}
+            />
+            <Legend
+              iconType="circle"
+              iconSize={8}
+              wrapperStyle={{ fontSize: 11 }}
+            />
+            {/* 이동 궤적 라인 */}
+            {trajectory.length > 1 && (
+              <Scatter
+                name="이동경로"
+                data={trajectory}
+                line={{ stroke: '#6366f1', strokeWidth: 1, strokeOpacity: 0.3 }}
+                lineType="joint"
+                fill="transparent"
+                legendType="none"
+              />
+            )}
+            {/* 타입별 점 */}
+            {grouped.map(g => (
+              <Scatter
+                key={g.type}
+                name={g.meta.label}
+                data={g.data}
+                fill={g.meta.color}
+                opacity={0.8}
+              />
+            ))}
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* 이벤트 타입 분포 + 시간별 밀도 */}
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <p className="mb-2 text-xs font-semibold text-[var(--text-secondary)]">이벤트 타입 분포</p>
+          <ResponsiveContainer width="100%" height={140}>
+            <BarChart data={typeCounts} layout="vertical" margin={{ left: 8 }}>
+              <XAxis type="number" tick={{ fontSize: 10 }} />
+              <YAxis type="category" dataKey="name" width={50} tick={{ fontSize: 10 }} />
+              <Tooltip contentStyle={{ fontSize: 11, borderRadius: 8 }} formatter={v => [`${v}회`]} />
+              <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+                {typeCounts.map((t, i) => (
+                  <Cell key={i} fill={t.fill} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div>
+          <p className="mb-2 text-xs font-semibold text-[var(--text-secondary)]">시간대별 이벤트 밀도 (0.5s)</p>
+          <ResponsiveContainer width="100%" height={140}>
+            <LineChart data={densityData} margin={{ left: 0, right: 8 }}>
+              <XAxis dataKey="t" tick={{ fontSize: 9 }} interval="preserveStartEnd" />
+              <YAxis tick={{ fontSize: 10 }} />
+              <Tooltip contentStyle={{ fontSize: 11, borderRadius: 8 }} formatter={v => [`${v}회`]} />
+              <Line
+                type="monotone"
+                dataKey="count"
+                stroke="#6366f1"
+                strokeWidth={1.5}
+                dot={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── IP 분석 탭 ──────────────────────────────
+
+function IPAnalysisTab({
+  items,
+  onAnalyze,
+}: {
+  items: IPSummaryItem[];
+  onAnalyze: (ip: string) => void;
+}) {
+  if (items.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">
+        IP 데이터가 없습니다. 가드레일 차단 이벤트에 IP가 포함되면 여기에 표시됩니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-[var(--neutral-200)] text-xs font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
+            <th className="py-2 pr-4">IP 주소</th>
+            <th className="py-2 pr-4">탐지 건수</th>
+            <th className="py-2 pr-4">차단 건수</th>
+            <th className="py-2 pr-4">최대 Risk</th>
+            <th className="py-2 pr-4">탐지 유형</th>
+            <th className="py-2 pr-4">첫 탐지 (KST)</th>
+            <th className="py-2 pr-4">최근 탐지 (KST)</th>
+            <th className="py-2">AI 분석</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[var(--neutral-100)]">
+          {items.map(item => (
+            <tr key={item.ip_address} className="hover:bg-[var(--neutral-50)]">
+              <td className="py-2.5 pr-4 font-mono text-xs font-semibold text-[var(--text-primary)]">
+                {item.ip_address}
+              </td>
+              <td className="py-2.5 pr-4 text-center text-[var(--text-secondary)]">
+                {item.total_events}
+              </td>
+              <td className="py-2.5 pr-4 text-center">
+                <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">
+                  {item.blocked_count}
+                </span>
+              </td>
+              <td className="py-2.5 pr-4">
+                <div className="flex items-center gap-2">
+                  <div className="h-1.5 w-14 overflow-hidden rounded-full bg-[var(--neutral-200)]">
+                    <div
+                      className={`h-full rounded-full ${item.max_risk >= 80 ? 'bg-red-500' : item.max_risk >= 50 ? 'bg-yellow-500' : 'bg-green-500'}`}
+                      style={{ width: `${item.max_risk}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-semibold text-[var(--text-secondary)]">{Math.round(item.max_risk)}%</span>
+                </div>
+              </td>
+              <td className="py-2.5 pr-4 text-xs text-[var(--text-secondary)]">
+                {item.detection_types || '-'}
+              </td>
+              <td className="py-2.5 pr-4 text-xs text-[var(--text-secondary)]">
+                {toKST(item.first_seen)}
+              </td>
+              <td className="py-2.5 pr-4 text-xs text-[var(--text-secondary)]">
+                {toKST(item.last_seen)}
+              </td>
+              <td className="py-2.5">
+                <button
+                  className="flex items-center gap-1 rounded-lg bg-[#ede9fe] px-2 py-1 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
+                  onClick={() => onAnalyze(item.ip_address)}
+                >
+                  <Sparkles className="size-3" />
+                  분석
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ─── 수동 심사 탭 ─────────────────────────────
+
+type ReviewSource = 'guardrail' | 'mouse';
+
+export interface ReviewRow {
+  id: string;
+  source: ReviewSource;
+  userId: string;
+  ipAddress: string;
+  riskScore: number;
+  reasons: string;
+  status: string;
+  detectedAt: string;
+}
+
+function ReviewTab({
+  detections,
+  mouseSessions,
+  onAnalyze,
+  onAction,
+  actionLoading,
+}: {
+  detections: BlockedEventRow[];
+  mouseSessions: MouseMacroSessionRow[];
+  onAnalyze: (row: ReviewRow) => void;
+  onAction: (id: string, action: 'Blocked' | 'Passed') => void;
+  actionLoading: string | null;
+}) {
+  const [sourceFilter, setSourceFilter] = useState<'all' | ReviewSource>('all');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'Blocked' | 'Passed' | 'Pending'>('all');
+  const [blockedIPs, setBlockedIPs] = useState<Set<string>>(new Set());
+
+  const rows: ReviewRow[] = [
+    ...detections.map(e => ({
+      id: e.event_id,
+      source: 'guardrail' as ReviewSource,
+      userId: e.user_id || '-',
+      ipAddress: e.ip_address || '-',
+      riskScore: e.risk_score,
+      reasons: e.reason_codes?.join(', ') || e.detection_type || '-',
+      status: e.status,
+      detectedAt: e.blocked_at,
+    })),
+    ...mouseSessions.map(s => ({
+      id: s.session_id,
+      source: 'mouse' as ReviewSource,
+      userId: s.user_id || '-',
+      ipAddress: '-',
+      riskScore: Math.round(s.probability * 100),
+      reasons: `Mouse Macro (확률 ${(s.probability * 100).toFixed(1)}%, 신뢰도 ${(s.confidence * 100).toFixed(1)}%)`,
+      status: 'Blocked',
+      detectedAt: s.detected_at,
+    })),
+  ].sort((a, b) => b.detectedAt.localeCompare(a.detectedAt));
+
+  const filtered = rows.filter(r => {
+    if (sourceFilter !== 'all' && r.source !== sourceFilter) return false;
+    if (statusFilter !== 'all' && r.status !== statusFilter) return false;
+    return true;
+  });
+
+  const handleMockBlockIP = (ip: string) => {
+    if (ip === '-') return;
+    setBlockedIPs(prev => new Set([...prev, ip]));
+  };
+
+  if (rows.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">
+        심사할 탐지 이벤트가 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 필터 */}
+      <div className="flex flex-wrap gap-3">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-[var(--text-tertiary)]">출처</span>
+          {(['all', 'guardrail', 'mouse'] as const).map(v => (
+            <button
+              key={v}
+              onClick={() => setSourceFilter(v)}
+              className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
+                sourceFilter === v
+                  ? 'bg-[var(--primary-normal)] text-white'
+                  : 'bg-[var(--neutral-100)] text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]'
+              }`}
+            >
+              {v === 'all' ? '전체' : v === 'guardrail' ? '가드레일' : '마우스 매크로'}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-[var(--text-tertiary)]">상태</span>
+          {(['all', 'Blocked', 'Passed', 'Pending'] as const).map(v => (
+            <button
+              key={v}
+              onClick={() => setStatusFilter(v)}
+              className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
+                statusFilter === v
+                  ? 'bg-[var(--primary-normal)] text-white'
+                  : 'bg-[var(--neutral-100)] text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]'
+              }`}
+            >
+              {v === 'all' ? '전체' : v}
+            </button>
+          ))}
+        </div>
+        <span className="ml-auto text-xs text-[var(--text-tertiary)]">
+          {filtered.length}건 표시 / 전체 {rows.length}건
+        </span>
+      </div>
+
+      {/* 이벤트 카드 목록 */}
+      <div className="space-y-3">
+        {filtered.map(row => {
+          const isIPBlocked = row.ipAddress !== '-' && blockedIPs.has(row.ipAddress);
+          return (
+            <div
+              key={row.id}
+              className={`rounded-xl border p-4 transition-colors ${
+                row.riskScore >= 80
+                  ? 'border-red-200 bg-red-50/40'
+                  : row.riskScore >= 50
+                  ? 'border-orange-200 bg-orange-50/40'
+                  : 'border-[var(--neutral-200)] bg-white'
+              }`}
+            >
+              {/* 상단: 이벤트 정보 3열 */}
+              <div className="grid grid-cols-3 gap-4 text-sm">
+                <div>
+                  <p className="text-xs font-semibold text-[var(--text-tertiary)] mb-1">이벤트</p>
+                  <p className="font-mono text-xs text-[var(--text-primary)]">{row.id.slice(0, 20)}</p>
+                  <p className="mt-0.5">
+                    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-semibold ${
+                      row.source === 'guardrail'
+                        ? 'bg-purple-100 text-purple-700'
+                        : 'bg-blue-100 text-blue-700'
+                    }`}>
+                      {row.source === 'guardrail' ? '가드레일' : '마우스 매크로'}
+                    </span>
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold text-[var(--text-tertiary)] mb-1">사용자 / IP</p>
+                  <p className="text-xs text-[var(--text-primary)]">User: {row.userId}</p>
+                  <p className="text-xs text-[var(--text-secondary)] font-mono flex items-center gap-1 mt-0.5">
+                    <Globe className="size-3" />
+                    {row.ipAddress}
+                    {isIPBlocked && (
+                      <span className="ml-1 rounded-full bg-red-600 px-1.5 py-0.5 text-white text-[10px] font-bold">차단됨</span>
+                    )}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold text-[var(--text-tertiary)] mb-1">위험도 / 시각</p>
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--neutral-200)]">
+                      <div
+                        className={`h-full rounded-full ${row.riskScore >= 80 ? 'bg-red-500' : row.riskScore >= 50 ? 'bg-yellow-500' : 'bg-green-500'}`}
+                        style={{ width: `${row.riskScore}%` }}
+                      />
+                    </div>
+                    <span className="text-xs font-semibold text-[var(--text-secondary)]">{row.riskScore}%</span>
+                  </div>
+                  <p className="text-xs text-[var(--text-secondary)]">{toKST(row.detectedAt)}</p>
+                </div>
+              </div>
+
+              {/* 탐지 사유 */}
+              <p className="mt-2 text-xs text-[var(--text-tertiary)] bg-[var(--neutral-50)] rounded-lg px-3 py-2">
+                탐지 사유: {row.reasons}
+              </p>
+
+              {/* 액션 버튼 */}
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {/* AI 심사 의견 */}
+                <button
+                  className="flex items-center gap-1.5 rounded-lg bg-[#ede9fe] px-3 py-1.5 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
+                  onClick={() => onAnalyze(row)}
+                >
+                  <Sparkles className="size-3" />
+                  AI 심사 의견
+                </button>
+
+                {/* 가드레일 이벤트만 차단/통과 가능 */}
+                {row.source === 'guardrail' && (
+                  <>
+                    <button
+                      disabled={row.status === 'Passed' || actionLoading === row.id}
+                      className="flex items-center gap-1.5 rounded-lg bg-green-100 px-3 py-1.5 text-xs font-semibold text-green-700 hover:bg-green-200 disabled:cursor-not-allowed disabled:opacity-40"
+                      onClick={() => onAction(row.id, 'Passed')}
+                    >
+                      <CheckCircle2 className="size-3" />
+                      통과
+                    </button>
+                    <button
+                      disabled={row.status === 'Blocked' || actionLoading === row.id}
+                      className="flex items-center gap-1.5 rounded-lg bg-red-100 px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-200 disabled:cursor-not-allowed disabled:opacity-40"
+                      onClick={() => onAction(row.id, 'Blocked')}
+                    >
+                      <Ban className="size-3" />
+                      차단
+                    </button>
+                  </>
+                )}
+
+                {/* IP 모의 차단 (실제 차단 없이 UI 표시만) */}
+                {row.ipAddress !== '-' && (
+                  <button
+                    className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors ${
+                      isIPBlocked
+                        ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                        : 'bg-orange-100 text-orange-700 hover:bg-orange-200'
+                    }`}
+                    onClick={() => !isIPBlocked && handleMockBlockIP(row.ipAddress)}
+                    disabled={isIPBlocked}
+                    title="시뮬레이션 — 실제 네트워크 차단은 적용되지 않습니다"
+                  >
+                    <Globe className="size-3" />
+                    {isIPBlocked ? 'IP 차단됨' : 'IP 차단 (모의)'}
+                  </button>
+                )}
+
+                {/* 현재 상태 뱃지 */}
+                <span className={`ml-auto rounded-full px-2 py-0.5 text-xs font-semibold ${
+                  STATUS_STYLE[row.status] ?? 'bg-gray-100 text-gray-700'
+                }`}>
+                  {row.status}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── AI 분석 모달 ─────────────────────────────
+
+function AnalysisModal({
+  title,
+  analysis,
+  isLoading,
+  error,
+  onClose,
+}: {
+  title: string;
+  analysis: string | null;
+  isLoading: boolean;
+  error: string | null;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-2xl rounded-2xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-[var(--neutral-200)] px-6 py-4">
+          <div className="flex items-center gap-2">
+            <Sparkles className="size-5 text-[#6366f1]" />
+            <h2 className="text-base font-semibold text-[var(--text-primary)]">{title}</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 hover:bg-[var(--neutral-100)] text-[var(--text-tertiary)]"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="px-6 py-5 min-h-[200px]">
+          {isLoading && (
+            <div className="flex flex-col items-center justify-center gap-3 py-10">
+              <Loader2 className="size-8 animate-spin text-[#6366f1]" />
+              <p className="text-sm text-[var(--text-tertiary)]">Upstage Solar가 분석 중입니다...</p>
+            </div>
+          )}
+          {error && (
+            <div className="flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-red-600" />
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+          )}
+          {analysis && !isLoading && (
+            <div className="prose prose-sm max-w-none">
+              {analysis.split('\n').map((line, i) => {
+                if (line.startsWith('##')) {
+                  return <p key={i} className="mt-3 mb-1 text-sm font-bold text-[var(--text-primary)]">{line.replace(/^##\s*/, '')}</p>;
+                }
+                if (/^\d+\./.test(line) || line.startsWith('- ') || line.startsWith('• ')) {
+                  return <p key={i} className="ml-3 text-sm text-[var(--text-secondary)] leading-relaxed">{line}</p>;
+                }
+                if (line.trim() === '') return <div key={i} className="h-2" />;
+                return <p key={i} className="text-sm text-[var(--text-secondary)] leading-relaxed">{line}</p>;
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end border-t border-[var(--neutral-200)] px-6 py-3">
+          <p className="mr-auto text-xs text-[var(--text-tertiary)]">Powered by Upstage Solar</p>
+          <button
+            onClick={onClose}
+            className="rounded-xl bg-[var(--neutral-100)] px-4 py-2 text-sm font-semibold text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── 마우스 궤적 모달 ─────────────────────────
+
+function TrajectoryModal({
+  session,
+  onClose,
+}: {
+  session: MouseMacroSessionRow;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-3xl rounded-2xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-[var(--neutral-200)] px-6 py-4">
+          <div className="flex items-center gap-2">
+            <BarChart2 className="size-5 text-[#6366f1]" />
+            <div>
+              <h2 className="text-base font-semibold text-[var(--text-primary)]">
+                마우스 궤적 분석
+              </h2>
+              <p className="text-xs text-[var(--text-tertiary)]">
+                {session.session_id.slice(0, 20)} · 확률 {(session.probability * 100).toFixed(1)}% · {toKST(session.detected_at)}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 hover:bg-[var(--neutral-100)] text-[var(--text-tertiary)]"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="px-6 py-5">
+          <MouseTrajectoryChart events={session.events ?? []} />
+        </div>
+
+        <div className="flex items-center justify-between border-t border-[var(--neutral-200)] px-6 py-3">
+          <p className="text-xs text-[var(--text-tertiary)]">
+            총 {session.event_count.toLocaleString()}개 이벤트 · 신뢰도 {(session.confidence * 100).toFixed(1)}%
+          </p>
+          <button
+            onClick={onClose}
+            className="rounded-xl bg-[var(--neutral-100)] px-4 py-2 text-sm font-semibold text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── 메인 페이지 ──────────────────────────────
+
+const MacroDashboardPage = () => {
+  const queryClient = useQueryClient();
+  const [tab, setTab] = useState<'guardrail' | 'mouse' | 'ip' | 'review'>('guardrail');
+
+  const { data: overview, isLoading, isError, dataUpdatedAt } = useQuery({
+    queryKey: ['macro-dashboard-overview'],
+    queryFn: fetchDashboardOverview,
+    refetchInterval: REFETCH_MS,
+  });
+
+  const { data: detections = [] } = useQuery({
+    queryKey: ['macro-dashboard-detections'],
+    queryFn: () => fetchDetections(100),
+    refetchInterval: REFETCH_MS,
+  });
+
+  const { data: mouseSessions = [] } = useQuery({
+    queryKey: ['macro-dashboard-mouse'],
+    queryFn: () => fetchMouseMacroSessions(50),
+    refetchInterval: REFETCH_MS,
+  });
+
+  const { data: alerts = [] } = useQuery({
+    queryKey: ['macro-dashboard-alerts'],
+    queryFn: () => fetchAlerts(20),
+    refetchInterval: REFETCH_MS,
+  });
+
+  const { data: ipSummary = [] } = useQuery({
+    queryKey: ['macro-dashboard-ip-summary'],
+    queryFn: fetchIPSummary,
+    refetchInterval: REFETCH_MS,
+  });
+
+  // ── AI 분석 모달 상태 ──
+  const [analysisModal, setAnalysisModal] = useState<{
+    open: boolean;
+    title: string;
+    analysis: string | null;
+    isLoading: boolean;
+    error: string | null;
+  }>({ open: false, title: '', analysis: null, isLoading: false, error: null });
+
+  const openAnalysis = (title: string) => {
+    setAnalysisModal({ open: true, title, analysis: null, isLoading: true, error: null });
+  };
+  const closeAnalysis = () => {
+    setAnalysisModal(prev => ({ ...prev, open: false }));
+  };
+
+  // ── 궤적 모달 상태 ──
+  const [trajectorySession, setTrajectorySession] = useState<MouseMacroSessionRow | null>(null);
+
+  const handleAnalyzeGuardrail = (eventId: string) => {
+    openAnalysis(`가드레일 차단 분석 — ${eventId.slice(0, 14)}`);
+    analyzeGuardrailEvent(eventId)
+      .then(res => setAnalysisModal(prev => ({ ...prev, isLoading: false, analysis: res.analysis })))
+      .catch(err => setAnalysisModal(prev => ({
+        ...prev,
+        isLoading: false,
+        error: (err as Error).message ?? '분석 실패',
+      })));
+  };
+
+  const handleAnalyzeMouseMacro = (sessionId: string) => {
+    openAnalysis(`마우스 매크로 분석 — ${sessionId.slice(0, 16)}`);
+    analyzeMouseMacroSession(sessionId)
+      .then(res => setAnalysisModal(prev => ({ ...prev, isLoading: false, analysis: res.analysis })))
+      .catch(err => setAnalysisModal(prev => ({
+        ...prev,
+        isLoading: false,
+        error: (err as Error).message ?? '분석 실패',
+      })));
+  };
+
+  const handleAnalyzeIP = (ipAddress: string) => {
+    openAnalysis(`IP 종합 분석 — ${ipAddress}`);
+    analyzeIPViolations(ipAddress)
+      .then(res => setAnalysisModal(prev => ({ ...prev, isLoading: false, analysis: res.analysis })))
+      .catch(err => setAnalysisModal(prev => ({
+        ...prev,
+        isLoading: false,
+        error: (err as Error).message ?? '분석 실패',
+      })));
+  };
+
+  const handleReviewAnalyze = (row: ReviewRow) => {
+    const label = row.source === 'guardrail'
+      ? `심사 의견 — ${row.id.slice(0, 14)} (가드레일)`
+      : `심사 의견 — ${row.id.slice(0, 14)} (마우스 매크로)`;
+    openAnalysis(label);
+
+    const analyzePromise = row.source === 'guardrail'
+      ? analyzeGuardrailEvent(row.id)
+      : analyzeMouseMacroSession(row.id);
+
+    analyzePromise
+      .then(res => setAnalysisModal(prev => ({ ...prev, isLoading: false, analysis: res.analysis })))
+      .catch(err => setAnalysisModal(prev => ({
+        ...prev,
+        isLoading: false,
+        error: (err as Error).message ?? '분석 실패',
+      })));
+  };
+
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const { mutate: doAction } = useMutation({
+    mutationFn: ({ id, action }: { id: string; action: 'Blocked' | 'Passed' }) =>
+      updateEventAction(id, action),
+    onMutate: ({ id }) => setActionLoading(id),
+    onSettled: () => {
+      setActionLoading(null);
+      void queryClient.invalidateQueries({ queryKey: ['macro-dashboard-detections'] });
+      void queryClient.invalidateQueries({ queryKey: ['macro-dashboard-overview'] });
+    },
+  });
+
+  const lastUpdated = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString('ko-KR', {
+        timeZone: 'Asia/Seoul',
+        hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+      })
+    : '-';
+
+  if (isError) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[var(--background-surface)] p-6">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <Wifi className="size-12 text-red-400" />
+          <p className="text-lg font-semibold text-[var(--text-primary)]">Go 서버에 연결할 수 없습니다</p>
+          <p className="text-sm text-[var(--text-tertiary)]">macro-dashboard-api 서버가 실행 중인지 확인하세요.</p>
+          <button
+            className="rounded-xl bg-[var(--primary-normal)] px-6 py-2.5 text-sm font-semibold text-white"
+            onClick={() => void queryClient.refetchQueries({ queryKey: ['macro-dashboard-overview'] })}
+          >
+            다시 시도
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  const stats = overview?.stats;
+
+  return (
+    <>
+    {analysisModal.open && (
+      <AnalysisModal
+        title={analysisModal.title}
+        analysis={analysisModal.analysis}
+        isLoading={analysisModal.isLoading}
+        error={analysisModal.error}
+        onClose={closeAnalysis}
+      />
+    )}
+    {trajectorySession && (
+      <TrajectoryModal
+        session={trajectorySession}
+        onClose={() => setTrajectorySession(null)}
+      />
+    )}
+    <main className="min-h-screen bg-[var(--background-surface)] p-6">
+      <div className="mx-auto max-w-7xl space-y-6">
+
+        {/* ── 헤더 ── */}
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-[var(--text-primary)]">
+              AI 매크로 보안 대시보드
+            </h1>
+            <p className="mt-1 text-sm text-[var(--text-tertiary)]">
+              가드레일 · 마우스 매크로 실시간 탐지 현황
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="flex items-center gap-1.5 text-xs text-[var(--text-tertiary)]">
+              <Clock className="size-3.5" />
+              마지막 업데이트: {lastUpdated} KST
+            </span>
+            <button
+              className="flex items-center gap-1.5 rounded-xl border border-[var(--neutral-200)] bg-white px-4 py-2 text-sm font-semibold text-[var(--text-secondary)] shadow-sm hover:bg-[var(--neutral-50)]"
+              onClick={() => void queryClient.invalidateQueries()}
+            >
+              <RefreshCw className="size-4" />
+              새로고침
+            </button>
+          </div>
+        </div>
+
+        {/* ── 알림 배너 ── */}
+        <AlertBanner alerts={alerts} />
+
+        {/* ── 통계 카드 ── */}
+        {isLoading ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="h-28 animate-pulse rounded-2xl bg-[var(--neutral-200)]" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <StatCard
+              label="가드레일 차단 건수"
+              value={stats?.blocked_count ?? 0}
+              unit="건"
+              delta={stats?.blocked_delta}
+              icon={<ShieldAlert className="size-5" />}
+            />
+            <StatCard
+              label="마우스 매크로 탐지"
+              value={stats?.mouse_macro_count ?? 0}
+              unit="건"
+              icon={<MousePointer2 className="size-5" />}
+            />
+            <StatCard
+              label="총 탐지 건수"
+              value={stats?.total_access ?? 0}
+              unit="건"
+              delta={stats?.total_access_delta}
+              icon={<Activity className="size-5" />}
+            />
+            <StatCard
+              label="차단율"
+              value={stats?.block_rate?.toFixed(1) ?? '0'}
+              unit="%"
+              delta={stats?.block_rate_delta}
+              icon={<ShieldCheck className="size-5" />}
+            />
+          </div>
+        )}
+
+        {/* ── 차트 2열 ── */}
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div className="rounded-2xl border border-[var(--neutral-200)] bg-white p-5 shadow-sm">
+            <h2 className="mb-4 text-sm font-semibold text-[var(--text-primary)]">탐지 유형 분포</h2>
+            {(overview?.detection_types?.length ?? 0) === 0 ? (
+              <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">데이터 없음</p>
+            ) : (
+              <ResponsiveContainer width="100%" height={200}>
+                <BarChart data={overview!.detection_types} layout="vertical" margin={{ left: 16 }}>
+                  <XAxis type="number" tick={{ fontSize: 11 }} />
+                  <YAxis type="category" dataKey="type" width={90} tick={{ fontSize: 11 }} />
+                  <Tooltip
+                    contentStyle={{ fontSize: 12, borderRadius: 8 }}
+                    formatter={(v) => [`${v}건`, '탐지 수']}
+                  />
+                  <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+                    {overview!.detection_types.map((_, i) => (
+                      <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+
+          <div className="rounded-2xl border border-[var(--neutral-200)] bg-white p-5 shadow-sm">
+            <h2 className="mb-4 text-sm font-semibold text-[var(--text-primary)]">
+              최근 24시간 탐지 트렌드 (KST)
+            </h2>
+            {(overview?.hourly_trend?.length ?? 0) === 0 ? (
+              <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">데이터 없음</p>
+            ) : (
+              <ResponsiveContainer width="100%" height={200}>
+                <LineChart data={overview!.hourly_trend} margin={{ left: 0, right: 8 }}>
+                  <XAxis
+                    dataKey="hour"
+                    tick={{ fontSize: 11 }}
+                    tickFormatter={h => `${((Number(h) + 9) % 24).toString().padStart(2, '0')}시`}
+                  />
+                  <YAxis tick={{ fontSize: 11 }} />
+                  <Tooltip
+                    contentStyle={{ fontSize: 12, borderRadius: 8 }}
+                    formatter={(v) => [`${v}건`, '탐지']}
+                    labelFormatter={h => `${((Number(h) + 9) % 24).toString().padStart(2, '0')}시 (KST)`}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="count"
+                    stroke="#6366f1"
+                    strokeWidth={2}
+                    dot={{ r: 3 }}
+                    activeDot={{ r: 5 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </div>
+
+        {/* ── 탐지 이벤트 테이블 (탭) ── */}
+        <div className="rounded-2xl border border-[var(--neutral-200)] bg-white shadow-sm">
+          <div className="flex items-center gap-1 border-b border-[var(--neutral-200)] px-5 pt-4 overflow-x-auto">
+            {([
+              { key: 'guardrail', label: `가드레일 탐지 (${detections.length})`, icon: <ShieldAlert className="size-3.5" /> },
+              { key: 'mouse',     label: `마우스 매크로 (${mouseSessions.length})`, icon: <MousePointer2 className="size-3.5" /> },
+              { key: 'ip',        label: `IP 분석 (${ipSummary.length})`, icon: <Globe className="size-3.5" /> },
+              { key: 'review',    label: `수동 심사 (${detections.length + mouseSessions.length})`, icon: <ClipboardList className="size-3.5" /> },
+            ] as const).map(t => (
+              <button
+                key={t.key}
+                onClick={() => setTab(t.key)}
+                className={`flex items-center gap-1.5 whitespace-nowrap rounded-t-lg px-4 py-2 text-sm font-semibold transition-colors ${
+                  tab === t.key
+                    ? 'border-b-2 border-[var(--primary-normal)] text-[var(--primary-normal)]'
+                    : 'text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]'
+                }`}
+              >
+                {t.icon}
+                {t.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="p-5">
+            {tab === 'guardrail' ? (
+              <DetectionsTable
+                rows={detections}
+                onAction={(id, action) => doAction({ id, action })}
+                actionLoading={actionLoading}
+                onAnalyze={handleAnalyzeGuardrail}
+              />
+            ) : tab === 'ip' ? (
+              <IPAnalysisTab
+                items={ipSummary}
+                onAnalyze={handleAnalyzeIP}
+              />
+            ) : tab === 'review' ? (
+              <ReviewTab
+                detections={detections}
+                mouseSessions={mouseSessions}
+                onAnalyze={handleReviewAnalyze}
+                onAction={(id, action) => doAction({ id, action })}
+                actionLoading={actionLoading}
+              />
+            ) : (
+              mouseSessions.length === 0 ? (
+                <p className="py-6 text-center text-sm text-[var(--text-tertiary)]">
+                  수신된 마우스 매크로 세션이 없습니다.
+                </p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-left text-sm">
+                    <thead>
+                      <tr className="border-b border-[var(--neutral-200)] text-xs font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
+                        <th className="py-2 pr-4">Session ID</th>
+                        <th className="py-2 pr-4">User ID</th>
+                        <th className="py-2 pr-4">탐지 시각 (KST)</th>
+                        <th className="py-2 pr-4">이벤트 수</th>
+                        <th className="py-2 pr-4">매크로 확률</th>
+                        <th className="py-2 pr-4">신뢰도</th>
+                        <th className="py-2 pr-4">궤적</th>
+                        <th className="py-2">AI 분석</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-[var(--neutral-100)]">
+                      {mouseSessions.map(s => (
+                        <tr key={s.session_id} className="hover:bg-[var(--neutral-50)]">
+                          <td className="py-2.5 pr-4 font-mono text-xs text-[var(--text-secondary)]">
+                            {s.session_id.slice(0, 16)}
+                          </td>
+                          <td className="py-2.5 pr-4 text-[var(--text-secondary)]">
+                            {s.user_id || '-'}
+                          </td>
+                          <td className="py-2.5 pr-4 text-[var(--text-secondary)]">
+                            {toKST(s.detected_at)}
+                          </td>
+                          <td className="py-2.5 pr-4 text-[var(--text-secondary)]">
+                            {s.event_count.toLocaleString()}개
+                          </td>
+                          <td className="py-2.5 pr-4">
+                            <div className="flex items-center gap-2">
+                              <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--neutral-200)]">
+                                <div
+                                  className="h-full rounded-full bg-[#6366f1]"
+                                  style={{ width: `${Math.round(s.probability * 100)}%` }}
+                                />
+                              </div>
+                              <span className="text-xs font-semibold text-[var(--text-secondary)]">
+                                {(s.probability * 100).toFixed(1)}%
+                              </span>
+                            </div>
+                          </td>
+                          <td className="py-2.5 pr-4">
+                            <span className="text-xs font-medium text-[var(--text-secondary)]">
+                              {(s.confidence * 100).toFixed(1)}%
+                            </span>
+                          </td>
+                          <td className="py-2.5 pr-4">
+                            <button
+                              className="flex items-center gap-1 rounded-lg bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-600 hover:bg-blue-100"
+                              onClick={() => setTrajectorySession(s)}
+                            >
+                              <BarChart2 className="size-3" />
+                              궤적
+                            </button>
+                          </td>
+                          <td className="py-2.5">
+                            <button
+                              className="flex items-center gap-1 rounded-lg bg-[#ede9fe] px-2 py-1 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
+                              onClick={() => handleAnalyzeMouseMacro(s.session_id)}
+                            >
+                              <Sparkles className="size-3" />
+                              분석
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )
+            )}
+          </div>
+        </div>
+
+        {/* ── 활성 알림 목록 ── */}
+        <div className="rounded-2xl border border-[var(--neutral-200)] bg-white p-5 shadow-sm">
+          <h2 className="mb-4 text-sm font-semibold text-[var(--text-primary)]">
+            활성 알림 (Risk ≥ 80%)
+          </h2>
+          <AlertList alerts={alerts} />
+        </div>
+
+      </div>
+    </main>
+    </>
+  );
+};
+
+export default MacroDashboardPage;

--- a/src/pages/macro-dashboard/ui/components/AlertBanner.tsx
+++ b/src/pages/macro-dashboard/ui/components/AlertBanner.tsx
@@ -1,0 +1,32 @@
+import { AlertTriangle } from 'lucide-react';
+
+import type { AlertItem } from '../../api/dashboardApi';
+
+type AlertBannerProps = {
+  alerts: AlertItem[];
+};
+
+const AlertBanner = ({ alerts }: AlertBannerProps) => {
+  if (alerts.length === 0) return null;
+
+  const critical = alerts.filter((alert) => alert.severity === 'critical');
+  const label =
+    critical.length > 0
+      ? `위험 알림 ${critical.length}건 — 즉시 확인이 필요합니다`
+      : `주의 알림 ${alerts.length}건이 발생했습니다`;
+
+  return (
+    <div
+      className={`flex items-center gap-3 rounded-xl border-l-4 p-4 ${
+        critical.length > 0 ? 'border-red-500 bg-red-50' : 'border-yellow-400 bg-yellow-50'
+      }`}
+    >
+      <AlertTriangle
+        className={`size-5 shrink-0 ${critical.length > 0 ? 'text-red-600' : 'text-yellow-600'}`}
+      />
+      <span className="text-sm font-semibold text-[var(--text-primary)]">{label}</span>
+    </div>
+  );
+};
+
+export default AlertBanner;

--- a/src/pages/macro-dashboard/ui/components/AlertList.tsx
+++ b/src/pages/macro-dashboard/ui/components/AlertList.tsx
@@ -1,0 +1,43 @@
+import { AlertTriangle } from 'lucide-react';
+
+import type { AlertItem } from '../../api/dashboardApi';
+import { SEVERITY_ICON_CLASS, SEVERITY_STYLE } from '../lib/dashboardConstants';
+import { toKST } from '../lib/dashboardFormat';
+
+type AlertListProps = {
+  alerts: AlertItem[];
+};
+
+const AlertList = ({ alerts }: AlertListProps) => {
+  if (alerts.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-[var(--text-tertiary)]">
+        현재 활성 알림이 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {alerts.map((alert) => (
+        <li
+          key={alert.alert_id}
+          className={`flex items-start gap-3 rounded-xl border-l-4 p-4 ${SEVERITY_STYLE[alert.severity]}`}
+        >
+          <AlertTriangle className={`mt-0.5 size-4 shrink-0 ${SEVERITY_ICON_CLASS[alert.severity]}`} />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold text-[var(--text-primary)]">{alert.message}</p>
+            <p className="mt-1 text-xs text-[var(--text-tertiary)]">
+              {alert.alert_type} · Risk {alert.risk_score}% · {toKST(alert.triggered_at)}
+            </p>
+          </div>
+          <span className="shrink-0 rounded-full bg-white/80 px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-[var(--text-secondary)]">
+            {alert.severity}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default AlertList;

--- a/src/pages/macro-dashboard/ui/components/AnalysisModal.tsx
+++ b/src/pages/macro-dashboard/ui/components/AnalysisModal.tsx
@@ -1,0 +1,88 @@
+import { AlertTriangle, Loader2, Sparkles, X } from 'lucide-react';
+
+type AnalysisModalProps = {
+  title: string;
+  analysis: string | null;
+  isLoading: boolean;
+  error: string | null;
+  onClose: () => void;
+};
+
+const AnalysisModal = ({ title, analysis, isLoading, error, onClose }: AnalysisModalProps) => {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-2xl rounded-2xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-[var(--neutral-200)] px-6 py-4">
+          <div className="flex items-center gap-2">
+            <Sparkles className="size-5 text-[#6366f1]" />
+            <h2 className="text-base font-semibold text-[var(--text-primary)]">{title}</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-[var(--text-tertiary)] hover:bg-[var(--neutral-100)]"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="min-h-[200px] px-6 py-5">
+          {isLoading && (
+            <div className="flex flex-col items-center justify-center gap-3 py-10">
+              <Loader2 className="size-8 animate-spin text-[#6366f1]" />
+              <p className="text-sm text-[var(--text-tertiary)]">Upstage Solar가 분석 중입니다...</p>
+            </div>
+          )}
+          {error && (
+            <div className="flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-red-600" />
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+          )}
+          {analysis && !isLoading && (
+            <div className="prose prose-sm max-w-none">
+              {analysis.split('\n').map((line, index) => {
+                if (line.startsWith('##')) {
+                  return (
+                    <p key={index} className="mb-1 mt-3 text-sm font-bold text-[var(--text-primary)]">
+                      {line.replace(/^##\s*/, '')}
+                    </p>
+                  );
+                }
+
+                if (/^\d+\./.test(line) || line.startsWith('- ') || line.startsWith('• ')) {
+                  return (
+                    <p key={index} className="ml-3 text-sm leading-relaxed text-[var(--text-secondary)]">
+                      {line}
+                    </p>
+                  );
+                }
+
+                if (line.trim() === '') {
+                  return <div key={index} className="h-2" />;
+                }
+
+                return (
+                  <p key={index} className="text-sm leading-relaxed text-[var(--text-secondary)]">
+                    {line}
+                  </p>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end border-t border-[var(--neutral-200)] px-6 py-3">
+          <p className="mr-auto text-xs text-[var(--text-tertiary)]">Powered by Upstage Solar</p>
+          <button
+            onClick={onClose}
+            className="rounded-xl bg-[var(--neutral-100)] px-4 py-2 text-sm font-semibold text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AnalysisModal;

--- a/src/pages/macro-dashboard/ui/components/DashboardCharts.tsx
+++ b/src/pages/macro-dashboard/ui/components/DashboardCharts.tsx
@@ -1,0 +1,60 @@
+import { Bar, BarChart, Cell, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+
+import type { DashboardOverview } from '../../api/dashboardApi';
+import { CHART_COLORS } from '../lib/dashboardConstants';
+
+type DashboardChartsProps = {
+  overview?: DashboardOverview;
+};
+
+const DashboardCharts = ({ overview }: DashboardChartsProps) => {
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <div className="rounded-2xl border border-[var(--neutral-200)] bg-white p-5 shadow-sm">
+        <h2 className="mb-4 text-sm font-semibold text-[var(--text-primary)]">탐지 유형 분포</h2>
+        {(overview?.detection_types?.length ?? 0) === 0 ? (
+          <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">데이터 없음</p>
+        ) : (
+          <ResponsiveContainer width="100%" height={200}>
+            <BarChart data={overview?.detection_types} layout="vertical" margin={{ left: 16 }}>
+              <XAxis type="number" tick={{ fontSize: 11 }} />
+              <YAxis type="category" dataKey="type" width={90} tick={{ fontSize: 11 }} />
+              <Tooltip contentStyle={{ fontSize: 12, borderRadius: 8 }} formatter={(value) => [`${value}건`, '탐지 수']} />
+              <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+                {overview?.detection_types.map((_, index) => (
+                  <Cell key={index} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      <div className="rounded-2xl border border-[var(--neutral-200)] bg-white p-5 shadow-sm">
+        <h2 className="mb-4 text-sm font-semibold text-[var(--text-primary)]">최근 24시간 탐지 트렌드 (KST)</h2>
+        {(overview?.hourly_trend?.length ?? 0) === 0 ? (
+          <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">데이터 없음</p>
+        ) : (
+          <ResponsiveContainer width="100%" height={200}>
+            <LineChart data={overview?.hourly_trend} margin={{ left: 0, right: 8 }}>
+              <XAxis
+                dataKey="hour"
+                tick={{ fontSize: 11 }}
+                tickFormatter={(hour) => `${((Number(hour) + 9) % 24).toString().padStart(2, '0')}시`}
+              />
+              <YAxis tick={{ fontSize: 11 }} />
+              <Tooltip
+                contentStyle={{ fontSize: 12, borderRadius: 8 }}
+                formatter={(value) => [`${value}건`, '탐지']}
+                labelFormatter={(hour) => `${((Number(hour) + 9) % 24).toString().padStart(2, '0')}시 (KST)`}
+              />
+              <Line type="monotone" dataKey="count" stroke="#6366f1" strokeWidth={2} dot={{ r: 3 }} activeDot={{ r: 5 }} />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DashboardCharts;

--- a/src/pages/macro-dashboard/ui/components/DetectionsTable.tsx
+++ b/src/pages/macro-dashboard/ui/components/DetectionsTable.tsx
@@ -1,0 +1,110 @@
+import { Clock, Sparkles } from 'lucide-react';
+
+import type { BlockedEventRow } from '../../api/dashboardApi';
+import { STATUS_STYLE } from '../lib/dashboardConstants';
+import { toKST } from '../lib/dashboardFormat';
+
+type DetectionsTableProps = {
+  rows: BlockedEventRow[];
+  onAction: (eventId: string, action: 'Blocked' | 'Passed') => void;
+  actionLoading: string | null;
+  onAnalyze: (eventId: string) => void;
+};
+
+const DetectionsTable = ({
+  rows,
+  onAction,
+  actionLoading,
+  onAnalyze,
+}: DetectionsTableProps) => {
+  if (rows.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-[var(--text-tertiary)]">
+        탐지된 이벤트가 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-[var(--neutral-200)] text-xs font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
+            <th className="py-2 pr-4">Event ID</th>
+            <th className="py-2 pr-4">탐지 시각 (KST)</th>
+            <th className="py-2 pr-4">IP 주소</th>
+            <th className="py-2 pr-4">탐지 유형</th>
+            <th className="py-2 pr-4">Risk</th>
+            <th className="py-2 pr-4">상태</th>
+            <th className="py-2 pr-4">심사</th>
+            <th className="py-2">AI 분석</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[var(--neutral-100)]">
+          {rows.map((row) => (
+            <tr key={row.event_id} className="hover:bg-[var(--neutral-50)]">
+              <td className="py-2.5 pr-4 font-mono text-xs text-[var(--text-secondary)]">
+                {row.event_id.slice(0, 14)}
+              </td>
+              <td className="py-2.5 pr-4 text-[var(--text-secondary)]">
+                <span className="flex items-center gap-1">
+                  <Clock className="size-3 shrink-0" />
+                  {toKST(row.blocked_at)}
+                </span>
+              </td>
+              <td className="py-2.5 pr-4 font-mono text-xs text-[var(--text-secondary)]">
+                {row.ip_address || '-'}
+              </td>
+              <td className="py-2.5 pr-4 text-[var(--text-secondary)]">{row.detection_type}</td>
+              <td className="py-2.5 pr-4">
+                <div className="flex items-center gap-2">
+                  <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--neutral-200)]">
+                    <div
+                      className={`h-full rounded-full ${row.risk_score >= 80 ? 'bg-red-500' : row.risk_score >= 50 ? 'bg-yellow-500' : 'bg-green-500'}`}
+                      style={{ width: `${row.risk_score}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-semibold text-[var(--text-secondary)]">{row.risk_score}%</span>
+                </div>
+              </td>
+              <td className="py-2.5 pr-4">
+                <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${STATUS_STYLE[row.status] ?? 'bg-gray-100 text-gray-700'}`}>
+                  {row.status}
+                </span>
+              </td>
+              <td className="py-2.5 pr-4">
+                <div className="flex gap-1">
+                  <button
+                    disabled={row.status === 'Passed' || actionLoading === row.event_id}
+                    className="rounded-lg bg-green-100 px-2 py-1 text-xs font-semibold text-green-700 hover:bg-green-200 disabled:cursor-not-allowed disabled:opacity-40"
+                    onClick={() => onAction(row.event_id, 'Passed')}
+                  >
+                    통과
+                  </button>
+                  <button
+                    disabled={row.status === 'Blocked' || actionLoading === row.event_id}
+                    className="rounded-lg bg-red-100 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-200 disabled:cursor-not-allowed disabled:opacity-40"
+                    onClick={() => onAction(row.event_id, 'Blocked')}
+                  >
+                    차단
+                  </button>
+                </div>
+              </td>
+              <td className="py-2.5">
+                <button
+                  className="flex items-center gap-1 rounded-lg bg-[#ede9fe] px-2 py-1 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
+                  onClick={() => onAnalyze(row.event_id)}
+                >
+                  <Sparkles className="size-3" />
+                  분석
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default DetectionsTable;

--- a/src/pages/macro-dashboard/ui/components/IPAnalysisTab.tsx
+++ b/src/pages/macro-dashboard/ui/components/IPAnalysisTab.tsx
@@ -1,0 +1,78 @@
+import { Sparkles } from 'lucide-react';
+
+import type { IPSummaryItem } from '../../api/dashboardApi';
+import { toKST } from '../lib/dashboardFormat';
+
+type IPAnalysisTabProps = {
+  items: IPSummaryItem[];
+  onAnalyze: (ip: string) => void;
+};
+
+const IPAnalysisTab = ({ items, onAnalyze }: IPAnalysisTabProps) => {
+  if (items.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">
+        IP 데이터가 없습니다. 가드레일 차단 이벤트에 IP가 포함되면 여기에 표시됩니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-[var(--neutral-200)] text-xs font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
+            <th className="py-2 pr-4">IP 주소</th>
+            <th className="py-2 pr-4">탐지 건수</th>
+            <th className="py-2 pr-4">차단 건수</th>
+            <th className="py-2 pr-4">최대 Risk</th>
+            <th className="py-2 pr-4">탐지 유형</th>
+            <th className="py-2 pr-4">첫 탐지 (KST)</th>
+            <th className="py-2 pr-4">최근 탐지 (KST)</th>
+            <th className="py-2">AI 분석</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[var(--neutral-100)]">
+          {items.map((item) => (
+            <tr key={item.ip_address} className="hover:bg-[var(--neutral-50)]">
+              <td className="py-2.5 pr-4 font-mono text-xs font-semibold text-[var(--text-primary)]">
+                {item.ip_address}
+              </td>
+              <td className="py-2.5 pr-4 text-center text-[var(--text-secondary)]">{item.total_events}</td>
+              <td className="py-2.5 pr-4 text-center">
+                <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">
+                  {item.blocked_count}
+                </span>
+              </td>
+              <td className="py-2.5 pr-4">
+                <div className="flex items-center gap-2">
+                  <div className="h-1.5 w-14 overflow-hidden rounded-full bg-[var(--neutral-200)]">
+                    <div
+                      className={`h-full rounded-full ${item.max_risk >= 80 ? 'bg-red-500' : item.max_risk >= 50 ? 'bg-yellow-500' : 'bg-green-500'}`}
+                      style={{ width: `${item.max_risk}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-semibold text-[var(--text-secondary)]">{Math.round(item.max_risk)}%</span>
+                </div>
+              </td>
+              <td className="py-2.5 pr-4 text-xs text-[var(--text-secondary)]">{item.detection_types || '-'}</td>
+              <td className="py-2.5 pr-4 text-xs text-[var(--text-secondary)]">{toKST(item.first_seen)}</td>
+              <td className="py-2.5 pr-4 text-xs text-[var(--text-secondary)]">{toKST(item.last_seen)}</td>
+              <td className="py-2.5">
+                <button
+                  className="flex items-center gap-1 rounded-lg bg-[#ede9fe] px-2 py-1 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
+                  onClick={() => onAnalyze(item.ip_address)}
+                >
+                  <Sparkles className="size-3" />
+                  분석
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default IPAnalysisTab;

--- a/src/pages/macro-dashboard/ui/components/MouseSessionsTable.tsx
+++ b/src/pages/macro-dashboard/ui/components/MouseSessionsTable.tsx
@@ -1,0 +1,93 @@
+import { BarChart2, Sparkles } from 'lucide-react';
+
+import type { MouseMacroSessionRow } from '../../api/dashboardApi';
+import { toKST } from '../lib/dashboardFormat';
+
+type MouseSessionsTableProps = {
+  sessions: MouseMacroSessionRow[];
+  onAnalyze: (sessionId: string) => void;
+  onOpenTrajectory: (session: MouseMacroSessionRow) => void;
+};
+
+const MouseSessionsTable = ({
+  sessions,
+  onAnalyze,
+  onOpenTrajectory,
+}: MouseSessionsTableProps) => {
+  if (sessions.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-[var(--text-tertiary)]">
+        수신된 마우스 매크로 세션이 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-[var(--neutral-200)] text-xs font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
+            <th className="py-2 pr-4">Session ID</th>
+            <th className="py-2 pr-4">User ID</th>
+            <th className="py-2 pr-4">탐지 시각 (KST)</th>
+            <th className="py-2 pr-4">이벤트 수</th>
+            <th className="py-2 pr-4">매크로 확률</th>
+            <th className="py-2 pr-4">신뢰도</th>
+            <th className="py-2 pr-4">궤적</th>
+            <th className="py-2">AI 분석</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[var(--neutral-100)]">
+          {sessions.map((session) => (
+            <tr key={session.session_id} className="hover:bg-[var(--neutral-50)]">
+              <td className="py-2.5 pr-4 font-mono text-xs text-[var(--text-secondary)]">
+                {session.session_id.slice(0, 16)}
+              </td>
+              <td className="py-2.5 pr-4 text-[var(--text-secondary)]">{session.user_id || '-'}</td>
+              <td className="py-2.5 pr-4 text-[var(--text-secondary)]">{toKST(session.detected_at)}</td>
+              <td className="py-2.5 pr-4 text-[var(--text-secondary)]">{session.event_count.toLocaleString()}개</td>
+              <td className="py-2.5 pr-4">
+                <div className="flex items-center gap-2">
+                  <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--neutral-200)]">
+                    <div
+                      className="h-full rounded-full bg-[#6366f1]"
+                      style={{ width: `${Math.round(session.probability * 100)}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-semibold text-[var(--text-secondary)]">
+                    {(session.probability * 100).toFixed(1)}%
+                  </span>
+                </div>
+              </td>
+              <td className="py-2.5 pr-4">
+                <span className="text-xs font-medium text-[var(--text-secondary)]">
+                  {(session.confidence * 100).toFixed(1)}%
+                </span>
+              </td>
+              <td className="py-2.5 pr-4">
+                <button
+                  className="flex items-center gap-1 rounded-lg bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-600 hover:bg-blue-100"
+                  onClick={() => onOpenTrajectory(session)}
+                >
+                  <BarChart2 className="size-3" />
+                  궤적
+                </button>
+              </td>
+              <td className="py-2.5">
+                <button
+                  className="flex items-center gap-1 rounded-lg bg-[#ede9fe] px-2 py-1 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
+                  onClick={() => onAnalyze(session.session_id)}
+                >
+                  <Sparkles className="size-3" />
+                  분석
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default MouseSessionsTable;

--- a/src/pages/macro-dashboard/ui/components/MouseTrajectoryChart.tsx
+++ b/src/pages/macro-dashboard/ui/components/MouseTrajectoryChart.tsx
@@ -1,0 +1,154 @@
+import {
+  BarChart,
+  Bar,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { MouseEventItem } from '../../api/dashboardApi';
+import { EVENT_TYPE_META } from '../lib/dashboardConstants';
+
+type MouseTrajectoryChartProps = {
+  events: MouseEventItem[];
+};
+
+const MouseTrajectoryChart = ({ events }: MouseTrajectoryChartProps) => {
+  if (!events || events.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">
+        이벤트 데이터가 없습니다.
+      </p>
+    );
+  }
+
+  const grouped = [1, 2, 3, 4, 5]
+    .map((type) => ({
+      type,
+      meta: EVENT_TYPE_META[type],
+      data: events
+        .filter((event) => event.event_type === type)
+        .map((event) => ({ x: Math.round(event.screen_x), y: Math.round(event.screen_y) })),
+    }))
+    .filter((group) => group.data.length > 0);
+
+  const trajectory = [...events]
+    .filter((event) => event.event_type === 2)
+    .sort((left, right) => left.timestamp - right.timestamp)
+    .map((event) => ({ x: Math.round(event.screen_x), y: Math.round(event.screen_y) }));
+
+  const typeCounts = [1, 2, 3, 4, 5]
+    .map((type) => ({
+      name: EVENT_TYPE_META[type].label,
+      count: events.filter((event) => event.event_type === type).length,
+      fill: EVENT_TYPE_META[type].color,
+    }))
+    .filter((item) => item.count > 0);
+
+  const minTimestamp = Math.min(...events.map((event) => event.timestamp));
+  const bucketMs = 500;
+  const buckets: Record<number, number> = {};
+
+  events.forEach((event) => {
+    const bucket = Math.floor((event.timestamp - minTimestamp) / bucketMs);
+    buckets[bucket] = (buckets[bucket] ?? 0) + 1;
+  });
+
+  const densityData = Object.entries(buckets)
+    .sort(([left], [right]) => Number(left) - Number(right))
+    .map(([bucket, count]) => ({
+      t: `${((Number(bucket) * bucketMs) / 1000).toFixed(1)}s`,
+      count,
+    }));
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="mb-2 text-xs font-semibold text-[var(--text-secondary)]">마우스 궤적 (화면 좌표)</p>
+        <ResponsiveContainer width="100%" height={300}>
+          <ScatterChart margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+            <XAxis
+              type="number"
+              dataKey="x"
+              name="X"
+              tick={{ fontSize: 10 }}
+              label={{ value: 'screen_x', position: 'insideBottom', offset: -4, fontSize: 10 }}
+            />
+            <YAxis
+              type="number"
+              dataKey="y"
+              name="Y"
+              reversed
+              tick={{ fontSize: 10 }}
+              label={{ value: 'screen_y', angle: -90, position: 'insideLeft', fontSize: 10 }}
+            />
+            <Tooltip
+              cursor={{ strokeDasharray: '3 3' }}
+              contentStyle={{ fontSize: 11, borderRadius: 8 }}
+              formatter={(value, name) => [value, name === 'x' ? 'X' : 'Y']}
+            />
+            <Legend iconType="circle" iconSize={8} wrapperStyle={{ fontSize: 11 }} />
+            {trajectory.length > 1 && (
+              <Scatter
+                name="이동경로"
+                data={trajectory}
+                line={{ stroke: '#6366f1', strokeWidth: 1, strokeOpacity: 0.3 }}
+                lineType="joint"
+                fill="transparent"
+                legendType="none"
+              />
+            )}
+            {grouped.map((group) => (
+              <Scatter
+                key={group.type}
+                name={group.meta.label}
+                data={group.data}
+                fill={group.meta.color}
+                opacity={0.8}
+              />
+            ))}
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <p className="mb-2 text-xs font-semibold text-[var(--text-secondary)]">이벤트 타입 분포</p>
+          <ResponsiveContainer width="100%" height={140}>
+            <BarChart data={typeCounts} layout="vertical" margin={{ left: 8 }}>
+              <XAxis type="number" tick={{ fontSize: 10 }} />
+              <YAxis type="category" dataKey="name" width={50} tick={{ fontSize: 10 }} />
+              <Tooltip contentStyle={{ fontSize: 11, borderRadius: 8 }} formatter={(value) => [`${value}회`]} />
+              <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+                {typeCounts.map((item, index) => (
+                  <Cell key={index} fill={item.fill} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div>
+          <p className="mb-2 text-xs font-semibold text-[var(--text-secondary)]">시간대별 이벤트 밀도 (0.5s)</p>
+          <ResponsiveContainer width="100%" height={140}>
+            <LineChart data={densityData} margin={{ left: 0, right: 8 }}>
+              <XAxis dataKey="t" tick={{ fontSize: 9 }} interval="preserveStartEnd" />
+              <YAxis tick={{ fontSize: 10 }} />
+              <Tooltip contentStyle={{ fontSize: 11, borderRadius: 8 }} formatter={(value) => [`${value}회`]} />
+              <Line type="monotone" dataKey="count" stroke="#6366f1" strokeWidth={1.5} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MouseTrajectoryChart;

--- a/src/pages/macro-dashboard/ui/components/ReviewTab.tsx
+++ b/src/pages/macro-dashboard/ui/components/ReviewTab.tsx
@@ -1,0 +1,229 @@
+import { useState } from 'react';
+import { Ban, CheckCircle2, Globe, Sparkles } from 'lucide-react';
+
+import type { BlockedEventRow, MouseMacroSessionRow } from '../../api/dashboardApi';
+import { STATUS_STYLE } from '../lib/dashboardConstants';
+import { toKST } from '../lib/dashboardFormat';
+import type { ReviewRow, ReviewSource } from '../types';
+
+type ReviewTabProps = {
+  detections: BlockedEventRow[];
+  mouseSessions: MouseMacroSessionRow[];
+  onAnalyze: (row: ReviewRow) => void;
+  onAction: (id: string, action: 'Blocked' | 'Passed') => void;
+  actionLoading: string | null;
+};
+
+const ReviewTab = ({
+  detections,
+  mouseSessions,
+  onAnalyze,
+  onAction,
+  actionLoading,
+}: ReviewTabProps) => {
+  const [sourceFilter, setSourceFilter] = useState<'all' | ReviewSource>('all');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'Blocked' | 'Passed' | 'Pending'>('all');
+  const [blockedIps, setBlockedIps] = useState<Set<string>>(new Set());
+
+  const rows: ReviewRow[] = [
+    ...detections.map((event) => ({
+      id: event.event_id,
+      source: 'guardrail' as const,
+      userId: event.user_id || '-',
+      ipAddress: event.ip_address || '-',
+      riskScore: event.risk_score,
+      reasons: event.reason_codes?.join(', ') || event.detection_type || '-',
+      status: event.status,
+      detectedAt: event.blocked_at,
+    })),
+    ...mouseSessions.map((session) => ({
+      id: session.session_id,
+      source: 'mouse' as const,
+      userId: session.user_id || '-',
+      ipAddress: '-',
+      riskScore: Math.round(session.probability * 100),
+      reasons: `Mouse Macro (확률 ${(session.probability * 100).toFixed(1)}%, 신뢰도 ${(session.confidence * 100).toFixed(1)}%)`,
+      status: 'Blocked',
+      detectedAt: session.detected_at,
+    })),
+  ].sort((left, right) => right.detectedAt.localeCompare(left.detectedAt));
+
+  const filteredRows = rows.filter((row) => {
+    if (sourceFilter !== 'all' && row.source !== sourceFilter) return false;
+    if (statusFilter !== 'all' && row.status !== statusFilter) return false;
+    return true;
+  });
+
+  const handleMockBlockIp = (ipAddress: string) => {
+    if (ipAddress === '-') return;
+    setBlockedIps((prev) => new Set([...prev, ipAddress]));
+  };
+
+  if (rows.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-[var(--text-tertiary)]">
+        심사할 탐지 이벤트가 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-3">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-[var(--text-tertiary)]">출처</span>
+          {(['all', 'guardrail', 'mouse'] as const).map((value) => (
+            <button
+              key={value}
+              onClick={() => setSourceFilter(value)}
+              className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
+                sourceFilter === value
+                  ? 'bg-[var(--primary-normal)] text-white'
+                  : 'bg-[var(--neutral-100)] text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]'
+              }`}
+            >
+              {value === 'all' ? '전체' : value === 'guardrail' ? '가드레일' : '마우스 매크로'}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-[var(--text-tertiary)]">상태</span>
+          {(['all', 'Blocked', 'Passed', 'Pending'] as const).map((value) => (
+            <button
+              key={value}
+              onClick={() => setStatusFilter(value)}
+              className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
+                statusFilter === value
+                  ? 'bg-[var(--primary-normal)] text-white'
+                  : 'bg-[var(--neutral-100)] text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]'
+              }`}
+            >
+              {value === 'all' ? '전체' : value}
+            </button>
+          ))}
+        </div>
+        <span className="ml-auto text-xs text-[var(--text-tertiary)]">
+          {filteredRows.length}건 표시 / 전체 {rows.length}건
+        </span>
+      </div>
+
+      <div className="space-y-3">
+        {filteredRows.map((row) => {
+          const isIpBlocked = row.ipAddress !== '-' && blockedIps.has(row.ipAddress);
+
+          return (
+            <div
+              key={row.id}
+              className={`rounded-xl border p-4 transition-colors ${
+                row.riskScore >= 80
+                  ? 'border-red-200 bg-red-50/40'
+                  : row.riskScore >= 50
+                    ? 'border-orange-200 bg-orange-50/40'
+                    : 'border-[var(--neutral-200)] bg-white'
+              }`}
+            >
+              <div className="grid grid-cols-3 gap-4 text-sm">
+                <div>
+                  <p className="mb-1 text-xs font-semibold text-[var(--text-tertiary)]">이벤트</p>
+                  <p className="font-mono text-xs text-[var(--text-primary)]">{row.id.slice(0, 20)}</p>
+                  <p className="mt-0.5">
+                    <span
+                      className={`inline-block rounded-full px-2 py-0.5 text-xs font-semibold ${
+                        row.source === 'guardrail' ? 'bg-purple-100 text-purple-700' : 'bg-blue-100 text-blue-700'
+                      }`}
+                    >
+                      {row.source === 'guardrail' ? '가드레일' : '마우스 매크로'}
+                    </span>
+                  </p>
+                </div>
+                <div>
+                  <p className="mb-1 text-xs font-semibold text-[var(--text-tertiary)]">사용자 / IP</p>
+                  <p className="text-xs text-[var(--text-primary)]">User: {row.userId}</p>
+                  <p className="mt-0.5 flex items-center gap-1 font-mono text-xs text-[var(--text-secondary)]">
+                    <Globe className="size-3" />
+                    {row.ipAddress}
+                    {isIpBlocked && (
+                      <span className="ml-1 rounded-full bg-red-600 px-1.5 py-0.5 text-[10px] font-bold text-white">
+                        차단됨
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <div>
+                  <p className="mb-1 text-xs font-semibold text-[var(--text-tertiary)]">위험도 / 시각</p>
+                  <div className="mb-0.5 flex items-center gap-2">
+                    <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--neutral-200)]">
+                      <div
+                        className={`h-full rounded-full ${row.riskScore >= 80 ? 'bg-red-500' : row.riskScore >= 50 ? 'bg-yellow-500' : 'bg-green-500'}`}
+                        style={{ width: `${row.riskScore}%` }}
+                      />
+                    </div>
+                    <span className="text-xs font-semibold text-[var(--text-secondary)]">{row.riskScore}%</span>
+                  </div>
+                  <p className="text-xs text-[var(--text-secondary)]">{toKST(row.detectedAt)}</p>
+                </div>
+              </div>
+
+              <p className="mt-2 rounded-lg bg-[var(--neutral-50)] px-3 py-2 text-xs text-[var(--text-tertiary)]">
+                탐지 사유: {row.reasons}
+              </p>
+
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <button
+                  className="flex items-center gap-1.5 rounded-lg bg-[#ede9fe] px-3 py-1.5 text-xs font-semibold text-[#6366f1] hover:bg-[#ddd6fe]"
+                  onClick={() => onAnalyze(row)}
+                >
+                  <Sparkles className="size-3" />
+                  AI 심사 의견
+                </button>
+
+                {row.source === 'guardrail' && (
+                  <>
+                    <button
+                      disabled={row.status === 'Passed' || actionLoading === row.id}
+                      className="flex items-center gap-1.5 rounded-lg bg-green-100 px-3 py-1.5 text-xs font-semibold text-green-700 hover:bg-green-200 disabled:cursor-not-allowed disabled:opacity-40"
+                      onClick={() => onAction(row.id, 'Passed')}
+                    >
+                      <CheckCircle2 className="size-3" />
+                      통과
+                    </button>
+                    <button
+                      disabled={row.status === 'Blocked' || actionLoading === row.id}
+                      className="flex items-center gap-1.5 rounded-lg bg-red-100 px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-200 disabled:cursor-not-allowed disabled:opacity-40"
+                      onClick={() => onAction(row.id, 'Blocked')}
+                    >
+                      <Ban className="size-3" />
+                      차단
+                    </button>
+                  </>
+                )}
+
+                {row.ipAddress !== '-' && (
+                  <button
+                    className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors ${
+                      isIpBlocked
+                        ? 'cursor-not-allowed bg-gray-100 text-gray-400'
+                        : 'bg-orange-100 text-orange-700 hover:bg-orange-200'
+                    }`}
+                    onClick={() => !isIpBlocked && handleMockBlockIp(row.ipAddress)}
+                    disabled={isIpBlocked}
+                    title="시뮬레이션 — 실제 네트워크 차단은 적용되지 않습니다"
+                  >
+                    <Globe className="size-3" />
+                    {isIpBlocked ? 'IP 차단됨' : 'IP 차단 (모의)'}
+                  </button>
+                )}
+
+                <span className={`ml-auto rounded-full px-2 py-0.5 text-xs font-semibold ${STATUS_STYLE[row.status] ?? 'bg-gray-100 text-gray-700'}`}>
+                  {row.status}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ReviewTab;

--- a/src/pages/macro-dashboard/ui/components/StatCard.tsx
+++ b/src/pages/macro-dashboard/ui/components/StatCard.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+type StatCardProps = {
+  label: string;
+  value: number | string;
+  unit?: string;
+  delta?: string;
+  icon: ReactNode;
+};
+
+const StatCard = ({ label, value, unit, delta, icon }: StatCardProps) => {
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl border border-[var(--neutral-200)] bg-white p-5 shadow-sm">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-[var(--text-tertiary)]">{label}</span>
+        <span className="text-[var(--text-tertiary)]">{icon}</span>
+      </div>
+      <div className="flex items-end gap-1">
+        <span className="text-3xl font-bold tracking-tight text-[var(--text-primary)]">
+          {typeof value === 'number' ? value.toLocaleString() : value}
+        </span>
+        {unit && <span className="mb-0.5 text-sm text-[var(--text-tertiary)]">{unit}</span>}
+      </div>
+      {delta && <span className="text-xs font-medium text-[var(--text-tertiary)]">{delta}</span>}
+    </div>
+  );
+};
+
+export default StatCard;

--- a/src/pages/macro-dashboard/ui/components/TrajectoryModal.tsx
+++ b/src/pages/macro-dashboard/ui/components/TrajectoryModal.tsx
@@ -1,0 +1,54 @@
+import { BarChart2, X } from 'lucide-react';
+
+import type { MouseMacroSessionRow } from '../../api/dashboardApi';
+import { toKST } from '../lib/dashboardFormat';
+import MouseTrajectoryChart from './MouseTrajectoryChart';
+
+type TrajectoryModalProps = {
+  session: MouseMacroSessionRow;
+  onClose: () => void;
+};
+
+const TrajectoryModal = ({ session, onClose }: TrajectoryModalProps) => {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-3xl rounded-2xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-[var(--neutral-200)] px-6 py-4">
+          <div className="flex items-center gap-2">
+            <BarChart2 className="size-5 text-[#6366f1]" />
+            <div>
+              <h2 className="text-base font-semibold text-[var(--text-primary)]">마우스 궤적 분석</h2>
+              <p className="text-xs text-[var(--text-tertiary)]">
+                {session.session_id.slice(0, 20)} · 확률 {(session.probability * 100).toFixed(1)}% · {toKST(session.detected_at)}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-[var(--text-tertiary)] hover:bg-[var(--neutral-100)]"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="px-6 py-5">
+          <MouseTrajectoryChart events={session.events ?? []} />
+        </div>
+
+        <div className="flex items-center justify-between border-t border-[var(--neutral-200)] px-6 py-3">
+          <p className="text-xs text-[var(--text-tertiary)]">
+            총 {session.event_count.toLocaleString()}개 이벤트 · 신뢰도 {(session.confidence * 100).toFixed(1)}%
+          </p>
+          <button
+            onClick={onClose}
+            className="rounded-xl bg-[var(--neutral-100)] px-4 py-2 text-sm font-semibold text-[var(--text-secondary)] hover:bg-[var(--neutral-200)]"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TrajectoryModal;

--- a/src/pages/macro-dashboard/ui/lib/dashboardConstants.ts
+++ b/src/pages/macro-dashboard/ui/lib/dashboardConstants.ts
@@ -1,0 +1,29 @@
+export const REFETCH_MS = 15_000;
+
+export const STATUS_STYLE: Record<string, string> = {
+  Blocked: 'bg-red-100 text-red-700',
+  Passed: 'bg-green-100 text-green-700',
+  Pending: 'bg-yellow-100 text-yellow-700',
+};
+
+export const SEVERITY_STYLE: Record<string, string> = {
+  critical: 'border-red-500 bg-red-50',
+  high: 'border-orange-400 bg-orange-50',
+  medium: 'border-yellow-400 bg-yellow-50',
+};
+
+export const SEVERITY_ICON_CLASS: Record<string, string> = {
+  critical: 'text-red-600',
+  high: 'text-orange-500',
+  medium: 'text-yellow-500',
+};
+
+export const CHART_COLORS = ['#6366f1', '#14b8a6', '#f59e0b', '#ef4444'];
+
+export const EVENT_TYPE_META: Record<number, { label: string; color: string }> = {
+  1: { label: '릴리즈', color: '#94a3b8' },
+  2: { label: '이동', color: '#6366f1' },
+  3: { label: '휠', color: '#14b8a6' },
+  4: { label: '드래그', color: '#f59e0b' },
+  5: { label: '클릭', color: '#ef4444' },
+};

--- a/src/pages/macro-dashboard/ui/lib/dashboardFormat.ts
+++ b/src/pages/macro-dashboard/ui/lib/dashboardFormat.ts
@@ -1,0 +1,32 @@
+export function toKST(utcStr: string): string {
+  if (!utcStr) return '-';
+
+  try {
+    return new Date(utcStr).toLocaleString('ko-KR', {
+      timeZone: 'Asia/Seoul',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+  } catch {
+    return utcStr.slice(0, 19).replace('T', ' ');
+  }
+}
+
+export function formatDashboardUpdateTime(timestamp: number): string {
+  if (!timestamp) {
+    return '-';
+  }
+
+  return new Date(timestamp).toLocaleTimeString('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}

--- a/src/pages/macro-dashboard/ui/types.ts
+++ b/src/pages/macro-dashboard/ui/types.ts
@@ -1,0 +1,14 @@
+export type ReviewSource = 'guardrail' | 'mouse';
+
+export type DashboardTabKey = 'guardrail' | 'mouse' | 'ip' | 'review';
+
+export interface ReviewRow {
+  id: string;
+  source: ReviewSource;
+  userId: string;
+  ipAddress: string;
+  riskScore: number;
+  reasons: string;
+  status: string;
+  detectedAt: string;
+}

--- a/src/shared/config/oauth.ts
+++ b/src/shared/config/oauth.ts
@@ -25,8 +25,7 @@ export const NAVER_REDIRECT_URI = resolveRedirectUri(
 export const GOOGLE_CLIENT_ID = import.meta.env.PUBLIC_GOOGLE_CLIENT_ID as
   | string
   | undefined;
-export const GOOGLE_REDIRECT_URI = resolveRedirectUri(
-  import.meta.env.PUBLIC_GOOGLE_REDIRECT_URI as string | undefined,
-  '/auth/google/callback',
-);
-export const GOOGLE_SCOPES = ["openid"];
+export const GOOGLE_REDIRECT_URI = import.meta.env.PUBLIC_GOOGLE_REDIRECT_URI as
+  | string
+  | undefined;
+export const GOOGLE_SCOPES = ["openid", "email", "profile"];

--- a/src/shared/lib/useMouseEventTracker.ts
+++ b/src/shared/lib/useMouseEventTracker.ts
@@ -19,8 +19,8 @@ export interface MacroPredictResult {
    event_count: number;
 }
 
-const ML_SERVER_URL = (import.meta.env.PUBLIC_MOUSE_ML_URL ?? '').trim() || 'http://localhost:8000';
-const SEND_INTERVAL_MS = 10_000;
+const ML_PREDICT_URL = '/api/v1/mouse/predict';
+const SEND_INTERVAL_MS = 20_000;
 const isDev = import.meta.env.DEV;
 
 interface TrackedMouseEvent {
@@ -43,10 +43,10 @@ function generateSessionId(): string {
 async function postPredict(body: PredictRequest): Promise<MacroPredictResult | null> {
    try {
       if (isDev) {
-         console.log(`[MouseTracker] POST ${ML_SERVER_URL}/predict | events: ${body.events.length} | session: ${body.session_id}`);
+         console.log(`[MouseTracker] POST ${ML_PREDICT_URL} | events: ${body.events.length} | session: ${body.session_id}`);
       }
 
-      const response = await fetch(`${ML_SERVER_URL}/predict`, {
+      const response = await fetch(ML_PREDICT_URL, {
          method: 'POST',
          headers: { 'Content-Type': 'application/json' },
          body: JSON.stringify(body),

--- a/src/shared/lib/useMouseEventTracker.ts
+++ b/src/shared/lib/useMouseEventTracker.ts
@@ -1,0 +1,142 @@
+/**
+ * 마우스 이벤트를 10초 단위로 수집하여 매크로 탐지 ML 서버(/predict)로 주기적으로 전송하는 훅.
+ *
+ * event_type 매핑:
+ *   1 = mouseup (release)
+ *   2 = mousemove (move)
+ *   3 = wheel
+ *   4 = mousemove (drag — 버튼 누른 채 이동)
+ *   5 = click
+ */
+
+import { useEffect, useRef } from 'react';
+
+export interface MacroPredictResult {
+   session_id: string;
+   is_macro: boolean;
+   probability: number;
+   confidence: number;
+   event_count: number;
+}
+
+const ML_SERVER_URL = (import.meta.env.PUBLIC_MOUSE_ML_URL ?? '').trim() || 'http://localhost:8000';
+const SEND_INTERVAL_MS = 10_000;
+const isDev = import.meta.env.DEV;
+
+interface TrackedMouseEvent {
+   timestamp: number;
+   event_type: number;
+   screen_x: number;
+   screen_y: number;
+}
+
+interface PredictRequest {
+   session_id: string;
+   user_id?: string;
+   events: TrackedMouseEvent[];
+}
+
+function generateSessionId(): string {
+   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+async function postPredict(body: PredictRequest): Promise<MacroPredictResult | null> {
+   try {
+      if (isDev) {
+         console.log(`[MouseTracker] POST ${ML_SERVER_URL}/predict | events: ${body.events.length} | session: ${body.session_id}`);
+      }
+
+      const response = await fetch(`${ML_SERVER_URL}/predict`, {
+         method: 'POST',
+         headers: { 'Content-Type': 'application/json' },
+         body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+         if (isDev) console.warn('[MouseTracker] 응답 오류:', response.status);
+         return null;
+      }
+
+      const result = (await response.json()) as MacroPredictResult;
+      if (isDev) console.log('[MouseTracker] 결과:', result);
+      return result;
+   } catch (err) {
+      if (isDev) console.warn('[MouseTracker] 전송 실패 (서버 미실행?):', err);
+      return null;
+   }
+}
+
+type UseMouseEventTrackerOptions = {
+   userId?: string;
+   onMacroDetected?: (result: MacroPredictResult) => void;
+};
+
+export function useMouseEventTracker({ userId, onMacroDetected }: UseMouseEventTrackerOptions = {}) {
+   const eventsRef = useRef<TrackedMouseEvent[]>([]);
+   const sessionIdRef = useRef<string>(generateSessionId());
+   const isDraggingRef = useRef(false);
+   const userIdRef = useRef(userId);
+   userIdRef.current = userId;
+   const onMacroDetectedRef = useRef(onMacroDetected);
+   onMacroDetectedRef.current = onMacroDetected;
+
+   useEffect(() => {
+      if (isDev) console.log('[MouseTracker] 수집 시작 | session:', sessionIdRef.current);
+
+      const push = (evt: TrackedMouseEvent) => {
+         eventsRef.current.push(evt);
+      };
+
+      const onMouseMove = (e: MouseEvent) => {
+         push({ timestamp: Date.now(), event_type: isDraggingRef.current ? 4 : 2, screen_x: e.screenX, screen_y: e.screenY });
+      };
+      const onMouseDown = () => { isDraggingRef.current = true; };
+      const onMouseUp = (e: MouseEvent) => {
+         isDraggingRef.current = false;
+         push({ timestamp: Date.now(), event_type: 1, screen_x: e.screenX, screen_y: e.screenY });
+      };
+      const onWheel = (e: WheelEvent) => {
+         push({ timestamp: Date.now(), event_type: 3, screen_x: e.screenX, screen_y: e.screenY });
+      };
+      const onClick = (e: MouseEvent) => {
+         push({ timestamp: Date.now(), event_type: 5, screen_x: e.screenX, screen_y: e.screenY });
+      };
+
+      window.addEventListener('mousemove', onMouseMove);
+      window.addEventListener('mousedown', onMouseDown);
+      window.addEventListener('mouseup', onMouseUp);
+      window.addEventListener('wheel', onWheel, { passive: true });
+      window.addEventListener('click', onClick);
+
+      const timer = setInterval(async () => {
+         const events = eventsRef.current.splice(0);
+
+         if (isDev) console.log('[MouseTracker] 10초 경과 | 수집된 이벤트:', events.length);
+
+         if (events.length < 10) {
+            if (isDev) console.warn('[MouseTracker] 이벤트 부족 (최소 10개) — 전송 생략');
+            return;
+         }
+
+         const result = await postPredict({
+            session_id: sessionIdRef.current,
+            user_id: userIdRef.current,
+            events,
+         });
+
+         if (result?.is_macro) {
+            onMacroDetectedRef.current?.(result);
+         }
+      }, SEND_INTERVAL_MS);
+
+      return () => {
+         if (isDev) console.log('[MouseTracker] 수집 종료');
+         window.removeEventListener('mousemove', onMouseMove);
+         window.removeEventListener('mousedown', onMouseDown);
+         window.removeEventListener('mouseup', onMouseUp);
+         window.removeEventListener('wheel', onWheel);
+         window.removeEventListener('click', onClick);
+         clearInterval(timer);
+      };
+   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+}

--- a/src/shared/lib/useMouseEventTracker.ts
+++ b/src/shared/lib/useMouseEventTracker.ts
@@ -109,7 +109,7 @@ export function useMouseEventTracker({ userId, onMacroDetected }: UseMouseEventT
       window.addEventListener('click', onClick);
 
       const timer = setInterval(async () => {
-         const events = eventsRef.current.splice(0);
+         const events = eventsRef.current.slice();
 
          if (isDev) console.log('[MouseTracker] 10초 경과 | 수집된 이벤트:', events.length);
 
@@ -123,6 +123,12 @@ export function useMouseEventTracker({ userId, onMacroDetected }: UseMouseEventT
             user_id: userIdRef.current,
             events,
          });
+
+         if (!result) {
+            return;
+         }
+
+         eventsRef.current.splice(0, events.length);
 
          if (result?.is_macro) {
             onMacroDetectedRef.current?.(result);

--- a/src/shared/widgets/layout/books/BooksLayout.tsx
+++ b/src/shared/widgets/layout/books/BooksLayout.tsx
@@ -1,9 +1,41 @@
-import { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+
+import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
+import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
+import { releaseQueueSession } from '@/pages/queue/api/queueApi';
+import { useBookingEntryStore } from '@/shared/lib/useBookingEntryStore';
+import { useBookingFlowTimerStore } from '@/shared/lib/useBookingFlowTimerStore';
+import { useMouseEventTracker } from '@/shared/lib/useMouseEventTracker';
 
 import BooksHeader from './BooksHeader';
 
 const BooksLayout = () => {
+   const navigate = useNavigate();
+   const bookingEntry = useBookingEntryStore(state => state.entry);
+   const clearEntry = useBookingEntryStore(state => state.clearEntry);
+   const clearTimer = useBookingFlowTimerStore(state => state.clearTimer);
+   const clearSeatHolds = useSeatHoldStore(state => state.clearSeatHolds);
+   const clearAllSelections = useSeatSelectionStore(state => state.clearAllSelections);
+
+   const exitRef = useRef<() => void>(() => {});
+   exitRef.current = () => {
+      clearTimer();
+      clearSeatHolds();
+      clearAllSelections();
+      void releaseQueueSession(bookingEntry?.gameId);
+      clearEntry();
+      navigate('/', { replace: true });
+   };
+
+   useMouseEventTracker({
+      userId: bookingEntry?.userId,
+      onMacroDetected: () => {
+         window.alert('매크로 사용이 감지되었습니다. 예매에 접근할 수 없습니다.');
+         exitRef.current();
+      },
+   });
+
    useEffect(() => {
       const handleWheel = (event: WheelEvent) => {
          if (event.ctrlKey || event.metaKey) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #366

  <br/>

  ## 🔎 개요

  마우스 트래킹 AI 판단 로직의 전송 실패 시 이벤트 유실 문제를 보완하고, 매크로 대시보드 페이지의 UI 책임을 컴포넌트/유틸 단위로 분리해 유지보수성을 개선했습니다.

  <br/>

  ## 📋 작업 내용

  - `src/shared/lib/useMouseEventTracker.ts`
    - 전송 전에 이벤트 버퍼를 즉시 비우지 않도록 수정했습니다.
    - ML 서버 요청이 실패하면 기존 이벤트를 유지하고, 성공 응답을 받은 경우에만 전송한 구간만큼 버퍼를 제거하도록 변경했습니다.
    - 이를 통해 일시적인 서버 오류나 네트워크 실패 시 마우스 이벤트 유실이 발생하지 않도록 보완했습니다.

  - `src/pages/macro-dashboard/ui/MacroDashboardPage.tsx`
    - 데이터 조회, 탭 상태 관리, 분석 요청 연결만 담당하도록 메인 페이지 책임을 축소했습니다.
    - 기존 1개 파일에 몰려 있던 표/차트/모달/카드 렌더링 로직을 별도 컴포넌트로 분리했습니다.

  - `src/pages/macro-dashboard/ui/components/*`
    - `AlertBanner`, `AlertList`, `StatCard`
    - `DetectionsTable`, `MouseSessionsTable`, `IPAnalysisTab`, `ReviewTab`
    - `MouseTrajectoryChart`, `DashboardCharts`
    - `AnalysisModal`, `TrajectoryModal`
    - 각 UI 블록을 독립 컴포넌트로 분리해 관심사를 명확히 했습니다.

  - `src/pages/macro-dashboard/ui/lib/*`, `src/pages/macro-dashboard/ui/types.ts`
    - 대시보드 전용 상수, 시간 포맷 유틸, 심사 탭 타입을 별도 파일로 분리했습니다.
    - 페이지와 하위 컴포넌트가 공통 로직을 중복 없이 참조할 수 있도록 정리했습니다.