### PR TITLE
[bug] 예매 좌석 페이지 새로고침 후 동일 구역 상태 조회 누락 수정 #371

### DIFF
--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -24,6 +24,7 @@ const MEANINGFUL_SEAT_MAP_ERROR_PATTERNS = [/예매 가능/i, /권한/i, /로그
 
 type SeatMapDataParams = {
    gameId?: string;
+   isEntryReady?: boolean;
    preferMockSeatMap?: boolean;
    stadiumId?: string;
    zone: ZoneItem;
@@ -225,13 +226,13 @@ const fetchAggregatedSeatSections = async ({
    return sectionBundles;
 };
 
-export const useSeatMapData = ({ gameId, preferMockSeatMap = false, stadiumId, zone }: SeatMapDataParams) => {
+export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap = false, stadiumId, zone }: SeatMapDataParams) => {
    const defaultSeatBlocks = useMemo(() => getSeatBlocks(zone), [zone]);
    const requiresSectionResolution = isAggregatedSectionCode(zone.sectionCode) || !zone.sectionIds?.length;
 
    const { data, error, isError, isFetching, isLoading, refetch } = useQuery({
       queryKey: ['booking-seat-map', gameId, stadiumId, zone.id, zone.sectionCode],
-      enabled: !preferMockSeatMap && Boolean(gameId && zone.id && zone.sectionCode),
+      enabled: isEntryReady && !preferMockSeatMap && Boolean(gameId && zone.id && zone.sectionCode),
       refetchOnMount: 'always',
       queryFn: async (): Promise<SeatMapApiSnapshot | null> => {
          if (!gameId || !zone.id || !zone.sectionCode) {

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -229,9 +229,11 @@ const fetchAggregatedSeatSections = async ({
 export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap = false, stadiumId, zone }: SeatMapDataParams) => {
    const defaultSeatBlocks = useMemo(() => getSeatBlocks(zone), [zone]);
    const requiresSectionResolution = isAggregatedSectionCode(zone.sectionCode) || !zone.sectionIds?.length;
+   const zoneSectionIdsKey = zone.sectionIds?.join(',') ?? '';
+   const zoneGradeIdsKey = zone.gradeIds?.join(',') ?? '';
 
    const { data, error, isError, isFetching, isLoading, refetch } = useQuery({
-      queryKey: ['booking-seat-map', gameId, stadiumId, zone.id, zone.sectionCode],
+      queryKey: ['booking-seat-map', gameId, stadiumId, zone.id, zone.sectionCode, zoneSectionIdsKey, zoneGradeIdsKey],
       enabled: isEntryReady && !preferMockSeatMap && Boolean(gameId && zone.id && zone.sectionCode),
       refetchOnMount: 'always',
       queryFn: async (): Promise<SeatMapApiSnapshot | null> => {

--- a/src/pages/books/model/useSeatsPageEntry.ts
+++ b/src/pages/books/model/useSeatsPageEntry.ts
@@ -15,6 +15,7 @@ export function useSeatsPageEntry(zoneId: string) {
    const bookingFlowMode: BookingFlowMode = location.pathname.startsWith('/resell-books') ? 'resell' : 'standard';
    const isResellMode = bookingFlowMode === 'resell';
    const routeBookingEntryState = location.state as BookingEntryState | null;
+   const hasBookingEntryHydrated = useBookingEntryStore(state => state.hasHydrated);
    const storedBookingEntryState = useBookingEntryStore(state => state.entry);
    const setBookingEntry = useBookingEntryStore(state => state.setEntry);
    const bookingEntryState = mergeBookingEntryState(routeBookingEntryState, storedBookingEntryState);
@@ -40,6 +41,7 @@ export function useSeatsPageEntry(zoneId: string) {
       bookingEntryState,
       bookingFlowMode,
       bookingZones,
+      hasBookingEntryHydrated,
       isResellMode,
       stadiumName,
       zone,

--- a/src/pages/books/model/useZoneSeatState.ts
+++ b/src/pages/books/model/useZoneSeatState.ts
@@ -13,6 +13,7 @@ import { useSeatMapData } from './useSeatMapData';
 type UseZoneSeatStateParams = {
    bookingEntryState: BookingEntryState | null;
    bookingZones: ZoneItem[];
+   hasBookingEntryHydrated?: boolean;
    onPurchaseLimitReached?: () => void;
    preferMockSeatMap?: boolean;
    zone: ZoneItem;
@@ -21,6 +22,7 @@ type UseZoneSeatStateParams = {
 export function useZoneSeatState({
    bookingEntryState,
    bookingZones,
+   hasBookingEntryHydrated = true,
    onPurchaseLimitReached,
    preferMockSeatMap = false,
    zone,
@@ -36,6 +38,7 @@ export function useZoneSeatState({
       refetchSeatMap,
    } = useSeatMapData({
       gameId: bookingEntryState?.gameId,
+      isEntryReady: hasBookingEntryHydrated || Boolean(bookingEntryState),
       preferMockSeatMap,
       stadiumId: bookingEntryState?.stadiumId,
       zone,

--- a/src/pages/books/ui/SeatsPage.tsx
+++ b/src/pages/books/ui/SeatsPage.tsx
@@ -26,7 +26,8 @@ function SeatsPage() {
    const { zoneId = '' } = useParams();
    const { getBotReport } = useBotDetector();
    const botData = getBotReport() ?? undefined;
-   const { bookingEntryState, isResellMode, bookingZones, stadiumName, zone, zoneOverviewImage } = useSeatsPageEntry(zoneId);
+   const { bookingEntryState, hasBookingEntryHydrated, isResellMode, bookingZones, stadiumName, zone, zoneOverviewImage } =
+      useSeatsPageEntry(zoneId);
    const [isPurchaseLimitDialogOpen, setIsPurchaseLimitDialogOpen] = useState(false);
    const purchaseLimit = useBookingPurchaseLimit();
    const {
@@ -48,6 +49,7 @@ function SeatsPage() {
    } = useZoneSeatState({
       bookingEntryState,
       bookingZones,
+      hasBookingEntryHydrated,
       onPurchaseLimitReached: () => setIsPurchaseLimitDialogOpen(true),
       preferMockSeatMap: isResellMode && isResaleBookingMockEnabled,
       zone,


### PR DESCRIPTION
## #️⃣ 관련 이슈

  - #371

  <br/>

  ## 🔎 개요

  일반 예매에서 특정 구역을 선택해 `SeatsPage`로 진입한 뒤 새로고침하면,
  방금 새로고침한 동일 구역에 한해서 좌석 상태 조회 API가 호출되지 않던 문제를 수정했다.

  리셀 예매 경로는 영향 범위에서 제외하고, 일반 예매 좌석 조회 흐름만 보정했다.

  <br/>

  ## 📋 작업 내용

  - `SeatsPage` 진입 시 세션 기반 `bookingEntry` 복원이 끝나기 전에는 일반 예매 좌석 맵 조회를 시작하지 않도록 조정
  - 일반 예매 좌석 맵 조회 훅에서 `zone.sectionIds`, `zone.gradeIds` 변경도 쿼리 키에 반영하도록 수정
  - 새로고침 이후 현재 선택 구역의 메타데이터가 복원되면서 동일 구역 좌석 상태 조회가 다시 실행되도록 보강
  - 리셀 예매는 최대한 건드리지 않도록 분리하고, 기존 호출 방식은 유지