### PR TITLE
[bug] 회원가입 스낵바 클릭 가로채기 버그 수정

### DIFF
--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from 'radix-ui';
 import { cn } from '@/shared/lib/utils';
 
 const buttonVariants = cva(
-   'inline-flex cursor-pointer select-none items-center justify-center gap-2 whitespace-nowrap rounded-lg transition-colors disabled:cursor-not-allowed disabled:pointer-events-none [&_svg]:size-5 [&_svg]:shrink-0',
+   'relative z-10 inline-flex cursor-pointer select-none items-center justify-center gap-2 whitespace-nowrap rounded-lg transition-colors disabled:cursor-not-allowed disabled:pointer-events-none [&_svg]:size-5 [&_svg]:shrink-0',
    {
       variants: {
          variant: {

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from 'radix-ui';
 import { cn } from '@/shared/lib/utils';
 
 const buttonVariants = cva(
-   'relative z-10 inline-flex cursor-pointer select-none items-center justify-center gap-2 whitespace-nowrap rounded-lg transition-colors disabled:cursor-not-allowed disabled:pointer-events-none [&_svg]:size-5 [&_svg]:shrink-0',
+   'inline-flex cursor-pointer select-none items-center justify-center gap-2 whitespace-nowrap rounded-lg transition-colors disabled:cursor-not-allowed disabled:pointer-events-none [&_svg]:size-5 [&_svg]:shrink-0',
    {
       variants: {
          variant: {

--- a/src/shared/ui/snackbar.tsx
+++ b/src/shared/ui/snackbar.tsx
@@ -39,7 +39,7 @@ export function Snackbar({ open, message, duration = 3000, onClose, className }:
          variant="success"
          aria-live="polite"
          className={cn(
-            'fixed bottom-8 left-1/2 -translate-x-1/2 z-100',
+            'pointer-events-none fixed bottom-8 left-1/2 -translate-x-1/2 z-100',
             'transition-opacity duration-300',
             visible ? 'opacity-100' : 'opacity-0',
             className,


### PR DESCRIPTION
## #️⃣ 관련 이슈

  - #389

  <br/>

  ## 🔎 개요

  - 회원가입 페이지에서 인증번호 전송 후 스낵바가 보이지 않는 상태에서도 버튼 클릭을 가로채던 문제를 수정했습니다.
  - 이전에 들어갔던 공용 버튼 레이어 보정(`z-10`)은 UI 영향이 있어 함께 되돌렸습니다.

  <br/>

  ## 📋 작업 내용

  - `Snackbar`에 `pointer-events-none`을 적용해 토스트가 표시 중이거나 fade-out 중이어도 하단 버튼 클릭을 막지 않도록 수정했습니다.
  - 공용 `Button`에 들어가 있던 `z-10`을 제거해 다른 화면 UI가 깨지는 회귀를 정리했습니다.