### PR TITLE
[bug] 좌석 페이지 새로고침 후 좌석 상태 재조회 누락 수정 #371

### DIFF
--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import {
    buildSeatBlockFromApiSeats,
+   fetchSeatGrades,
    fetchSeatSections,
    fetchSeatStatuses,
    mapSeatStatusToUiStatus,
@@ -170,6 +171,22 @@ const buildAggregatedSeatMapSnapshot = ({
    };
 };
 
+const resolveSeatMapStadiumId = async ({
+   gameId,
+   stadiumId,
+}: {
+   gameId: string;
+   stadiumId?: string;
+}) => {
+   if (stadiumId) {
+      return stadiumId;
+   }
+
+   const grades = await fetchSeatGrades({ gameId });
+
+   return grades.find((grade) => grade.stadiumId)?.stadiumId;
+};
+
 const fetchAggregatedSeatSections = async ({
    gameId,
    stadiumId,
@@ -210,6 +227,7 @@ const fetchAggregatedSeatSections = async ({
 
 export const useSeatMapData = ({ gameId, preferMockSeatMap = false, stadiumId, zone }: SeatMapDataParams) => {
    const defaultSeatBlocks = useMemo(() => getSeatBlocks(zone), [zone]);
+   const requiresSectionResolution = isAggregatedSectionCode(zone.sectionCode) || !zone.sectionIds?.length;
 
    const { data, error, isError, isFetching, isLoading, refetch } = useQuery({
       queryKey: ['booking-seat-map', gameId, stadiumId, zone.id, zone.sectionCode],
@@ -219,6 +237,13 @@ export const useSeatMapData = ({ gameId, preferMockSeatMap = false, stadiumId, z
             return null;
          }
 
+         const resolvedStadiumId = requiresSectionResolution
+            ? await resolveSeatMapStadiumId({
+                 gameId,
+                 stadiumId,
+              })
+            : stadiumId;
+
          if (!isAggregatedSectionCode(zone.sectionCode)) {
             const resolvedSectionId = zone.sectionIds?.[0];
             const resolvedSection = resolvedSectionId
@@ -227,7 +252,7 @@ export const useSeatMapData = ({ gameId, preferMockSeatMap = false, stadiumId, z
                     sectionCode: zone.sectionCode,
                  }
                : await resolveSeatSectionByCode({
-                    stadiumId,
+                    stadiumId: resolvedStadiumId,
                     gameId,
                     sectionCode: zone.sectionCode,
                  });
@@ -262,13 +287,13 @@ export const useSeatMapData = ({ gameId, preferMockSeatMap = false, stadiumId, z
             };
          }
 
-         if (!stadiumId) {
-            return null;
+         if (!resolvedStadiumId) {
+            throw new Error(DEFAULT_SEAT_MAP_ERROR_MESSAGE);
          }
 
          const sectionBundles = await fetchAggregatedSeatSections({
             gameId,
-            stadiumId,
+            stadiumId: resolvedStadiumId,
             zone,
          });
 

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -232,6 +232,7 @@ export const useSeatMapData = ({ gameId, preferMockSeatMap = false, stadiumId, z
    const { data, error, isError, isFetching, isLoading, refetch } = useQuery({
       queryKey: ['booking-seat-map', gameId, stadiumId, zone.id, zone.sectionCode],
       enabled: !preferMockSeatMap && Boolean(gameId && zone.id && zone.sectionCode),
+      refetchOnMount: 'always',
       queryFn: async (): Promise<SeatMapApiSnapshot | null> => {
          if (!gameId || !zone.id || !zone.sectionCode) {
             return null;


### PR DESCRIPTION
## #️⃣ 관련 이슈
  - #371

  <br/>

  ## 🔎 개요

  좌석 선택 페이지에서 새로고침한 구역에 한해 좌석 상태 조회 API가 다시 호출되지 않던 버그를 수정했습니다.
  새로고침 이후 `stadiumId`/`sectionId` 해석이 끊기는 경우와, 동일 구역 재진입 시 query가 재조회되지 않는 경우를 함께 정리했습니다.

  <br/>

  ## 📋 작업 내용

  - `src/pages/books/model/useSeatMapData.ts`
  - 좌석 페이지 새로고침 후 `stadiumId`가 비어 있는 경우에도 `seat-grades`를 통해 `stadiumId`를 다시 해석하도록 수정했습니다.
  - 단일 구역에서 `sectionIds`가 없을 때도 복구된 `stadiumId`를 기준으로 `sectionId`를 다시 해석하도록 수정했습니다.
  - 집계 구역에서 `stadiumId`가 없을 때 `null`로 조용히 종료되던 흐름을 제거하고, 좌석 상태 조회가 누락되지 않도록 처리했습니다.
  - 좌석 상태 query에 `refetchOnMount: 'always'`를 적용해 동일 구역 재진입 시에도 좌석 상태 API가 다시 호출되도록 보장했습니다.