### PR TITLE
[bug] 좌석 새로고침 후 동일 구역 상태 재조회 보강

### DIFF
--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import {
@@ -231,10 +231,13 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
    const requiresSectionResolution = isAggregatedSectionCode(zone.sectionCode) || !zone.sectionIds?.length;
    const zoneSectionIdsKey = zone.sectionIds?.join(',') ?? '';
    const zoneGradeIdsKey = zone.gradeIds?.join(',') ?? '';
+   const shouldEnableSeatMapQuery =
+      isEntryReady && !preferMockSeatMap && Boolean(gameId && zone.id && zone.sectionCode);
+   const seatMapRequestKey = [gameId, stadiumId, zone.id, zone.sectionCode, zoneSectionIdsKey, zoneGradeIdsKey].join('|');
 
    const { data, error, isError, isFetching, isLoading, refetch } = useQuery({
       queryKey: ['booking-seat-map', gameId, stadiumId, zone.id, zone.sectionCode, zoneSectionIdsKey, zoneGradeIdsKey],
-      enabled: isEntryReady && !preferMockSeatMap && Boolean(gameId && zone.id && zone.sectionCode),
+      enabled: shouldEnableSeatMapQuery,
       refetchOnMount: 'always',
       queryFn: async (): Promise<SeatMapApiSnapshot | null> => {
          if (!gameId || !zone.id || !zone.sectionCode) {
@@ -312,6 +315,22 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
          });
       },
    });
+
+   const lastRefetchedRequestKeyRef = useRef<string | null>(null);
+
+   useEffect(() => {
+      if (!shouldEnableSeatMapQuery) {
+         lastRefetchedRequestKeyRef.current = null;
+         return;
+      }
+
+      if (lastRefetchedRequestKeyRef.current === seatMapRequestKey) {
+         return;
+      }
+
+      lastRefetchedRequestKeyRef.current = seatMapRequestKey;
+      void refetch();
+   }, [refetch, seatMapRequestKey, shouldEnableSeatMapQuery]);
 
    return {
       seatBlocks: data?.seatBlocks ?? defaultSeatBlocks,


### PR DESCRIPTION
## #️⃣ 관련 이슈

  - #371

  <br/>

  ## 🔎 개요

  `/books/seats/:zoneId` 화면에서 새로고침한 직후, 해당 구역에 한해서만 좌석 상태 조회 API가 다시 호출되지 않던 문제를 수정했습니다.

  <br/>

  ## 📋 작업 내용

  - `src/pages/books/model/useSeatMapData.ts` 에서 좌석 맵 조회 활성 조건을 `shouldEnableSeatMapQuery` 로 분리했습니다.
  - `gameId`, `stadiumId`, `zone.id`, `zone.sectionCode`, `zone.sectionIds`, `zone.gradeIds` 조합으로 요청 시그니처를 만들고, 이 값이 준비되거나 변경되면 좌석 맵 쿼리를 명시적으로 다시 refetch 하도록 보강했습니다.
  - 새로고침 후 동일 구역으로 재진입하는 경우에도 `GET /api/v1/game-seats/{gameId}/sections/{sectionId}/seat-statuses` 호출이 누락되지 않도록 처리했습니다.