### PR TITLE
[refactor] 마이페이지 예매 취소 payload 및 QR 발급 API 연결 정리

### DIFF
--- a/src/pages/mypage/model/purchaseDetailTypes.ts
+++ b/src/pages/mypage/model/purchaseDetailTypes.ts
@@ -6,6 +6,7 @@ export type PaymentEventType = '결제 완료';
 
 export type PurchaseSeatItem = {
    ticketId: string;
+   orderItemId?: string;
    orderId: string;
    section: string;
    seatDetail: string;

--- a/src/pages/mypage/ui/CancelConfirmDialog.tsx
+++ b/src/pages/mypage/ui/CancelConfirmDialog.tsx
@@ -46,12 +46,16 @@ export default function CancelConfirmDialog({
    const navigate = useNavigate();
    const queryClient = useQueryClient();
    const [isLoading, setIsLoading] = useState(false);
+   const isFullSeatSelection = ticketCount === totalSeatCount;
+   const hasPartialOrderItemIds = selectedOrderItemIds.length > 0 && !isFullSeatSelection;
+   const requestType = hasPartialOrderItemIds ? 'ORDER_PARTIAL' : 'ORDER_FULL';
+   const orderItemIds = hasPartialOrderItemIds ? selectedOrderItemIds : undefined;
 
    const { mutate: cancel } = useMutation({
       mutationFn: () =>
          cancelOrder(orderId, {
-            requestType: selectedOrderItemIds.length === totalSeatCount ? 'ORDER_FULL' : 'ORDER_PARTIAL',
-            orderItemIds: selectedOrderItemIds.length === totalSeatCount ? undefined : selectedOrderItemIds,
+            requestType,
+            orderItemIds,
          }),
       onSuccess: () => {
          selectedTicketIds.forEach((ticketId) => {

--- a/src/pages/mypage/ui/PurchaseDetailDialogs.tsx
+++ b/src/pages/mypage/ui/PurchaseDetailDialogs.tsx
@@ -23,7 +23,15 @@ interface PurchaseDetailDialogsProps {
       paymentMethodDisplay?: string;
       canSell: boolean;
       paymentSummary: { fee: number };
-      seatItems: Array<{ ticketId: string; orderId: string; section: string; seatDetail: string; status: string; price: number }>;
+      seatItems: Array<{
+         ticketId: string;
+         orderItemId?: string;
+         orderId: string;
+         section: string;
+         seatDetail: string;
+         status: string;
+         price: number;
+      }>;
    };
    isBankTransfer: boolean;
    qrOpen: boolean;
@@ -62,6 +70,7 @@ export function PurchaseDetailDialogs({
                paymentMethod={detail.paymentMethodDisplay}
                seats={activeSeatItems.map((seat) => ({
                   orderId: seat.orderId,
+                  orderItemId: seat.orderItemId,
                   ticketId: seat.ticketId,
                   section: seat.section,
                   seatDetail: seat.seatDetail,

--- a/src/pages/mypage/ui/PurchaseDetailPage.tsx
+++ b/src/pages/mypage/ui/PurchaseDetailPage.tsx
@@ -336,6 +336,7 @@ export default function PurchaseDetailPage() {
       const seatItems: PurchaseSeatItem[] = [
          {
             ticketId: currentApiDetail.ticketId,
+            orderItemId: currentApiDetail.orderItemId,
             orderId: formatTicketNumber(
                currentApiDetail.ticketNumber,
                currentApiDetail.ticketStatus === 'RESALE_ISSUED'

--- a/src/pages/mypage/ui/QrViewDialog.tsx
+++ b/src/pages/mypage/ui/QrViewDialog.tsx
@@ -1,12 +1,14 @@
 // src/pages/mypage/ui/QrViewDialog.tsx
 
 import { useState, useEffect, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { QRCodeCanvas } from '@rc-component/qrcode';
 import { ChevronLeft, ChevronRight, RefreshCcw, Clock } from 'lucide-react';
+import { fetchTicketQr } from '@/entities/ticket/api/ticketApi';
 import { Button } from '@/shared/ui/button';
 import { Dialog, DialogContent, DialogClose } from '@/shared/ui/dialog';
 
 const QR_DURATION = 180; // 3분
-const QR_IMAGE_SRC = '/images/QR%EC%BD%94%EB%93%9C.png';
 
 export interface QrSeat {
    ticketId?: string;
@@ -39,14 +41,26 @@ export default function QrViewDialog({
 }: QrViewDialogProps) {
    const [currentIndex, setCurrentIndex] = useState(0);
    const [timeLeft, setTimeLeft] = useState(QR_DURATION);
+   const [refreshNonce, setRefreshNonce] = useState(0);
 
    const currentSeat = seats[currentIndex];
+   const qrQuery = useQuery({
+      queryKey: ['ticketQr', currentSeat?.ticketId, refreshNonce],
+      queryFn: () => fetchTicketQr(currentSeat!.ticketId!),
+      enabled: open && Boolean(currentSeat?.ticketId),
+      retry: false,
+      staleTime: 0,
+   });
+   const effectiveLoading = isTicketInfoLoading || (Boolean(currentSeat?.ticketId) && qrQuery.isLoading);
+   const effectiveError = isTicketInfoError || (Boolean(currentSeat?.ticketId) && qrQuery.isError);
+   const qrValue = qrQuery.data?.qrToken;
 
    // 팝업 열릴 때 초기화
    useEffect(() => {
       if (!open) return;
       setCurrentIndex(0);
       setTimeLeft(QR_DURATION);
+      setRefreshNonce(0);
    }, [open]);
 
    // 카운트다운 타이머
@@ -62,11 +76,12 @@ export default function QrViewDialog({
 
    const handleRefresh = useCallback(() => {
       setTimeLeft(QR_DURATION);
+      setRefreshNonce(prev => prev + 1);
    }, []);
 
    const renderStatusContent = () => {
       switch (true as boolean) {
-         case isTicketInfoLoading:
+         case effectiveLoading:
             return (
                <div className="flex flex-col items-center gap-4 px-5 pt-7.5 pb-5 text-center">
                   <p className="text-[18px] font-bold text-[#161d24] leading-[1.55]">QR 확인</p>
@@ -76,7 +91,7 @@ export default function QrViewDialog({
                   </Button>
                </div>
             );
-         case isTicketInfoError:
+         case effectiveError:
             return (
                <div className="flex flex-col items-center gap-4 px-5 pt-7.5 pb-5 text-center">
                   <p className="text-[18px] font-bold text-[#161d24] leading-[1.55]">QR 확인</p>
@@ -87,7 +102,14 @@ export default function QrViewDialog({
                      <Button variant="tertiary" className="flex-1 py-1.5" onClick={onClose}>
                         닫기
                      </Button>
-                     <Button variant="primary" className="flex-1 py-1.5" onClick={onRetryTicketInfo}>
+                     <Button
+                        variant="primary"
+                        className="flex-1 py-1.5"
+                        onClick={() => {
+                           onRetryTicketInfo?.();
+                           void qrQuery.refetch();
+                        }}
+                     >
                         다시 시도
                      </Button>
                   </div>
@@ -98,6 +120,16 @@ export default function QrViewDialog({
                <div className="flex flex-col items-center gap-4 px-5 pt-7.5 pb-5 text-center">
                   <p className="text-[18px] font-bold text-[#161d24] leading-[1.55]">QR 확인</p>
                   <p className="text-[16px] text-[#374553]">표시할 티켓이 없습니다.</p>
+                  <Button variant="primary" className="w-full py-1.5" onClick={onClose}>
+                     닫기
+                  </Button>
+               </div>
+            );
+         case !currentSeat.ticketId:
+            return (
+               <div className="flex flex-col items-center gap-4 px-5 pt-7.5 pb-5 text-center">
+                  <p className="text-[18px] font-bold text-[#161d24] leading-[1.55]">QR 확인</p>
+                  <p className="text-[16px] text-[#374553]">QR을 발급할 티켓 정보가 없습니다.</p>
                   <Button variant="primary" className="w-full py-1.5" onClick={onClose}>
                      닫기
                   </Button>
@@ -151,11 +183,19 @@ export default function QrViewDialog({
                         </button>
 
                         <div className="w-[200px] h-[200px] flex items-center justify-center bg-surface rounded-xl overflow-hidden">
-                           <img
-                              src={QR_IMAGE_SRC}
-                              alt="QR 코드"
-                              className="w-full h-full object-contain"
-                           />
+                           {qrValue ? (
+                              <QRCodeCanvas
+                                 value={qrValue}
+                                 size={180}
+                                 level="M"
+                                 marginSize={2}
+                                 bgColor="#ffffff"
+                                 fgColor="#161d24"
+                                 title="모바일 티켓 QR 코드"
+                              />
+                           ) : (
+                              <div className="text-[14px] text-[#646f7c]">QR 생성 중</div>
+                           )}
                         </div>
 
                         <button

--- a/src/pages/mypage/ui/ResellRegisterDialog.tsx
+++ b/src/pages/mypage/ui/ResellRegisterDialog.tsx
@@ -5,7 +5,7 @@ import { X } from 'lucide-react';
 
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import { createResaleListings } from '@/entities/resale/api/resaleApi';
-import { useResellRegisterInsights } from '@/features/resale/model/useResellRegisterInsights';
+import { buildMockResellZoneInsights } from '@/entities/resale/model/resellZoneInsights';
 import { formatPrice } from '@/pages/books/model/zoneData';
 import { createStoredResaleListings } from '@/shared/lib/resaleListingStorage';
 import ResellPriceChart from '@/pages/books/ui/components/ResellPriceChart';
@@ -111,16 +111,13 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
          : item.game.quantity > 0
            ? Math.round(item.price / item.game.quantity)
            : item.price;
-
-   const resaleInsightsQuery = useResellRegisterInsights({
-      enabled: open,
-      gameId: item.gameId,
-      seatGradeName: item.seatGradeName,
-      sectionCode: item.game.section,
-      unitPrice,
+   const insights = buildMockResellZoneInsights({
+      zone: {
+         id: item.game.section || item.seatGradeName || 'fallback-grade',
+         name: item.seatGradeName || item.game.section || '좌석 등급',
+         price: unitPrice,
+      },
    });
-
-   const insights = resaleInsightsQuery.data?.insights ?? null;
    const checkedCount = checkedSeats.size;
 
    useEffect(() => {
@@ -394,27 +391,7 @@ export default function ResellRegisterDialog({ open, onClose, onCompleteConfirm,
                   </div>
 
                   {/* 거래 변동 + 차트 */}
-                  {resaleInsightsQuery.isLoading ? (
-                     <div className="bg-surface rounded-xl px-5 py-10 text-center text-[14px] text-[#646f7c]">
-                        거래 변동 정보를 불러오는 중입니다.
-                     </div>
-                  ) : resaleInsightsQuery.isError ? (
-                     <div className="bg-surface rounded-xl px-5 py-8 flex flex-col items-center gap-3 text-center">
-                        <p className="text-[14px] text-[#374553]">
-                           리셀 그래프 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
-                        </p>
-                        <Button
-                           variant="tertiary"
-                           type="button"
-                           className="px-4 py-2"
-                           onClick={() => {
-                              void resaleInsightsQuery.refetch();
-                           }}
-                        >
-                           다시 시도
-                        </Button>
-                     </div>
-                  ) : insights ? (
+                  {insights ? (
                      <ResellPriceChart insights={insights} />
                   ) : (
                      <div className="bg-surface rounded-xl px-5 py-10 text-center text-[14px] text-[#646f7c]">


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #186
  <br/>

  ## 🔎 개요

  마이페이지 API 연결을 정리하면서 예매 취소 요청 payload 오류를 수정했고, QR 확인 팝업이 실제 QR 토큰 발급 API를 호출하도록 변경했습니다.
  추가로 리셀 등록 팝업을 열 때 발생하던 좌석 등급/거래 그래프 조회는 제거해 불필요한 호출이 나가지 않도록 정리했습니다.

  <br/>

  ## 📋 작업 내용

  - 마이페이지 예매 취소 시 `ORDER_PARTIAL` 요청에 필요한 `orderItemId`가 누락되던 문제를 수정했습니다.
  - 취소 대상 좌석에 `orderItemId`가 없을 때는 빈 `orderItemIds`로 부분 취소를 보내지 않도록 요청 타입을 보정했습니다.
  - 구매 상세 좌석 모델에 `orderItemId`를 추가하고 취소 다이얼로그까지 전달되도록 연결했습니다.
  - QR 확인 팝업이 `GET /api/v1/tickets/{ticketId}/qr` 를 호출해 QR 토큰을 받아오도록 변경했습니다.
  - QR 팝업에서 좌석 전환 및 새로고침 시 QR 토큰을 다시 발급받도록 반영했습니다.
  - 기존 정적 QR 이미지 렌더링을 제거하고, 발급된 QR 토큰으로 실제 QR 코드를 렌더링하도록 변경했습니다.
  - 리셀 등록 팝업 오픈 시 호출되던 좌석 등급 조회/리셀 그래프 조회를 제거했습니다.
  - 리셀 등록 팝업의 차트/최근 거래 내역은 로컬 mock 인사이트만 사용하도록 정리했습니다.