### PR TITLE
[test] 좌석 상태 조회 흐름 로그 추가

### DIFF
--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -355,16 +355,36 @@ export const resolveSeatSectionByCode = async ({
    sectionCode: string;
 }) => {
    if (!stadiumId) {
+      logBookingFlow('bookingApi', 'resolveSeatSectionByCode skipped: missing stadiumId', {
+         stadiumId,
+         gameId,
+         sectionCode,
+      });
       return null;
    }
 
+   logBookingFlow('bookingApi', 'resolveSeatSectionByCode request', {
+      stadiumId,
+      gameId,
+      sectionCode,
+   });
    const sections = await fetchSeatSections({
       stadiumId,
       gameId,
    });
    const normalizedTargetSectionCode = normalizeSectionCode(sectionCode);
+   const resolvedSection =
+      sections.find((section) => normalizeSectionCode(section.sectionCode) === normalizedTargetSectionCode) ?? null;
 
-   return sections.find((section) => normalizeSectionCode(section.sectionCode) === normalizedTargetSectionCode) ?? null;
+   logBookingFlow('bookingApi', 'resolveSeatSectionByCode response', {
+      stadiumId,
+      gameId,
+      sectionCode,
+      normalizedTargetSectionCode,
+      resolvedSection,
+   });
+
+   return resolvedSection;
 };
 
 export const fetchSeats = async ({
@@ -396,11 +416,32 @@ export const fetchSeats = async ({
 };
 
 export const fetchSeatStatuses = async (gameId: string, sectionId: string) => {
-   const response = await apiClient.get<ApiEnvelope<SeatStatusResponse[]>>(
-      `/api/v1/game-seats/${gameId}/sections/${sectionId}/seat-statuses`,
-   );
+   logBookingFlow('bookingApi', 'fetchSeatStatuses request', {
+      gameId,
+      sectionId,
+   });
+   try {
+      const response = await apiClient.get<ApiEnvelope<SeatStatusResponse[]>>(
+         `/api/v1/game-seats/${gameId}/sections/${sectionId}/seat-statuses`,
+      );
+      const statuses = response.data.data ?? [];
 
-   return response.data.data;
+      logBookingFlow('bookingApi', 'fetchSeatStatuses response', {
+         gameId,
+         sectionId,
+         count: statuses.length,
+         summary: summarizeSeatStatusSnapshot(statuses),
+      });
+
+      return statuses;
+   } catch (error) {
+      logBookingFlowError('bookingApi', 'fetchSeatStatuses error', {
+         gameId,
+         sectionId,
+         error,
+      });
+      throw error;
+   }
 };
 
 export const summarizeSeatStatusSnapshot = (statuses: SeatStatusResponse[]) => {

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -15,6 +15,7 @@ import {
 } from '@/pages/books/api/bookingApi';
 import { getSeatBlocks } from '@/pages/books/model/seatData';
 import type { SeatBlock, SeatItem, ZoneItem } from '@/pages/books/model/types';
+import { logBookingFlow, logBookingFlowError, summarizeZone } from '@/shared/lib/bookingFlowDebug';
 import { getErrorMessage } from '@/shared/lib/error/getErrorMessage';
 
 const AGGREGATED_SECTION_CODE_PATTERN = /[~,/]/;
@@ -240,7 +241,21 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
       enabled: shouldEnableSeatMapQuery,
       refetchOnMount: 'always',
       queryFn: async (): Promise<SeatMapApiSnapshot | null> => {
+         logBookingFlow('useSeatMapData', 'queryFn start', {
+            seatMapRequestKey,
+            shouldEnableSeatMapQuery,
+            requiresSectionResolution,
+            gameId,
+            stadiumId,
+            zone: summarizeZone(zone),
+         });
+
          if (!gameId || !zone.id || !zone.sectionCode) {
+            logBookingFlow('useSeatMapData', 'queryFn skipped: missing query inputs', {
+               gameId,
+               zoneId: zone.id,
+               sectionCode: zone.sectionCode,
+            });
             return null;
          }
 
@@ -250,6 +265,13 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
                  stadiumId,
               })
             : stadiumId;
+
+         logBookingFlow('useSeatMapData', 'resolved stadium for seat map', {
+            seatMapRequestKey,
+            requiresSectionResolution,
+            inputStadiumId: stadiumId,
+            resolvedStadiumId,
+         });
 
          if (!isAggregatedSectionCode(zone.sectionCode)) {
             const resolvedSectionId = zone.sectionIds?.[0];
@@ -263,6 +285,12 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
                     gameId,
                     sectionCode: zone.sectionCode,
                  });
+
+            logBookingFlow('useSeatMapData', 'resolved single section seat map target', {
+               seatMapRequestKey,
+               resolvedSectionId,
+               resolvedSection,
+            });
 
             if (!resolvedSection) {
                throw new Error(DEFAULT_SEAT_MAP_ERROR_MESSAGE);
@@ -278,6 +306,13 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
             if (!seatBlock) {
                throw new Error(DEFAULT_SEAT_MAP_ERROR_MESSAGE);
             }
+
+            logBookingFlow('useSeatMapData', 'single section seat map resolved', {
+               seatMapRequestKey,
+               sectionId: resolvedSection.sectionId,
+               sectionCode: resolvedSection.sectionCode,
+               seatCount: seats.length,
+            });
 
             return {
                seatBlocks: [seatBlock],
@@ -304,6 +339,13 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
             zone,
          });
 
+         logBookingFlow('useSeatMapData', 'aggregated seat sections resolved', {
+            seatMapRequestKey,
+            sectionBundleCount: sectionBundles.length,
+            sectionIds: sectionBundles.map((section) => section.sectionId),
+            sectionCodes: sectionBundles.map((section) => section.sectionCode),
+         });
+
          if (sectionBundles.length === 0) {
             throw new Error(DEFAULT_SEAT_MAP_ERROR_MESSAGE);
          }
@@ -315,6 +357,48 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
          });
       },
    });
