### PR TITLE
[bug] 버튼 hit area 및 숨김 클릭 이슈 수정

### DIFF
--- a/src/pages/home/ui/game-schedule/ScheduleList.tsx
+++ b/src/pages/home/ui/game-schedule/ScheduleList.tsx
@@ -218,7 +218,7 @@ function ActionButtons({
             </div>
          )}
 
-         <div className={cn('hidden md:flex gap-2.5 items-stretch shrink-0', isEnded && 'opacity-0')}>
+         <div className={cn('hidden md:flex gap-2.5 items-stretch shrink-0', isEnded && 'pointer-events-none invisible')}>
             {/* 예매 버튼 — 데스크톱 */}
             {isTicketScheduled ? (
                <div className="w-[88px] bg-[#e9ebee] rounded-md px-4 py-2 flex flex-col items-center justify-center gap-0.5">

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from 'radix-ui';
 import { cn } from '@/shared/lib/utils';
 
 const buttonVariants = cva(
-   'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg transition-colors disabled:cursor-not-allowed [&_svg]:size-5 [&_svg]:shrink-0',
+   'inline-flex cursor-pointer select-none items-center justify-center gap-2 whitespace-nowrap rounded-lg transition-colors disabled:cursor-not-allowed disabled:pointer-events-none [&_svg]:size-5 [&_svg]:shrink-0',
    {
       variants: {
          variant: {

--- a/src/shared/ui/input-group.tsx
+++ b/src/shared/ui/input-group.tsx
@@ -34,7 +34,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 const inputGroupAddonVariants = cva(
-   "text-muted-foreground flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium select-none [&>svg:not([class*='size-'])]:size-4 [&>kbd]:rounded-[calc(var(--radius)-5px)] group-data-[disabled=true]/input-group:opacity-50",
+   "text-muted-foreground flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium select-none has-[button]:cursor-default [&>svg:not([class*='size-'])]:size-4 [&>kbd]:rounded-[calc(var(--radius)-5px)] group-data-[disabled=true]/input-group:opacity-50",
    {
       variants: {
          align: {

--- a/src/shared/ui/option.tsx
+++ b/src/shared/ui/option.tsx
@@ -4,7 +4,7 @@ import { Slot } from '@radix-ui/react-slot';
 import { cn } from '@/shared/lib/utils';
 
 const optionVariants = cva(
-   'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border transition-colors disabled:cursor-not-allowed',
+   'inline-flex cursor-pointer select-none items-center justify-center gap-2 whitespace-nowrap rounded-md border transition-colors disabled:cursor-not-allowed',
    {
       variants: {
          variant: {
@@ -53,7 +53,7 @@ const Option = React.forwardRef<HTMLButtonElement, OptionProps>(
                       항상 가장 넓은 너비인 'label-1-semibold'로 공간을 확보합니다. 
                       화면에는 보이지 않지만 버튼의 너비를 고정하는 역할을 합니다. 
                   */}
-                  <span className="invisible text-label-1-semibold opacity-0" aria-hidden="true">
+                  <span className="pointer-events-none invisible text-label-1-semibold opacity-0" aria-hidden="true">
                      {children}
                   </span>
 
@@ -63,7 +63,7 @@ const Option = React.forwardRef<HTMLButtonElement, OptionProps>(
                   */}
                   <span
                      className={cn(
-                        'absolute inset-0 flex items-center justify-center',
+                        'pointer-events-none absolute inset-0 flex items-center justify-center',
                         active ? 'text-label-1-semibold' : 'text-label-1-medium',
                      )}
                   >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -155,6 +155,13 @@
    }
 }
 
+@layer base {
+   button:not(:disabled) {
+      cursor: pointer;
+      user-select: none;
+   }
+}
+
 /* =====================================================
    Typography - Font
 ===================================================== */


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #389
- #390

  <br/>

  ## 🔎 개요

  - 회원가입 페이지에서 버튼 텍스트 위에 마우스를 올렸을 때 입력 커서처럼 보이고 클릭이 불안정한 문제를 수정했습니다.
  - 홈 경기일정의 종료 경기 카드에서 보이지 않는 리셀 예매 버튼이 클릭되던 문제를 수정했습니다.

  <br/>

  ## 📋 작업 내용

  - 공용 버튼 스타일에 `cursor-pointer`, `select-none`을 적용하고 비활성화 상태에서는 `pointer-events-none`으로 처리해 버튼 전반의 클릭 영역 동작을 정리했습니다.
  - `Option` 컴포넌트의 오버레이 텍스트에 `pointer-events-none`을 적용해 텍스트가 클릭을 가로채지 않도록 수정했습니다.
  - `InputGroup` addon 내부에 버튼이 포함된 경우 텍스트 입력용 커서가 노출되지 않도록 보정했습니다.
  - 홈 경기일정 `ScheduleList`에서 종료 경기의 데스크톱 액션 영역을 `invisible`과 `pointer-events-none`으로 처리해, 보이지 않는 버튼이 클릭되지 않도록 수정했습니다.