### PR TITLE
[refactor] 홈구단 팀 코드 path 적용

### DIFF
--- a/cloud-home-team-code-path-handover.md
+++ b/cloud-home-team-code-path-handover.md
@@ -1,0 +1,64 @@
+# 홈구단 팀 코드 Path 전달
+
+클라우드 팀 제안에 맞춰 예매 플로우 API는 홈구단 `teamCode` 를 path 로 전달한다.
+
+## 규칙
+
+```text
+/api/{teamCode}/v1/...
+```
+
+예시:
+
+```text
+/api/KIA/v1/queue/enter
+/api/LG/v1/stadium-seats/games/{gameId}/seat-grades
+/api/SSG/v1/orders
+```
+
+## 사용 값
+
+- `homeTeamId(UUID)` 사용 안 함
+- `header` 사용 안 함
+- `query` 사용 안 함
+- `teamCode` 사용
+
+| 구단명 | teamCode |
+|---|---|
+| 삼성 라이온즈 | `SS` |
+| KIA 타이거즈 | `KIA` |
+| LG 트윈스 | `LG` |
+| 한화 이글스 | `HH` |
+| SSG 랜더스 | `SSG` |
+| NC 다이노스 | `NC` |
+| KT wiz | `KT` |
+| 롯데 자이언츠 | `LOT` |
+| 두산 베어스 | `DO` |
+| 키움 히어로즈 | `KIW` |
+
+## 적용 대상 API
+
+| 구분 | Method | API |
+|---|---|---|
+| 대기열 | `POST` | `/api/{teamCode}/v1/queue/enter` |
+| 대기열 | `GET` | `/api/{teamCode}/v1/queue/{gameId}/global-status` |
+| 대기열 | `GET` | `/api/{teamCode}/v1/queue/{gameId}/status` |
+| 대기열 | `POST` | `/api/{teamCode}/v1/queue/{gameId}/seat-enter` |
+| 대기열 | `POST` | `/api/{teamCode}/v1/queue/{gameId}/leave` |
+| 좌석 예매 | `GET` | `/api/{teamCode}/v1/stadium-seats/games/{gameId}/seat-grades` |
+| 좌석 예매 | `GET` | `/api/{teamCode}/v1/stadium-seats/stadiums/{stadiumId}/seat-sections` |
+| 좌석 예매 | `GET` | `/api/{teamCode}/v1/seats/seat-sections/{sectionId}/seats` |
+| 좌석 예매 | `GET` | `/api/{teamCode}/v1/game-seats/{gameId}/sections/{sectionId}/seat-statuses` |
+| 좌석 예매 | `GET` | `/api/{teamCode}/v1/teams/{teamId}/ticket-pricing-policies` |
+| 좌석 예매 | `POST` | `/api/{teamCode}/v1/seat-reservations/seats/{seatId}` |
+| 좌석 예매 | `POST` | `/api/{teamCode}/v1/seat-reservations/{holdId}` |
+| 결제 | `POST` | `/api/{teamCode}/v1/orders` |
+| 결제 | `GET` | `/api/{teamCode}/v1/payments/orders/{orderId}` |
+| 결제 | `POST` | `/api/{teamCode}/v1/payments/orders/{orderId}` |
+| 리셀 결제 | `POST` | `/api/{teamCode}/v1/resales/holds` |
+| 리셀 결제 | `PATCH` | `/api/{teamCode}/v1/resales/holds/{holdId}/release` |
+| 리셀 결제 | `POST` | `/api/{teamCode}/v1/resales/orders` |
+| 리셀 결제 | `GET` | `/api/{teamCode}/v1/resales/orders/{orderId}/transactions` |
+| 리셀 결제 | `POST` | `/api/{teamCode}/v1/payments/resales` |
+| 리셀 결제 | `PATCH` | `/api/{teamCode}/v1/resales/orders/{orderId}/complete` |
+| 리셀 결제 | `GET` | `/api/{teamCode}/v1/payments/resales/ledgers/orders/{orderId}` |

