### PR TITLE
[bug] 새로고침 시 예매 좌석 화면 선마운트 차단

### DIFF
--- a/src/shared/widgets/layout/books/BooksLayout.tsx
+++ b/src/shared/widgets/layout/books/BooksLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
@@ -10,13 +10,30 @@ import { useMouseEventTracker } from '@/shared/lib/useMouseEventTracker';
 
 import BooksHeader from './BooksHeader';
 
+const isBookSelectionPath = (pathname: string) =>
+   pathname.startsWith('/books') || pathname.startsWith('/resell-books');
+
+const isPageReload = () => {
+   if (typeof window === 'undefined' || typeof performance === 'undefined') {
+      return false;
+   }
+
+   const [navigationEntry] = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[];
+   return navigationEntry?.type === 'reload';
+};
+
 const BooksLayout = () => {
    const navigate = useNavigate();
+   const location = useLocation();
+   const { pathname } = location;
+   const hasHydrated = useBookingEntryStore(state => state.hasHydrated);
    const bookingEntry = useBookingEntryStore(state => state.entry);
    const clearEntry = useBookingEntryStore(state => state.clearEntry);
    const clearTimer = useBookingFlowTimerStore(state => state.clearTimer);
    const clearSeatHolds = useSeatHoldStore(state => state.clearSeatHolds);
    const clearAllSelections = useSeatSelectionStore(state => state.clearAllSelections);
+   const shouldRedirectToQueueOnReload =
+      hasHydrated && isPageReload() && isBookSelectionPath(pathname) && Boolean(bookingEntry);
 
    const exitRef = useRef<() => void>(() => {});
    exitRef.current = () => {
@@ -37,6 +54,10 @@ const BooksLayout = () => {
    });
 
    useEffect(() => {
+      if (shouldRedirectToQueueOnReload) {
+         return;
+      }
+
       const handleWheel = (event: WheelEvent) => {
          if (event.ctrlKey || event.metaKey) {
             event.preventDefault();
@@ -70,6 +91,18 @@ const BooksLayout = () => {
          window.removeEventListener('gesturechange', handleGesture as EventListener);
       };
    }, []);
+
+   if (!hasHydrated && isBookSelectionPath(pathname)) {
+      return (
+         <div className="min-h-screen bg-background">
+            <BooksHeader />
+         </div>
+      );
+   }
+
+   if (shouldRedirectToQueueOnReload && bookingEntry) {
+      return <Navigate to="/queue" replace state={bookingEntry} />;
+   }
 
    return (
       <div className="min-h-screen bg-background">


### PR DESCRIPTION
## #️⃣ 관련 이슈

  - #371

  <br/>

  ## 🔎 개요

  예매 좌석 화면(`SeatsPage`)에서 새로고침할 때, `/queue` 리다이렉트 전에 좌석 화면이 먼저 mount 되면서 좌석 상태 조회 query가 비정상적으로 시작되고 이후 동일 구역 재진입을 오염시키던 문제를 수정했습니다.

  이번 수정은 seat map query를 사후 정리하는 방식보다 더 안정적으로, 새로고침 시 예매 좌석 화면이 먼저 mount 되지 않도록 상위 레이아웃에서 진입 자체를 차단하는 방향으로 적용했습니다.

  <br/>

  ## 📋 작업 내용

  - `src/shared/widgets/layout/books/BooksLayout.tsx`
    - 예매 플로우 경로(`/books`, `/books/seats/:zoneId`, `/resell-books/...`) 에서 새로고침이 감지되고, `bookingEntry` 가 복원된 상태라면 `Outlet` 을 렌더링을 하지 않고 바로 `/queue` 로 이동하도록 처리했습니다.
    - 이로 인해 새로고침 직후 `SeatsPage`, `useSeatMapData`, `useZoneSeatState` 가 먼저 실행되면서 React Query의 `booking-seat-map` 상태를 오염시키는 경로를 원천 차단했습니다.
    - hydration 이전에는 내부 예매 화면 대신 레이아웃 헤더만 렌더링해, 상태 복원 전에 하위 페이지가 먼저 mount 되지 않도록 보강했습니다.

  - 해결 의도
    - 기존에는 새로고침 후 `/queue` 로 이동하기 전에 `SeatsPage` 가 잠깐 mount 되면서 동일 구역 query key가 먼저 생성됐습니다.
    - 그 결과 이후 정상 플로우로 같은 구역에 재진입해도 좌석 상태 조회 API가 다시 시작되지 않는 문제가 발생했습니다.
    - 이번에는 하위 예매 페이지 자체가 mount 되지 않도록 변경해, 같은 유형의 캐시/수명주기 경합을 구조적으로 막았습니다.