+
+   useEffect(() => {
+      logBookingFlow('useSeatMapData', 'query state snapshot', {
+         seatMapRequestKey,
+         enabled: shouldEnableSeatMapQuery,
+         isEntryReady,
+         preferMockSeatMap,
+         requiresSectionResolution,
+         gameId,
+         stadiumId,
+         zone: summarizeZone(zone),
+         hasData: Boolean(data),
+         apiSeatItemCount: data?.seatItems.length ?? 0,
+         isFetching,
+         isLoading,
+         isError,
+      });
+   }, [
+      data,
+      gameId,
+      isEntryReady,
+      isError,
+      isFetching,
+      isLoading,
+      preferMockSeatMap,
+      requiresSectionResolution,
+      seatMapRequestKey,
+      shouldEnableSeatMapQuery,
+      stadiumId,
+      zone,
+   ]);
+
+   useEffect(() => {
+      if (!error) {
+         return;
+      }
+
+      logBookingFlowError('useSeatMapData', 'query error', {
+         seatMapRequestKey,
+         error,
+      });
+   }, [error, seatMapRequestKey]);
 
    const lastRefetchedRequestKeyRef = useRef<string | null>(null);
 
@@ -329,6 +413,9 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
       }
 
       lastRefetchedRequestKeyRef.current = seatMapRequestKey;
+      logBookingFlow('useSeatMapData', 'manual refetch triggered for request key', {
+         seatMapRequestKey,
+      });
       void refetch();
    }, [refetch, seatMapRequestKey, shouldEnableSeatMapQuery]);
 

--- a/src/pages/books/model/useSeatsPageEntry.ts
+++ b/src/pages/books/model/useSeatsPageEntry.ts
@@ -8,6 +8,7 @@ import {
    useBookingEntryStore,
    type BookingEntryState,
 } from '@/shared/lib/useBookingEntryStore';