--- a/src/entities/resale/api/resaleApi.ts
+++ b/src/entities/resale/api/resaleApi.ts
@@ -2,6 +2,7 @@
 
 import apiClient from '@/shared/api/client';
 import type { ApiEnvelope } from '@/features/auth/api/types';
+import { buildBookingApiPath } from '@/shared/lib/bookingApiPath';
 import { createBookingFlowHeaders } from '@/shared/lib/guardrailHeaders';
 import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
 import { isResaleBookingMockEnabled, isResaleDemoEnabled } from '@/shared/config/runtime';
@@ -429,7 +430,7 @@ export const fetchResaleLedgers = async (params?: {
 
 export const fetchResaleLedgerByOrderId = async (orderId: string): Promise<ResaleLedger> => {
    const response = await apiClient.get<ApiEnvelope<ResaleLedger>>(
-      `/api/v1/payments/resales/ledgers/orders/${encodeURIComponent(orderId)}`,
+      buildBookingApiPath(`/api/v1/payments/resales/ledgers/orders/${encodeURIComponent(orderId)}`),
    );
 
    return response.data.data;

--- a/src/entities/seat-hold/api/seatHoldApi.ts
+++ b/src/entities/seat-hold/api/seatHoldApi.ts
@@ -2,6 +2,7 @@ import apiClient, { unwrapApiData } from '@/shared/api/client';
 import type { ApiEnvelope } from '@/features/auth/api/types';
 import { createBookingFlowHeaders } from '@/shared/lib/guardrailHeaders';
 import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
+import { buildBookingApiPath, buildBookingApiUrl } from '@/shared/lib/bookingApiPath';
 
 export type HoldSeatRequest = {
    gameId: string;
@@ -17,18 +18,15 @@ export type ReleaseSeatHoldResponse = {
 };
 
 const getSeatHoldReleaseUrl = (holdId: string) => {
-   const path = `/api/v1/seat-reservations/${encodeURIComponent(holdId)}`;
-
-   if (shouldUseRelativeApiBase || !configuredApiBaseUrl) {
-      return path;
-   }
-
-   return new URL(path, configuredApiBaseUrl).toString();
+   return buildBookingApiUrl({
+      path: `/api/v1/seat-reservations/${encodeURIComponent(holdId)}`,
+      baseUrl: shouldUseRelativeApiBase ? undefined : configuredApiBaseUrl,
+   });
 };
 
 export const holdSeatReservation = async (seatId: string, payload: HoldSeatRequest) => {
    const response = await apiClient.post<ApiEnvelope<HoldSeatResponse>>(
-      `/api/v1/seat-reservations/seats/${encodeURIComponent(seatId)}`,
+      buildBookingApiPath(`/api/v1/seat-reservations/seats/${encodeURIComponent(seatId)}`),
       payload,
    );
 
@@ -37,7 +35,7 @@ export const holdSeatReservation = async (seatId: string, payload: HoldSeatReque
 
 export const releaseSeatReservation = async (holdId: string) => {
    const response = await apiClient.post<ApiEnvelope<ReleaseSeatHoldResponse>>(
-      `/api/v1/seat-reservations/${encodeURIComponent(holdId)}`,
+      buildBookingApiPath(`/api/v1/seat-reservations/${encodeURIComponent(holdId)}`),
    );
 
    return unwrapApiData<ReleaseSeatHoldResponse>(response.data);

--- a/src/entities/seat/api/seatGradeApi.ts
+++ b/src/entities/seat/api/seatGradeApi.ts
@@ -1,5 +1,6 @@
 import apiClient from '@/shared/api/client';
 import type { ApiEnvelope } from '@/features/auth/api/types';
+import { buildBookingApiPath } from '@/shared/lib/bookingApiPath';
 
 export type SeatGradeResponse = {
    seatGradeId: string;
@@ -23,7 +24,7 @@ export const fetchSeatGrades = async ({
    forceNewSession?: boolean;
 }) => {
    const response = await apiClient.get<ApiEnvelope<SeatGradeSearchResultResponse>>(
-      `/api/v1/stadium-seats/games/${gameId}/seat-grades`,
+      buildBookingApiPath(`/api/v1/stadium-seats/games/${gameId}/seat-grades`),
       {
          params: forceNewSession ? { forceNewSession: true } : undefined,
       },

--- a/src/pages/books/api/bookingApi.ts
+++ b/src/pages/books/api/bookingApi.ts
@@ -2,6 +2,7 @@ import apiClient from '@/shared/api/client';
 import type { ApiEnvelope } from '@/features/auth/api/types';
 import { getBookingZones } from '@/pages/books/model/zoneData';
 import type { SeatBlock, SeatItem, SeatStatus, ZoneItem } from '@/pages/books/model/types';
+import { buildBookingApiPath } from '@/shared/lib/bookingApiPath';
 
 export type SeatGradeResponse = {
    seatGradeId: string;
@@ -300,7 +301,7 @@ export const fetchSeatGrades = async ({
 }) => {
    try {
       const response = await apiClient.get<ApiEnvelope<SeatGradeSearchResultResponse>>(
-         `/api/v1/stadium-seats/games/${gameId}/seat-grades`,
+         buildBookingApiPath(`/api/v1/stadium-seats/games/${gameId}/seat-grades`),
          {
             params: forceNewSession ? { forceNewSession: true } : undefined,
          },
@@ -320,7 +321,7 @@ export const fetchSeatSections = async ({
    gameId?: string;
 }) => {
    try {
-      const response = await apiClient.get<ApiEnvelope<SeatSectionResponse[]>>(`/api/v1/stadium-seats/stadiums/${stadiumId}/seat-sections`, {
+      const response = await apiClient.get<ApiEnvelope<SeatSectionResponse[]>>(buildBookingApiPath(`/api/v1/stadium-seats/stadiums/${stadiumId}/seat-sections`), {
          params: gameId ? { gameId } : undefined,
       });
       return response.data.data;
@@ -359,7 +360,7 @@ export const fetchSeats = async ({
    sectionId: string;
    gameId: string;
 }) => {
-   const response = await apiClient.get<ApiEnvelope<RawSeatResponse[]>>(`/api/v1/seats/seat-sections/${sectionId}/seats`, {
+   const response = await apiClient.get<ApiEnvelope<RawSeatResponse[]>>(buildBookingApiPath(`/api/v1/seats/seat-sections/${sectionId}/seats`), {
       params: { gameId },
    });
 
@@ -383,7 +384,7 @@ export const fetchSeats = async ({
 export const fetchSeatStatuses = async (gameId: string, sectionId: string) => {
    try {
       const response = await apiClient.get<ApiEnvelope<SeatStatusResponse[]>>(
-         `/api/v1/game-seats/${gameId}/sections/${sectionId}/seat-statuses`,
+         buildBookingApiPath(`/api/v1/game-seats/${gameId}/sections/${sectionId}/seat-statuses`),
       );
       return response.data.data ?? [];
    } catch (error) {
@@ -404,7 +405,7 @@ export const summarizeSeatStatusSnapshot = (statuses: SeatStatusResponse[]) => {
 export const fetchTicketPricingPolicy = async (teamId: string) => {
    try {
       const response = await apiClient.get<ApiEnvelope<TicketPricingPolicyResponse>>(
-         `/api/v1/teams/${teamId}/ticket-pricing-policies`,
+         buildBookingApiPath(`/api/v1/teams/${teamId}/ticket-pricing-policies`),
       );
       return response.data.data;
    } catch (error) {

--- a/src/pages/queue/api/queueApi.ts
+++ b/src/pages/queue/api/queueApi.ts
@@ -6,6 +6,7 @@ import type { ApiEnvelope } from '@/features/auth/api/types';
 import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
 import { buildMockQueueTokenJti } from '@/shared/config/booking';
 import { isResaleBookingMockEnabled } from '@/shared/config/runtime';
+import { buildBookingApiPath, buildBookingApiUrl } from '@/shared/lib/bookingApiPath';
 import { useBookingEntryStore } from '@/shared/lib/useBookingEntryStore';
 
 export interface QueueEnterResponse {
@@ -68,7 +69,7 @@ export const enterQueue = async (gameId: string): Promise<QueueEnterResponse> =>
 
   try {
     const response = await apiClient.post<ApiEnvelope<QueueEnterResponse>>(
-      '/api/v1/queue/enter',
+      buildBookingApiPath('/api/v1/queue/enter'),
       { gameId },
     );
     return response.data.data;
@@ -84,7 +85,7 @@ export const getQueueGlobalStatus = async (gameId: string): Promise<QueueStatusR
   }
 
   const response = await apiClient.get<ApiEnvelope<QueueStatusResponse>>(
-    `/api/v1/queue/${encodeURIComponent(gameId)}/global-status`,
+    buildBookingApiPath(`/api/v1/queue/${encodeURIComponent(gameId)}/global-status`),
   );
   return response.data.data;
 };
@@ -97,7 +98,7 @@ export const getQueueStatus = async (gameId: string): Promise<QueueStatusRespons
 
   try {
     const response = await apiClient.get<ApiEnvelope<QueueStatusResponse>>(
-      `/api/v1/queue/${encodeURIComponent(gameId)}/status`,
+      buildBookingApiPath(`/api/v1/queue/${encodeURIComponent(gameId)}/status`),
     );
     return response.data.data;
   } catch (error) {
@@ -121,7 +122,7 @@ export const seatEnterQueue = async (
 
   try {
     const response = await apiClient.post<ApiEnvelope<QueueSeatEnterResponse>>(
-      `/api/v1/queue/${encodeURIComponent(gameId)}/seat-enter`,
+      buildBookingApiPath(`/api/v1/queue/${encodeURIComponent(gameId)}/seat-enter`),
       { queueToken },
     );
     return response.data.data;
@@ -142,7 +143,7 @@ export const leaveQueue = async (gameId: string): Promise<QueueLeaveResponse> =>
 
   try {
     const response = await apiClient.post<ApiEnvelope<QueueLeaveResponse>>(
-      `/api/v1/queue/${encodeURIComponent(gameId)}/leave`,
+      buildBookingApiPath(`/api/v1/queue/${encodeURIComponent(gameId)}/leave`),
     );
     return response.data.data;
   } catch (error) {
@@ -151,9 +152,10 @@ export const leaveQueue = async (gameId: string): Promise<QueueLeaveResponse> =>
 };
 
 const getLeaveQueueUrl = (gameId: string) => {
-  const path = `/api/v1/queue/${encodeURIComponent(gameId)}/leave`;
-  if (shouldUseRelativeApiBase || !configuredApiBaseUrl) return path;
-  return new URL(path, configuredApiBaseUrl).toString();
+  return buildBookingApiUrl({
+    path: `/api/v1/queue/${encodeURIComponent(gameId)}/leave`,
+    baseUrl: shouldUseRelativeApiBase ? undefined : configuredApiBaseUrl,
+  });
 };
 
 /**

--- a/src/pages/tickets/api/paymentApi.ts
+++ b/src/pages/tickets/api/paymentApi.ts
@@ -11,6 +11,7 @@ import { type StoredPaymentCompleteItem } from '@/shared/lib/paymentCompleteStor
 import { resolveUserIdFromJwt } from '@/shared/lib/jwt';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import { configuredApiBaseUrl, shouldUseRelativeApiBase } from '@/shared/config/api';
+import { buildBookingApiPath, buildBookingApiUrl } from '@/shared/lib/bookingApiPath';
 import { isResaleBookingMockEnabled, isResaleDemoEnabled } from '@/shared/config/runtime';
 import {
    completeDemoResaleOrder,
@@ -186,13 +187,10 @@ const createClientTransactionId = (prefix: string) => {
 const delay = (ms: number) => new Promise(resolve => window.setTimeout(resolve, ms));
 
 const getResaleHoldReleaseUrl = (holdId: string) => {
-   const path = `/api/v1/resales/holds/${encodeURIComponent(holdId)}/release`;
-
-   if (shouldUseRelativeApiBase || !configuredApiBaseUrl) {
-      return path;
-   }
-
-   return new URL(path, configuredApiBaseUrl).toString();
+   return buildBookingApiUrl({
+      path: `/api/v1/resales/holds/${encodeURIComponent(holdId)}/release`,
+      baseUrl: shouldUseRelativeApiBase ? undefined : configuredApiBaseUrl,
+   });
 };
 
 const assertNever = (value: never): never => {
@@ -228,20 +226,22 @@ const toPaymentMethodLabel = (paymentMethod: PaymentMethod) => {
 };
 
 const createOrder = async (payload: CreateOrderRequest) => {
-   const response = await apiClient.post<ApiEnvelope<CreateOrderResponse>>('/api/v1/orders', payload);
+   const response = await apiClient.post<ApiEnvelope<CreateOrderResponse>>(buildBookingApiPath('/api/v1/orders'), payload);
 
    return response.data.data;
 };
 
 export const getOrderPayment = async (orderId: string) => {
-   const response = await apiClient.get<ApiEnvelope<OrderPaymentResponse>>(`/api/v1/payments/orders/${orderId}`);
+   const response = await apiClient.get<ApiEnvelope<OrderPaymentResponse>>(
+      buildBookingApiPath(`/api/v1/payments/orders/${orderId}`),
+   );
 
    return response.data.data;
 };
 
 const createOrderPayment = async (orderId: string, payload: OrderPaymentRequest) => {
    const response = await apiClient.post<ApiEnvelope<OrderPaymentResponse>>(
-      `/api/v1/payments/orders/${orderId}`,
+      buildBookingApiPath(`/api/v1/payments/orders/${orderId}`),
       payload,
    );
 
@@ -253,7 +253,7 @@ const createResaleHold = async (payload: ResaleHoldRequest) => {
       return createDemoResaleHold(payload.listingId, payload.queueTokenJti);
    }
 
-   const response = await apiClient.post<ApiEnvelope<ResaleHoldResponse>>('/api/v1/resales/holds', payload);
+   const response = await apiClient.post<ApiEnvelope<ResaleHoldResponse>>(buildBookingApiPath('/api/v1/resales/holds'), payload);
 
    return response.data.data;
 };
@@ -264,7 +264,7 @@ export const releaseResaleHold = async (holdId: string) => {
    }
 
    const response = await apiClient.patch<ApiEnvelope<ResaleHoldResponse>>(
-      `/api/v1/resales/holds/${encodeURIComponent(holdId)}/release`,
+      buildBookingApiPath(`/api/v1/resales/holds/${encodeURIComponent(holdId)}/release`),
    );
 
    return response.data.data;
@@ -298,7 +298,7 @@ const createResaleOrder = async (payload: ResaleOrderRequest) => {
       });
    }
 
-   const response = await apiClient.post<ApiEnvelope<ResaleOrderResponse>>('/api/v1/resales/orders', payload);
+   const response = await apiClient.post<ApiEnvelope<ResaleOrderResponse>>(buildBookingApiPath('/api/v1/resales/orders'), payload);
 
    return response.data.data;
 };
@@ -325,7 +325,7 @@ const getResaleTransactions = async (orderId: string) => {
    }
 
    const response = await apiClient.get<ApiEnvelope<ResaleOrderTransactionsResponse | string[]>>(
-      `/api/v1/resales/orders/${orderId}/transactions`,
+      buildBookingApiPath(`/api/v1/resales/orders/${orderId}/transactions`),
    );
 
    return normalizeTransactionIds(response.data.data);
@@ -355,7 +355,7 @@ const createResalePayment = async (payload: ResalePaymentRequest) => {
       });
    }
 
-   const response = await apiClient.post<ApiEnvelope<OrderPaymentResponse>>('/api/v1/payments/resales', payload);
+   const response = await apiClient.post<ApiEnvelope<OrderPaymentResponse>>(buildBookingApiPath('/api/v1/payments/resales'), payload);
 
    return response.data.data;
 };
@@ -380,7 +380,7 @@ const completeResaleOrder = async (orderId: string, paymentId: string): Promise<
    }
 
    const response = await apiClient.patch<ApiEnvelope<CompleteResaleOrderResponse>>(
-      `/api/v1/resales/orders/${encodeURIComponent(orderId)}/complete`,
+      buildBookingApiPath(`/api/v1/resales/orders/${encodeURIComponent(orderId)}/complete`),
       undefined,
       {
          params: { paymentId },

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -26,25 +26,26 @@ const authorizationOptionalApiPaths = new Set([
   tokenReissuePath,
 ]);
 const shouldKeepSessionAlivePathPrefixes = ["/books", "/resell-books", "/tickets"];
+const OPTIONAL_TEAM_PATH_SEGMENT = '(?:/[^/]+)?';
 const PUBLIC_API_PATH_PATTERNS = [
   /^\/api\/v1\/games(?:\/|$)/,
   /^\/api\/v1\/baseball-teams(?:\/|$)/
 ];
 
 const GUARDRAIL_HEADER_API_PATH_PATTERNS = [
-  /^\/api\/v1\/seat-reservations(?:\/|$)/,
-  /^\/api\/v1\/orders(?:\/|$)/,
-  /^\/api\/v1\/payments\/orders(?:\/|$)/,
-  /^\/api\/v1\/resales\/holds(?:\/|$)/,
-  /^\/api\/v1\/resales\/orders(?:\/|$)/,
-  /^\/api\/v1\/payments\/resales(?:\/|$)/,
-  /^\/api\/v1\/resales\/games(?:\/|$)/,
-  /^\/api\/v1\/resales\/listings(?:\/|$)/,
-  /^\/api\/v1\/resales\/histories(?:\/|$)/,
-  /^\/api\/v1\/game-seats(?:\/|$)/,
-  /^\/api\/v1\/stadium-seats(?:\/|$)/,
-  /^\/api\/v1\/seats(?:\/|$)/,
-  /^\/api\/v1\/teams\/[^/]+\/ticket-pricing-policies(?:\/|$)/,
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/seat-reservations(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/orders(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/payments/orders(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/resales/holds(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/resales/orders(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/payments/resales(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/resales/games(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/resales/listings(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/resales/histories(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/game-seats(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/stadium-seats(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/seats(?:/|$)`),
+  new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/teams/[^/]+/ticket-pricing-policies(?:/|$)`),
 ];
 
 type RetriableAxiosRequestConfig = AxiosRequestConfig & {
@@ -115,7 +116,7 @@ const shouldSkipAuthorizationHeader = (config: AxiosRequestConfig) => {
 
   try {
     const { pathname } = new URL(requestUrl, window.location.origin);
-    if (/^\/api\/v1\/queue\/[^/]+\/global-status$/.test(pathname)) {
+    if (new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/queue/[^/]+/global-status$`).test(pathname)) {
       return true;
     }
 
@@ -169,7 +170,7 @@ const shouldSkipCredentials = (config: AxiosRequestConfig) => {
 
   try {
     const { pathname } = new URL(requestUrl, window.location.origin);
-    if (/^\/api\/v1\/queue\/[^/]+\/global-status$/.test(pathname)) {
+    if (new RegExp(`^/api${OPTIONAL_TEAM_PATH_SEGMENT}/v1/queue/[^/]+/global-status$`).test(pathname)) {
       return true;
     }
 

--- a/src/shared/lib/bookingApiPath.ts
+++ b/src/shared/lib/bookingApiPath.ts
@@ -1,0 +1,83 @@
+import { teams } from '@/entities/team/model/teams';
+import { useBookingEntryStore } from '@/shared/lib/useBookingEntryStore';
+
+const API_PREFIX = '/api/';
+const shouldScopeBookingApiPath = !import.meta.env.DEV;
+
+const normalizeTeamCode = (teamCode?: string) => {
+   const trimmedValue = teamCode?.trim();
+
+   return trimmedValue ? encodeURIComponent(trimmedValue) : '';
+};
+
+const resolveTeamCodeFromTeamKey = (teamKey?: string) => {
+   if (!teamKey) {
+      return undefined;
+   }
+
+   return teams.find((team) => team.id === teamKey)?.teamCode;
+};
+
+const resolveTeamCodeFromServerTeamId = (serverTeamId?: string) => {
+   if (!serverTeamId) {
+      return undefined;
+   }
+
+   return teams.find((team) => team.serverTeamId === serverTeamId)?.teamCode;
+};
+
+export const getBookingApiTeamCode = (explicitTeamCode?: string) => {
+   const normalizedExplicitTeamCode = normalizeTeamCode(explicitTeamCode);
+
+   if (normalizedExplicitTeamCode) {
+      return normalizedExplicitTeamCode;
+   }
+
+   const bookingEntry = useBookingEntryStore.getState().entry;
+   const resolvedTeamCode =
+      resolveTeamCodeFromTeamKey(bookingEntry?.homeTeamId) ?? resolveTeamCodeFromServerTeamId(bookingEntry?.serverHomeTeamId);
+
+   return normalizeTeamCode(resolvedTeamCode);
+};
+
+/**
+ * Cloud 팀 요청 기준으로 예매 트래픽은 `/api/{teamCode}/v1/...` 형태의 경로를 사용한다.
+ * 실제 라우팅 규칙이 바뀌더라도 이 helper만 수정하면 예매 플로우 전체에 반영할 수 있다.
+ */
+export const buildBookingApiPath = (path: string, explicitTeamCode?: string) => {
+   if (!shouldScopeBookingApiPath) {
+      return path;
+   }
+
+   const teamCode = getBookingApiTeamCode(explicitTeamCode);
+
+   if (!teamCode || !path.startsWith(API_PREFIX)) {
+      return path;
+   }
+
+   const scopedApiPrefix = `${API_PREFIX}${teamCode}/`;
+
+   if (path.startsWith(scopedApiPrefix)) {
+      return path;
+   }
+
+   return path.replace(API_PREFIX, scopedApiPrefix);
+};
+
+export const buildBookingApiUrl = ({
+   path,
+   baseUrl,
+   teamCode,
+}: {
+   path: string;
+   baseUrl?: string;
+   teamCode?: string;
+}) => {
+   const resolvedPath = buildBookingApiPath(path, teamCode);
+
+   if (!baseUrl) {
+      return resolvedPath;
+   }
+
+   return new URL(resolvedPath, baseUrl).toString();
+};


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #397

  <br/>

  ## 🔎 개요

  예매 플로우 API 경로에 홈구단 `teamCode` 를 path segment로 포함하도록 반영했습니다.
  대기열, 좌석 예매, 결제, 리셀 결제 API가 배포 환경에서 `/api/{teamCode}/v1/...` 형태를 사용하도록 정리했습니다.

  <br/>

  ## 📋 작업 내용

  - 예매 플로우 전용 API path helper를 추가했습니다.
  - `bookingEntry`의 홈구단 정보를 실제 서버 `teamCode`로 변환해 API path에 주입하도록 반영했습니다.
  - 대기열 API 경로에 `teamCode` path 적용
  - 좌석 등급/구역/좌석/좌석 상태/가격 정책 조회 경로에 `teamCode` path 적용
  - 좌석 점유/해제 경로에 `teamCode` path 적용
  - 일반 결제/리셀 결제 관련 주문, 결제, 점유, 거래 조회 경로에 `teamCode` path 적용
  - `apiClient`의 guardrail/인증 예외 패턴이 `/api/{teamCode}/v1/...` 경로도 처리하도록 보정했습니다.