### PR TITLE
[bug] 좌석맵 재조회 및 대기열 재진입 루프 수정

### DIFF
--- a/src/app/providers/router/ui/BookingFlowStateGuard.tsx
+++ b/src/app/providers/router/ui/BookingFlowStateGuard.tsx
@@ -24,7 +24,8 @@ const requiresQueueReentryOnBoot = (pathname: string) =>
    isBookSelectionPath(pathname) || isTicketCheckoutPath(pathname);
 const shouldReleaseQueueOnUnload = (pathname: string) =>
    isBookSelectionPath(pathname) || isTicketCheckoutPath(pathname);
-const isPageReload = () => {
+
+const getInitialLoadWasReload = () => {
    if (typeof window === 'undefined' || typeof performance === 'undefined') {
       return false;
    }
@@ -39,6 +40,7 @@ const BookingFlowStateGuard = () => {
    const location = useLocation();
    const { pathname, search } = location;
    const previousPathnameRef = useRef<string | null>(null);
+   const initialLoadWasReloadRef = useRef(getInitialLoadWasReload());
    const hasHydrated = useBookingEntryStore((state) => state.hasHydrated);
    const bookingEntry = useBookingEntryStore((state) => state.entry);
 
@@ -64,12 +66,17 @@ const BookingFlowStateGuard = () => {
          didExitBookingFlow,
          requiresEntry,
          requiresQueueReentryOnBoot: requiresQueueReentryOnBoot(pathname),
-         isReload: isPageReload(),
+         isReload: initialLoadWasReloadRef.current,
          hasHydrated,
          bookingEntry: summarizeBookingEntry(bookingEntry),
       });
 
-      if (isInitialAppLoad && isPageReload() && requiresQueueReentryOnBoot(pathname) && bookingEntry) {
+      if (
+         isInitialAppLoad &&
+         initialLoadWasReloadRef.current &&
+         requiresQueueReentryOnBoot(pathname) &&
+         bookingEntry
+      ) {
          logBookingFlow('BookingFlowStateGuard', 'redirect to /queue on reload', {
             pathname,
             search,

--- a/src/pages/books/model/useSeatMapData.ts
+++ b/src/pages/books/model/useSeatMapData.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
    buildSeatBlockFromApiSeats,
@@ -27,6 +27,7 @@ type SeatMapDataParams = {
    gameId?: string;
    isEntryReady?: boolean;
    preferMockSeatMap?: boolean;
+   queueTokenJti?: string;
    stadiumId?: string;
    zone: ZoneItem;
 };
@@ -227,17 +228,43 @@ const fetchAggregatedSeatSections = async ({
    return sectionBundles;
 };
 
-export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap = false, stadiumId, zone }: SeatMapDataParams) => {
+export const useSeatMapData = ({
+   gameId,
+   isEntryReady = true,
+   preferMockSeatMap = false,
+   queueTokenJti,
+   stadiumId,
+   zone,
+}: SeatMapDataParams) => {
+   const queryClient = useQueryClient();
    const defaultSeatBlocks = useMemo(() => getSeatBlocks(zone), [zone]);
    const requiresSectionResolution = isAggregatedSectionCode(zone.sectionCode) || !zone.sectionIds?.length;
    const zoneSectionIdsKey = zone.sectionIds?.join(',') ?? '';
    const zoneGradeIdsKey = zone.gradeIds?.join(',') ?? '';
    const shouldEnableSeatMapQuery =
       isEntryReady && !preferMockSeatMap && Boolean(gameId && zone.id && zone.sectionCode);
-   const seatMapRequestKey = [gameId, stadiumId, zone.id, zone.sectionCode, zoneSectionIdsKey, zoneGradeIdsKey].join('|');
+   const seatMapQueryKey = [
+      'booking-seat-map',
+      gameId,
+      stadiumId,
+      queueTokenJti,
+      zone.id,
+      zone.sectionCode,
+      zoneSectionIdsKey,
+      zoneGradeIdsKey,
+   ] as const;
+   const seatMapRequestKey = [
+      gameId,
+      stadiumId,
+      queueTokenJti,
+      zone.id,
+      zone.sectionCode,
+      zoneSectionIdsKey,
+      zoneGradeIdsKey,
+   ].join('|');
 
    const { data, error, isError, isFetching, isLoading, refetch } = useQuery({
-      queryKey: ['booking-seat-map', gameId, stadiumId, zone.id, zone.sectionCode, zoneSectionIdsKey, zoneGradeIdsKey],
+      queryKey: seatMapQueryKey,
       enabled: shouldEnableSeatMapQuery,
       refetchOnMount: 'always',
       queryFn: async (): Promise<SeatMapApiSnapshot | null> => {
@@ -367,6 +394,7 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
          requiresSectionResolution,
          gameId,
          stadiumId,
+         queueTokenJti,
          zone: summarizeZone(zone),
          hasData: Boolean(data),
          apiSeatItemCount: data?.seatItems.length ?? 0,
@@ -386,6 +414,7 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
       seatMapRequestKey,
       shouldEnableSeatMapQuery,
       stadiumId,
+      queueTokenJti,
       zone,
    ]);
 
@@ -401,10 +430,12 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
    }, [error, seatMapRequestKey]);
 
    const lastRefetchedRequestKeyRef = useRef<string | null>(null);
+   const lastRecoveredRequestKeyRef = useRef<string | null>(null);
 
    useEffect(() => {
       if (!shouldEnableSeatMapQuery) {
          lastRefetchedRequestKeyRef.current = null;
+         lastRecoveredRequestKeyRef.current = null;
          return;
       }
 
@@ -418,6 +449,46 @@ export const useSeatMapData = ({ gameId, isEntryReady = true, preferMockSeatMap 
       });
       void refetch();
    }, [refetch, seatMapRequestKey, shouldEnableSeatMapQuery]);
+
+   useEffect(() => {
+      if (!shouldEnableSeatMapQuery || Boolean(data) || isError) {
+         return;
+      }
+
+      const queryState = queryClient.getQueryState<SeatMapApiSnapshot | null>(seatMapQueryKey);
+      const isStuckPendingFetch =
+         queryState?.fetchStatus === 'fetching' &&
+         queryState.status === 'pending' &&
+         !queryState.dataUpdatedAt;
+
+      if (!isStuckPendingFetch || lastRecoveredRequestKeyRef.current === seatMapRequestKey) {
+         return;
+      }
+
+      lastRecoveredRequestKeyRef.current = seatMapRequestKey;
+      logBookingFlow('useSeatMapData', 'recover stuck pending seat map query', {
+         seatMapRequestKey,
+      });
+
+      void queryClient.cancelQueries({
+         queryKey: seatMapQueryKey,
+         exact: true,
+      }).then(() => {
+         queryClient.removeQueries({
+            queryKey: seatMapQueryKey,
+            exact: true,
+         });
+         void refetch();
+      });
+   }, [
+      data,
+      isError,
+      queryClient,
+      refetch,
+      seatMapQueryKey,
+      seatMapRequestKey,
+      shouldEnableSeatMapQuery,
+   ]);
 
    return {
       seatBlocks: data?.seatBlocks ?? defaultSeatBlocks,

--- a/src/pages/books/model/useZoneSeatState.ts
+++ b/src/pages/books/model/useZoneSeatState.ts
@@ -41,6 +41,7 @@ export function useZoneSeatState({
       gameId: bookingEntryState?.gameId,
       isEntryReady: hasBookingEntryHydrated || Boolean(bookingEntryState),
       preferMockSeatMap,
+      queueTokenJti: bookingEntryState?.queueTokenJti,
       stadiumId: bookingEntryState?.stadiumId,
       zone,
    });

--- a/src/shared/widgets/layout/books/BooksLayout.tsx
+++ b/src/shared/widgets/layout/books/BooksLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import { useSeatHoldStore } from '@/entities/seat-hold/model/useSeatHoldStore';
 import { useSeatSelectionStore } from '@/entities/seat-selection/model/useSeatSelectionStore';
@@ -13,15 +13,6 @@ import BooksHeader from './BooksHeader';
 const isBookSelectionPath = (pathname: string) =>
    pathname.startsWith('/books') || pathname.startsWith('/resell-books');
 
-const isPageReload = () => {
-   if (typeof window === 'undefined' || typeof performance === 'undefined') {
-      return false;
-   }
-
-   const [navigationEntry] = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[];
-   return navigationEntry?.type === 'reload';
-};
-
 const BooksLayout = () => {
    const navigate = useNavigate();
    const location = useLocation();
@@ -32,8 +23,6 @@ const BooksLayout = () => {
    const clearTimer = useBookingFlowTimerStore(state => state.clearTimer);
    const clearSeatHolds = useSeatHoldStore(state => state.clearSeatHolds);
    const clearAllSelections = useSeatSelectionStore(state => state.clearAllSelections);
-   const shouldRedirectToQueueOnReload =
-      hasHydrated && isPageReload() && isBookSelectionPath(pathname) && Boolean(bookingEntry);
 
    const exitRef = useRef<() => void>(() => {});
    exitRef.current = () => {
@@ -54,10 +43,6 @@ const BooksLayout = () => {
    });
 
    useEffect(() => {
-      if (shouldRedirectToQueueOnReload) {
-         return;
-      }
-
       const handleWheel = (event: WheelEvent) => {
          if (event.ctrlKey || event.metaKey) {
             event.preventDefault();
@@ -98,10 +83,6 @@ const BooksLayout = () => {
             <BooksHeader />
          </div>
       );
-   }
-
-   if (shouldRedirectToQueueOnReload && bookingEntry) {
-      return <Navigate to="/queue" replace state={bookingEntry} />;
    }
 
    return (


### PR DESCRIPTION
## #️⃣ 관련 이슈

  - #371

  <br/>

  ## 🔎 개요

  브라우저 새로고침 이후 같은 구역 좌석 페이지에 다시 진입할 때 좌석 상태 조회 API가 호출되지 않던 문제와,예매 플로우 이탈 후 `/queue` 재진입이 반복되며 대기열 API가 무한 호출되던 문제를 수정했습니다.

  <br/>

  ## 📋 작업 내용

  - `BookingFlowStateGuard`의 새로고침 판정을 앱 최초 진입 시점 1회로만 사용하도록 변경했습니다.
  - `BooksLayout`에서 `/books*` 렌더링마다 `/queue`로 재리다이렉트하던 로직을 제거했습니다.
  - 좌석맵 React Query 키에 `queueTokenJti`를 포함해 대기열 세션별로 좌석 조회 캐시를 분리했습니다.
  - `data` 없이 `fetching` 상태만 남은 좌석맵 stuck query를 감지하면 쿼리를 정리하고 재조회하도록 보강했습니다.
  - `useZoneSeatState`에서 좌석맵 조회 시 현재 대기열 토큰을 함께 전달하도록 수정했습니다.