+import { logBookingFlow, summarizeBookingEntry, summarizeZone } from '@/shared/lib/bookingFlowDebug';
 import { getBookingZones, getStadiumName, getZoneOverviewImage } from './zoneData';
 
 export function useSeatsPageEntry(zoneId: string) {
@@ -36,6 +37,17 @@ export function useSeatsPageEntry(zoneId: string) {
       [bookingEntryState?.homeTeamId, zone.id],
    );
    const stadiumName = useMemo(() => getStadiumName(bookingEntryState?.homeTeamId), [bookingEntryState?.homeTeamId]);
+
+   useEffect(() => {
+      logBookingFlow('useSeatsPageEntry', 'resolved seat page entry', {
+         zoneId,
+         bookingFlowMode,
+         hasBookingEntryHydrated,
+         bookingEntryState: summarizeBookingEntry(bookingEntryState),
+         bookingZoneIds: bookingZones.map((item) => item.id),
+         resolvedZone: summarizeZone(zone),
+      });
+   }, [bookingEntryState, bookingFlowMode, bookingZones, hasBookingEntryHydrated, zone, zoneId]);
 
    return {
       bookingEntryState,

--- a/src/pages/books/model/useZoneSeatState.ts
+++ b/src/pages/books/model/useZoneSeatState.ts
@@ -9,6 +9,7 @@ import { getSelectedSeatDetails } from './selectedSeats';
 import type { SeatItem, ZoneItem } from './types';
 import { useSeatHoldActions } from './useSeatHoldActions';
 import { useSeatMapData } from './useSeatMapData';
+import { logBookingFlow, summarizeBookingEntry, summarizeZone } from '@/shared/lib/bookingFlowDebug';
 
 type UseZoneSeatStateParams = {
    bookingEntryState: BookingEntryState | null;
@@ -60,13 +61,47 @@ export function useZoneSeatState({
    );
 
    useEffect(() => {
+      logBookingFlow('useZoneSeatState', 'seat map source snapshot', {
+         hasBookingEntryHydrated,
+         bookingEntryState: summarizeBookingEntry(bookingEntryState),
+         zone: summarizeZone(zone),
+         hasApiSeatMap,
+         apiSeatItemCount: apiSeatItems.length,
+         initialSeatCount: initialSeats.length,
+         zoneSeatStateExists: Boolean(zoneSeatState),
+         isSeatMapLoading,
+         isSeatMapError,
+         seatMapErrorMessage,
+      });
+   }, [
+      apiSeatItems.length,
+      bookingEntryState,
+      hasApiSeatMap,
+      hasBookingEntryHydrated,
+      initialSeats.length,
+      isSeatMapError,
+      isSeatMapLoading,
+      seatMapErrorMessage,
+      zone,
+      zoneSeatState,
+   ]);
+
+   useEffect(() => {
       const syncedInitialSeats = syncHeldSeatsIntoZone(zone.id, initialSeats);
 
       if (hasApiSeatMap && apiSeatItems.length > 0) {
+         logBookingFlow('useZoneSeatState', 'apply server seat snapshot', {
+            zoneId: zone.id,
+            apiSeatItemCount: apiSeatItems.length,
+         });
          applyServerSeatSnapshot(zone.id, syncHeldSeatsIntoZone(zone.id, apiSeatItems));
          return;
       }
 
+      logBookingFlow('useZoneSeatState', 'initialize zone with local seat map', {
+         zoneId: zone.id,
+         initialSeatCount: syncedInitialSeats.length,
+      });
       initializeZone(zone.id, syncedInitialSeats);
    }, [
       apiSeatItems,

--- a/src/shared/lib/bookingFlowDebug.ts
+++ b/src/shared/lib/bookingFlowDebug.ts
@@ -1,4 +1,5 @@
 import type { BookingEntryState } from '@/shared/lib/useBookingEntryStore';
+import type { ZoneItem } from '@/pages/books/model/types';
 
 const BOOKING_FLOW_DEBUG_PREFIX = '[BookingFlowDebug]';
 
@@ -27,6 +28,22 @@ export const summarizeBookingEntry = (entry: BookingEntryState | null | undefine
       bookingZoneCount: entry.bookingZones?.length ?? 0,
       bookingZoneIds: entry.bookingZones?.map((zone) => zone.id) ?? [],
       hasBotData: Boolean(entry.botData),
+   };
+};
+
+export const summarizeZone = (zone: ZoneItem | null | undefined) => {
+   if (!zone) {
+      return null;
+   }
+
+   return {
+      id: zone.id,
+      name: zone.name,
+      price: zone.price,
+      remaining: zone.remaining,
+      sectionCode: zone.sectionCode,
+      sectionIds: zone.sectionIds ?? [],
+      gradeIds: zone.gradeIds ?? [],
    };
 };
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

  - #371

  <br/>

  ## 🔎 개요

  `/books/seats/:zoneId` 에서 새로고침 후 특정 구역의 좌석 상태 조회 API 호출이 누락되는 문제를 정확히 추적할 수 있도록, 예매 진입 상태부터 구역 해석, 쿼리 활성화, 실제 `seat-statuses` 호출까지 전체 흐름 로그를 추가했습니다.

  <br/>

  ## 📋 작업 내용

  - `src/shared/lib/bookingFlowDebug.ts`
    - 구역 메타데이터를 요약해서 출력할 수 있는 `summarizeZone` 로그 헬퍼를 추가했습니다.

  - `src/pages/books/model/useSeatsPageEntry.ts`
    - `zoneId`, hydration 상태, 복원된 `bookingEntryState`, 최종 선택된 `zone` 이 어떻게 해석되는지 로그를 추가했습니다.

  - `src/pages/books/model/useZoneSeatState.ts`
    - API seat map 사용 여부, 로컬 fallback 초기화 여부, zone state 존재 여부, seat map 로딩/에러 상태 로그를 추가했습니다.
    - 서버 스냅샷 적용 시점과 로컬 seat map 초기화 시점을 구분해서 확인할 수 있도록 로그를 남기도록 했습니다.

  - `src/pages/books/model/useSeatMapData.ts`
    - `enabled` 조건, request key, section 해석 필요 여부, 수동 `refetch` 트리거 여부를 로그로 확인할 수 있도록 보강했습니다.
    - 단일 section 분기와 집계 section 분기에서 각각 어떤 `sectionId` 와 `sectionCode` 로 좌석 상태 조회를 시도하는지 확인할 수 있도록 했습니다.
    - 쿼리 에러가 발생할 경우 request key 기준으로 에러를 추적할 수 있도록 로그를 추가했습니다.

  - `src/pages/books/api/bookingApi.ts`
    - `resolveSeatSectionByCode` 요청/응답 로그를 추가했습니다.
    - `fetchSeatStatuses` 요청/응답/에러 로그를 추가했고, 응답 개수와 상태 요약도 함께 출력하도록 했습니다.