### PR TITLE
[bug] 새로고침 리다이렉트 시 좌석 상태 캐시 정리

### DIFF
--- a/src/app/providers/router/ui/BookingFlowStateGuard.tsx
+++ b/src/app/providers/router/ui/BookingFlowStateGuard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { leaveQueueKeepalive } from '@/pages/queue/api/queueApi';
@@ -34,6 +35,7 @@ const isPageReload = () => {
 
 const BookingFlowStateGuard = () => {
    const navigate = useNavigate();
+   const queryClient = useQueryClient();
    const location = useLocation();
    const { pathname, search } = location;
    const previousPathnameRef = useRef<string | null>(null);
@@ -73,6 +75,12 @@ const BookingFlowStateGuard = () => {
             search,
             bookingEntry: summarizeBookingEntry(bookingEntry),
          });
+         void queryClient.cancelQueries({
+            queryKey: ['booking-seat-map'],
+         });
+         queryClient.removeQueries({
+            queryKey: ['booking-seat-map'],
+         });
          useSeatHoldStore.getState().clearSeatHolds();
          useSeatSelectionStore.getState().clearAllSelections();
          useBookingFlowTimerStore.getState().clearTimer();
@@ -101,7 +109,7 @@ const BookingFlowStateGuard = () => {
       }
 
       previousPathnameRef.current = pathname;
-   }, [bookingEntry, hasHydrated, navigate, pathname, search]);
+   }, [bookingEntry, hasHydrated, navigate, pathname, queryClient, search]);
 
    useEffect(() => {
       if (!shouldReleaseQueueOnUnload(pathname) || !bookingEntry?.gameId || !bookingEntry.queueTokenJti) {


### PR DESCRIPTION
## #️⃣ 관련 이슈

  - #371

  <br/>

  ## 🔎 개요

  `/books/seats/:zoneId` 화면에서 새로고침 직후 `/queue` 로 리다이렉트되는 과정에서, 동일 구역의 좌석 상태 조회 query가 React Query에 미완료 상태로 남아 이후 정상 플로우로 다시 진입해도 `seat-statuses` API가 재호출되지 않던 문제를 수정했습니다.

  <br/>

  ## 📋 작업 내용

  - `src/app/providers/router/ui/BookingFlowStateGuard.tsx`
    - 새로고침 후 `/queue` 리다이렉트 직전에 `booking-seat-map` query를 명시적으로 취소하도록 처리했습니다.
    - 이어서 같은 query를 React Query 캐시에서 제거하도록 처리했습니다.
    - 이로 인해 새로고침 중간에 남은 동일 구역 query key가 이후 재진입을 오염시키지 않도록 보강했습니다.

  - 문제 원인
    - `SeatsPage` 가 새로고침 직후 완전히 막히기 전에 잠깐 mount 되면서 seat map query를 먼저 시작했습니다.
    - 그 직후 `BookingFlowStateGuard` 가 `/queue` 로 리다이렉트하면서 동일 구역 query가 미완료 상태로 남았습니다.
    - 이후 사용자가 정상 플로우로 다시 같은 구역에 진입하면 React Query가 같은 key를 재사용해 `GET /api/v1/game-seats/{gameId}/sections/{sectionId}/seat-
  statuses` 호출이 다시 발생하지 않았습니다.

  - 기대 효과
    - 새로고침 후 queue 경유 뒤에도 동일 구역 재진입 시 좌석 상태 조회 API가 다시 정상 호출됩니다.
    - 다른 구역은 물론, 새로고침을 수행했던 구역도 동일하게 재조회가 보장됩니다.
