### PR TITLE
[refactor] MSW 비활성 시 팀 코드 path 적용 

### DIFF
--- a/src/shared/lib/bookingApiPath.ts
+++ b/src/shared/lib/bookingApiPath.ts
@@ -1,8 +1,9 @@
 import { teams } from '@/entities/team/model/teams';
+import { isMswEnabled } from '@/shared/config/runtime';
 import { useBookingEntryStore } from '@/shared/lib/useBookingEntryStore';
 
 const API_PREFIX = '/api/';
-const shouldScopeBookingApiPath = !import.meta.env.DEV;
+const shouldScopeBookingApiPath = !isMswEnabled;
 
 const normalizeTeamCode = (teamCode?: string) => {
    const trimmedValue = teamCode?.trim();


### PR DESCRIPTION
## #️⃣ 관련 이슈

  - #397

  <br/>

  ## 🔎 개요

  예매 플로우 API가 홈구단 `teamCode`를 path segment로 전달하도록 정리했습니다.
  또한 MSW가 활성화된 경우에는 기존 경로를 유지하고, MSW가 비활성화된 경우에는 팀 코드가 포함된 경로로 실제 요청을 보내도록 조건을 보정했습니다.

  <br/>

  ## 📋 작업 내용

  - 예매 플로우 전용 API path helper를 추가했습니다.
  - `bookingEntry`의 홈구단 정보를 실제 서버 `teamCode`로 변환해 API path에 반영하도록 수정했습니다.
  - 대기열, 좌석 예매, 결제, 리셀 결제 API 경로에 `/api/{teamCode}/v1/...` 규칙을 적용했습니다.
  - keepalive 요청 경로도 동일한 팀 코드 path 규칙을 따르도록 맞췄습니다.
  - `apiClient`의 인증/guardrail 예외 패턴이 팀 코드가 포함된 경로도 처리하도록 보정했습니다.
  - MSW 활성화 여부를 기준으로 경로 변환을 분기하도록 수정했습니다.
    - `isMswEnabled === true`: 기존 `/api/v1/...`
    - `isMswEnabled !== true`: `/api/{teamCode}/v1/...`