### PR TITLE
[bug] 마이페이지 리셀 구매 QR 및 취소 안내 보완

### DIFF
--- a/src/pages/mypage/model/purchaseDetailHelpers.ts
+++ b/src/pages/mypage/model/purchaseDetailHelpers.ts
@@ -26,6 +26,25 @@ export const parseDateValue = (value: string | undefined | null): Date | null =>
    if (!value) return null;
 
    const normalizedForDate = value.replace(/\.\s/g, '.').replace(/\.$/, '').trim();
+   const localDateTimeMatch = normalizedForDate.match(
+      /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?$/,
+   );
+
+   // 타임존 정보가 없는 "YYYY-MM-DD HH:mm:ss"/"YYYY-MM-DDTHH:mm:ss" 형식은
+   // 브라우저 구현 차이에 기대지 않고 로컬 시각으로 명시적으로 해석한다.
+   if (localDateTimeMatch) {
+      const [, year, month, day, hour = '0', minute = '0', second = '0'] = localDateTimeMatch;
+
+      return new Date(
+         Number(year),
+         Number(month) - 1,
+         Number(day),
+         Number(hour),
+         Number(minute),
+         Number(second),
+      );
+   }
+
    const directDate = new Date(normalizedForDate);
    if (!Number.isNaN(directDate.getTime())) return directDate;
 
@@ -94,6 +113,8 @@ export const getGameStartCancellationDeadline = (gameDate: string | undefined): 
    const parsedGameDate = parseDateValue(gameDate);
    if (!parsedGameDate) return undefined;
 
+   // parseDateValue가 시간대 없는 gameDate를 로컬 시각으로 고정 해석하므로,
+   // "경기 시작 4시간 전" 계산도 동일한 기준에서 일관되게 동작한다.
    return new Date(parsedGameDate.getTime() - 4 * 60 * 60 * 1000).toISOString();
 };
 

--- a/src/pages/mypage/model/purchaseDetailHelpers.ts
+++ b/src/pages/mypage/model/purchaseDetailHelpers.ts
@@ -90,6 +90,31 @@ export const getFallbackCancelableUntil = (orderedAt: string | undefined): strin
    ).toISOString();
 };
 
+export const getGameStartCancellationDeadline = (gameDate: string | undefined): string | undefined => {
+   const parsedGameDate = parseDateValue(gameDate);
+   if (!parsedGameDate) return undefined;
+
+   return new Date(parsedGameDate.getTime() - 4 * 60 * 60 * 1000).toISOString();
+};
+
+export const resolveCancelDeadline = ({
+   cancelableUntil,
+   gameDate,
+   orderedAt,
+}: {
+   cancelableUntil?: string;
+   gameDate?: string;
+   orderedAt?: string;
+}): string | undefined => {
+   return cancelableUntil || getGameStartCancellationDeadline(gameDate) || getFallbackCancelableUntil(orderedAt);
+};
+
+export const isCancellationWindowOpen = (cancelDeadline: string | undefined, now = new Date()): boolean => {
+   const parsedDeadline = parseDateValue(cancelDeadline);
+   if (!parsedDeadline) return false;
+   return parsedDeadline.getTime() > now.getTime();
+};
+
 export const formatGameTitle = (value: string): string => {
    const [left, right] = value.split(/\s+vs\s+/i);
    if (!left || !right) return value.trim();

--- a/src/pages/mypage/model/useMypageData.ts
+++ b/src/pages/mypage/model/useMypageData.ts
@@ -180,12 +180,27 @@ const fetchMyOrderSummaries = async (): Promise<EnrichedOrderListItem[]> => {
    }));
 };
 
+const buildStoredPurchaseTicketIds = (item: StoredPaymentCompleteItem): string[] => {
+   const normalizedQuantity = Math.max(item.quantity, item.seats.length, 1);
+
+   return Array.from({ length: normalizedQuantity }, (_, index) => {
+      if (index === 0 && item.ticketId) {
+         return item.ticketId;
+      }
+
+      const baseId = item.orderId ?? item.orderNumber ?? 'stored-order';
+      const prefix = item.orderType === 'resale' ? 'mock-resale-ticket' : 'mock-ticket';
+      return `${prefix}:${baseId}:${index}`;
+   });
+};
+
 const mapStoredPaymentCompleteItemToPurchaseHistory = (item: StoredPaymentCompleteItem): PurchaseHistoryItem => {
    const seats = item.seats.length > 0
       ? item.seats.map((seatInfo) => parseSeatDetail(seatInfo))
       : Array.from({ length: item.quantity }, (_, index) => `좌석${index + 1}`);
    const primarySeatInfo = item.seats[0];
    const sectionLabel = primarySeatInfo ? parseGradeName(primarySeatInfo) : '좌석 정보';
+   const ticketIds = buildStoredPurchaseTicketIds(item);
 
    return {
       id: item.ticketId ?? item.orderId ?? item.orderNumber,
@@ -207,6 +222,8 @@ const mapStoredPaymentCompleteItemToPurchaseHistory = (item: StoredPaymentComple
       paymentStatus: mapPurchaseStatus(item.orderStatus ?? item.paymentStatus ?? 'CONFIRMED'),
       deliveryType: '모바일 티켓',
       canSell: item.orderType !== 'resale',
+      ticketIds,
+      seatPrices: Array.from({ length: item.quantity }, () => Math.round(item.amount / Math.max(item.quantity, 1))),
    };
 };
 

--- a/src/pages/mypage/model/useMypageData.ts
+++ b/src/pages/mypage/model/useMypageData.ts
@@ -184,6 +184,8 @@ const buildStoredPurchaseTicketIds = (item: StoredPaymentCompleteItem): string[]
    const normalizedQuantity = Math.max(item.quantity, item.seats.length, 1);
 
    return Array.from({ length: normalizedQuantity }, (_, index) => {
+      // 결제 완료 저장소의 ticketId는 주문 내 첫 번째 티켓 식별자로 취급한다.
+      // 나머지 좌석은 mock QR 렌더링이 가능하도록 안정적인 fallback ID를 생성한다.
       if (index === 0 && item.ticketId) {
          return item.ticketId;
       }

--- a/src/pages/mypage/ui/CancelConfirmDialog.tsx
+++ b/src/pages/mypage/ui/CancelConfirmDialog.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '@/shared/ui/button';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { cancelOrder } from '@/entities/order/api/orderApi';
+import { getErrorMessage } from '@/shared/lib/error/getErrorMessage';
 
 interface Props {
    open: boolean;
@@ -44,9 +45,10 @@ export default function CancelConfirmDialog({
    totalSeatCount,
 }: Props) {
    const navigate = useNavigate();
-   const queryClient = useQueryClient();
-   const [isLoading, setIsLoading] = useState(false);
-   const isFullSeatSelection = ticketCount === totalSeatCount;
+  const queryClient = useQueryClient();
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const isFullSeatSelection = ticketCount === totalSeatCount;
    const hasPartialOrderItemIds = selectedOrderItemIds.length > 0 && !isFullSeatSelection;
    const requestType = hasPartialOrderItemIds ? 'ORDER_PARTIAL' : 'ORDER_FULL';
    const orderItemIds = hasPartialOrderItemIds ? selectedOrderItemIds : undefined;
@@ -58,6 +60,7 @@ export default function CancelConfirmDialog({
             orderItemIds,
          }),
       onSuccess: () => {
+         setErrorMessage(null);
          selectedTicketIds.forEach((ticketId) => {
             queryClient.invalidateQueries({ queryKey: ['ticketDetail', ticketId] });
             queryClient.invalidateQueries({ queryKey: ['ticketDetailFallback', ticketId] });
@@ -69,7 +72,8 @@ export default function CancelConfirmDialog({
          onClose();
          navigate(`/mypage/purchase/${orderId}`, { state: { showCancelSuccess: true } });
       },
-      onError: () => {
+      onError: (error) => {
+         setErrorMessage(getErrorMessage(error, '예매 취소에 실패했습니다. 잠시 후 다시 시도해주세요.'));
          setIsLoading(false);
       },
    });
@@ -149,6 +153,12 @@ export default function CancelConfirmDialog({
                      </span>
                   </div>
                </div>
+
+               {errorMessage && (
+                  <p className="rounded-lg bg-destructive/10 px-3 py-2 text-[13px] leading-normal text-destructive">
+                     {errorMessage}
+                  </p>
+               )}
             </div>
 
             <div className="flex gap-3 px-5 pb-5">
@@ -159,6 +169,7 @@ export default function CancelConfirmDialog({
                   className="flex-1 py-3"
                   disabled={isLoading}
                   onClick={() => {
+                     setErrorMessage(null);
                      setIsLoading(true);
                      cancel();
                   }}

--- a/src/pages/mypage/ui/HistoryCard.tsx
+++ b/src/pages/mypage/ui/HistoryCard.tsx
@@ -16,6 +16,7 @@ import ActionStatusDialog from './ActionStatusDialog';
 import { cancelResaleListing } from '@/entities/resale/api/resaleApi';
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import { markStoredResaleListingCanceled } from '@/shared/lib/resaleListingStorage';
+import { isCancellationWindowOpen, resolveCancelDeadline } from '../model/purchaseDetailHelpers';
 
 export type PurchaseStatus = '입금 대기' | '예매 완료' | '부분 처리' | '관람 완료' | '취소/환불';
 export type SaleStatus = '판매 중' | '판매 완료' | '정산 대기' | '판매 취소 대기' | '취소 대기' | '취소 완료';
@@ -90,11 +91,16 @@ export default function HistoryCard(props: HistoryCardProps) {
    const [noAccountOpen, setNoAccountOpen] = useState(false);
    const [qrOpen, setQrOpen] = useState(false);
    const [saleCancelDialogType, setSaleCancelDialogType] = useState<'success' | 'error' | null>(null);
+   const [cancelUnavailableOpen, setCancelUnavailableOpen] = useState(false);
 
    const { mode, item } = props;
    const isPurchase = isPurchaseHistoryItem(mode, item);
    const purchaseItem = isPurchase ? item : null;
    const purchaseOrderId = purchaseItem?.rawOrderId;
+   const purchaseCancelDeadline = resolveCancelDeadline({
+      gameDate: purchaseItem?.game.datetime,
+      orderedAt: purchaseItem?.rawOrderDate ?? purchaseItem?.orderDate,
+   });
 
    // 모드별 파생값
    const dateLabel = isPurchase ? '예약일자' : '판매일자';
@@ -116,18 +122,21 @@ export default function HistoryCard(props: HistoryCardProps) {
       (purchaseItem?.paymentStatus === '입금 대기' ||
          purchaseItem?.paymentStatus === '예매 완료' ||
          purchaseItem?.paymentStatus === '부분 처리');
+   const isQrAvailablePurchaseStatus =
+      purchaseItem?.paymentStatus === '예매 완료' || purchaseItem?.paymentStatus === '부분 처리';
    const isSellablePurchaseStatus =
       !isResalePurchase &&
-      (purchaseItem?.paymentStatus === '예매 완료' || purchaseItem?.paymentStatus === '부분 처리');
+      isQrAvailablePurchaseStatus;
    const showSellBtn =
       hasPurchaseOrder &&
       purchaseItem?.deliveryType === '모바일 티켓' &&
       isSellablePurchaseStatus;
    const showCancelBtn = hasPurchaseOrder && isCancelablePurchaseStatus;
+   const canProceedCancel = isCancellationWindowOpen(purchaseCancelDeadline);
    const showQrBtn =
       hasPurchaseOrder &&
       item.deliveryType === '모바일 티켓' &&
-      isSellablePurchaseStatus;
+      isQrAvailablePurchaseStatus;
    const showDash =
       isPurchase && (purchaseItem?.paymentStatus === '취소/환불' || purchaseItem?.paymentStatus === '관람 완료');
    const canCancelSale = !isPurchase && (item as SaleHistoryItem).canCancel;
@@ -165,6 +174,14 @@ export default function HistoryCard(props: HistoryCardProps) {
                        }
                      : undefined
                }
+            />
+         )}
+         {isPurchase && (
+            <ActionStatusDialog
+               open={cancelUnavailableOpen}
+               title="예매 취소"
+               message="경기 시작 4시간 전까지만 취소할 수 있습니다."
+               onClose={() => setCancelUnavailableOpen(false)}
             />
          )}
          {isPurchase && resellOpen && purchaseItem && (
@@ -206,6 +223,7 @@ export default function HistoryCard(props: HistoryCardProps) {
             <QrViewDialog
                open={qrOpen}
                onClose={() => setQrOpen(false)}
+               disableQrTokenFetch={isResalePurchase}
                seats={item.game.seats.map((seat, index) => ({
                   ticketId: purchaseItem?.ticketIds?.[index],
                   section: item.game.section,
@@ -342,7 +360,12 @@ export default function HistoryCard(props: HistoryCardProps) {
                                  className="w-full"
                                  onClick={e => {
                                     e.stopPropagation();
-                                    setCancelOpen(true);
+                                    if (canProceedCancel) {
+                                       setCancelOpen(true);
+                                       return;
+                                    }
+
+                                    setCancelUnavailableOpen(true);
                                  }}
                               >
                                  예매 취소
@@ -483,7 +506,12 @@ export default function HistoryCard(props: HistoryCardProps) {
                                 className="flex-1"
                                 onClick={e => {
                                    e.stopPropagation();
-                                   setCancelOpen(true);
+                                   if (canProceedCancel) {
+                                      setCancelOpen(true);
+                                      return;
+                                   }
+
+                                   setCancelUnavailableOpen(true);
                                 }}
                              >
                                 예매 취소

--- a/src/pages/mypage/ui/PurchaseDetailDialogs.tsx
+++ b/src/pages/mypage/ui/PurchaseDetailDialogs.tsx
@@ -13,6 +13,7 @@ const parseGradeName = (seatInfo: string): string => {
 
 interface PurchaseDetailDialogsProps {
    orderId: string;
+   disableQrTokenFetch?: boolean;
    detail: {
       id: string;
       orderId: string;
@@ -44,6 +45,7 @@ interface PurchaseDetailDialogsProps {
 
 export function PurchaseDetailDialogs({
    orderId,
+   disableQrTokenFetch = false,
    detail,
    isBankTransfer,
    qrOpen,
@@ -119,6 +121,7 @@ export function PurchaseDetailDialogs({
          <QrViewDialog
             open={qrOpen}
             onClose={onCloseQr}
+            disableQrTokenFetch={disableQrTokenFetch}
             seats={detail.seatItems
                .filter((seat) => seat.status !== '취소완료')
                .map((seat) => ({ ticketId: seat.ticketId, section: seat.section, seatDetail: seat.seatDetail }))}

--- a/src/pages/mypage/ui/PurchaseDetailPage.tsx
+++ b/src/pages/mypage/ui/PurchaseDetailPage.tsx
@@ -20,6 +20,7 @@ import StatusBadge from './StatusBadge';
 import TicketItem from './TicketItem';
 import InfoItem from './InfoItem';
 import { PurchaseDetailDialogs } from './PurchaseDetailDialogs';
+import ActionStatusDialog from './ActionStatusDialog';
 import { Snackbar } from '@/shared/ui/snackbar';
 import { readStoredPaymentCompleteItems } from '@/shared/lib/paymentCompleteStorage';
 import { useAuthStore } from '@/entities/auth/model/authStore';
@@ -32,10 +33,12 @@ import {
    formatDateTime,
    parseGradeName,
    getFallbackCancelableUntil,
+   isCancellationWindowOpen,
    formatGameTitle,
    mapOverallStatus,
    mapTicketItemStatus,
    formatPrice,
+   resolveCancelDeadline,
 } from '../model/purchaseDetailHelpers';
 
 function SectionCard({ children, className = '' }: { children: ReactNode; className?: string }) {
@@ -81,6 +84,7 @@ export default function PurchaseDetailPage() {
    const [qrOpen, setQrOpen] = useState(false);
    const [cancelOpen, setCancelOpen] = useState(false);
    const [resellOpen, setResellOpen] = useState(false);
+   const [cancelUnavailableOpen, setCancelUnavailableOpen] = useState(false);
 
    const locationStateItem = (location.state as { historyItem?: PurchaseHistoryItem } | null)?.historyItem;
 
@@ -230,6 +234,12 @@ export default function PurchaseDetailPage() {
          // paidAt이 없을 경우 예매일자로 폴백
          const paidAt = orderPaymentQuery.data?.paidAt ?? fallbackOrderedAt;
          const total = orderPaymentQuery.data?.paymentAmount ?? fallbackTotalAmount;
+         const cancelDeadline = fallbackTicketStatus !== 'INVALID'
+            ? resolveCancelDeadline({
+                 gameDate: fallbackSource?.game.datetime ?? matchedOrder?.gameDate,
+                 orderedAt: fallbackOrderedAt,
+              })
+            : undefined;
 
          return {
             id: fallbackSource?.rawOrderId ?? fallbackSource?.id ?? resolvedOrderId ?? orderId ?? 'purchase-detail',
@@ -245,9 +255,7 @@ export default function PurchaseDetailPage() {
             orderDate: fallbackOrderedAt,
             orderer: ordererName,
             issuedAt: fallbackOrderedAt,
-            cancelDeadline: fallbackTicketStatus !== 'INVALID'
-               ? getFallbackCancelableUntil(fallbackOrderedAt)
-               : undefined,
+            cancelDeadline,
             seatInfo: fallbackSeatInfos[0] ?? '',
             ticketPrice: unitPrice,
             paymentMethodDisplay,
@@ -289,6 +297,10 @@ export default function PurchaseDetailPage() {
             status: '예매완료',
             price: Math.round(storedPaymentDetail.amount / Math.max(seats.length, 1)),
          }));
+         const cancelDeadline = resolveCancelDeadline({
+            gameDate: storedPaymentDetail.gameDate,
+            orderedAt: storedPaymentDetail.paidAt ?? storedPaymentDetail.orderedAt,
+         });
 
          return {
             id: storedPaymentDetail.ticketId ?? storedPaymentDetail.orderId ?? storedPaymentDetail.orderNumber,
@@ -304,7 +316,7 @@ export default function PurchaseDetailPage() {
             orderDate: storedPaymentDetail.orderedAt,
             orderer: myProfileSummaryQuery.data?.name?.trim() || fallbackOrdererName,
             issuedAt: storedPaymentDetail.paidAt ?? storedPaymentDetail.orderedAt,
-            cancelDeadline: getFallbackCancelableUntil(storedPaymentDetail.paidAt ?? storedPaymentDetail.orderedAt),
+            cancelDeadline,
             cancelDate: undefined,
             seatInfo: seats[0],
             ticketPrice: Math.round(storedPaymentDetail.amount / Math.max(seats.length, 1)),
@@ -368,6 +380,13 @@ export default function PurchaseDetailPage() {
          || undefined;
       const paymentAmount = orderPaymentQuery.data?.paymentAmount ?? total;
       const isResaleTicket = currentApiDetail.ticketStatus === 'RESALE_ISSUED';
+      const cancelDeadline = isInvalid
+         ? undefined
+         : resolveCancelDeadline({
+              cancelableUntil: currentApiDetail.cancelableUntil,
+              gameDate: currentApiDetail.gameDate,
+              orderedAt: currentApiDetail.orderedAt ?? currentApiDetail.issuedAt,
+           });
 
       return {
          id: currentApiDetail.ticketId,
@@ -383,10 +402,7 @@ export default function PurchaseDetailPage() {
          orderDate: currentApiDetail.orderedAt ?? currentApiDetail.issuedAt,
          orderer: ordererName,
          issuedAt: currentApiDetail.issuedAt,
-         cancelDeadline: isInvalid
-            ? undefined
-            : (currentApiDetail.cancelableUntil ??
-              getFallbackCancelableUntil(currentApiDetail.orderedAt ?? currentApiDetail.issuedAt)),
+         cancelDeadline,
          cancelDate: isInvalid ? (currentApiDetail.issuedAt ?? '-') : undefined,
          seatInfo: currentApiDetail.seatInfo,
          ticketPrice: currentApiDetail.ticketPrice,
@@ -450,9 +466,16 @@ export default function PurchaseDetailPage() {
    const totalRefund = totalTicketPrice - serviceFee;
    const seatTickets = detail.seatItems;
    const hasResolvedPaymentInfo = Boolean(detail.paymentMethodDisplay || detail.paidAt);
+   const canProceedCancel = detail.canCancel && isCancellationWindowOpen(detail.cancelDeadline);
 
    return (
       <div className="flex flex-col items-center pt-8 lg:pt-12.5 pb-40 px-4">
+         <ActionStatusDialog
+            open={cancelUnavailableOpen}
+            title="예매 취소"
+            message="경기 시작 4시간 전까지만 취소할 수 있습니다."
+            onClose={() => setCancelUnavailableOpen(false)}
+         />
          <Snackbar
             open={showCancelSnackbar}
             message="취소가 완료되었습니다."
@@ -461,6 +484,7 @@ export default function PurchaseDetailPage() {
 
          <PurchaseDetailDialogs
             orderId={orderId!}
+            disableQrTokenFetch={isMockResalePurchase}
             detail={detail}
             isBankTransfer={orderPaymentQuery.data?.paymentMethod === 'ACCOUNT_TRANSFER'}
             qrOpen={qrOpen}
@@ -627,7 +651,18 @@ export default function PurchaseDetailPage() {
 
             <div className="flex gap-3">
                {detail.canCancel && (
-                  <Button variant="tertiary" className="flex-1 py-3" onClick={() => setCancelOpen(true)}>
+                  <Button
+                     variant="tertiary"
+                     className="flex-1 py-3"
+                     onClick={() => {
+                        if (canProceedCancel) {
+                           setCancelOpen(true);
+                           return;
+                        }
+
+                        setCancelUnavailableOpen(true);
+                     }}
+                  >
                      예매 취소하기
                   </Button>
                )}

--- a/src/pages/mypage/ui/QrViewDialog.tsx
+++ b/src/pages/mypage/ui/QrViewDialog.tsx
@@ -1,6 +1,6 @@
 // src/pages/mypage/ui/QrViewDialog.tsx
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { QRCodeCanvas } from '@rc-component/qrcode';
 import { ChevronLeft, ChevronRight, RefreshCcw, Clock } from 'lucide-react';
@@ -20,6 +20,7 @@ interface QrViewDialogProps {
    open: boolean;
    onClose: () => void;
    seats: QrSeat[];
+   disableQrTokenFetch?: boolean;
    isTicketInfoLoading?: boolean;
    isTicketInfoError?: boolean;
    onRetryTicketInfo?: () => void;
@@ -35,6 +36,7 @@ export default function QrViewDialog({
    open,
    onClose,
    seats,
+   disableQrTokenFetch = false,
    isTicketInfoLoading = false,
    isTicketInfoError = false,
    onRetryTicketInfo,
@@ -47,13 +49,21 @@ export default function QrViewDialog({
    const qrQuery = useQuery({
       queryKey: ['ticketQr', currentSeat?.ticketId, refreshNonce],
       queryFn: () => fetchTicketQr(currentSeat!.ticketId!),
-      enabled: open && Boolean(currentSeat?.ticketId),
+      enabled: open && Boolean(currentSeat?.ticketId) && !disableQrTokenFetch,
       retry: false,
       staleTime: 0,
    });
-   const effectiveLoading = isTicketInfoLoading || (Boolean(currentSeat?.ticketId) && qrQuery.isLoading);
-   const effectiveError = isTicketInfoError || (Boolean(currentSeat?.ticketId) && qrQuery.isError);
-   const qrValue = qrQuery.data?.qrToken;
+   const effectiveLoading =
+      isTicketInfoLoading || (Boolean(currentSeat?.ticketId) && !disableQrTokenFetch && qrQuery.isLoading);
+   const effectiveError =
+      isTicketInfoError || (Boolean(currentSeat?.ticketId) && !disableQrTokenFetch && qrQuery.isError);
+   const qrValue = useMemo(() => {
+      if (disableQrTokenFetch && currentSeat?.ticketId) {
+         return `mock-resale-qr:${currentSeat.ticketId}:${refreshNonce}`;
+      }
+
+      return qrQuery.data?.qrToken;
+   }, [currentSeat?.ticketId, disableQrTokenFetch, qrQuery.data?.qrToken, refreshNonce]);
 
    // 팝업 열릴 때 초기화
    useEffect(() => {

--- a/src/pages/tickets/api/paymentApi.ts
+++ b/src/pages/tickets/api/paymentApi.ts
@@ -369,6 +369,7 @@ type CompleteResaleOrderResponse = {
    items: Array<{
       transactionId: string;
       listingId: string;
+      ticketId?: string;
       seatInfo: string;
       price: number;
    }>;
@@ -587,6 +588,7 @@ export const submitResaleOrder = async (
          gameVenue: payload.gameVenue,
          seats: [payload.seatInfo],
          resaleListingId: payload.listingId,
+         ticketId: completeResult.items[0]?.ticketId,
          issuedTicketCount,
       });
    } catch (error) {

--- a/src/shared/lib/demo/resaleDemo.ts
+++ b/src/shared/lib/demo/resaleDemo.ts
@@ -606,6 +606,7 @@ export const completeDemoResaleOrder = (orderId: string) => {
          return {
             transactionId: order.transactionIds[index] ?? createId('demo-transaction'),
             listingId: listing.listingId,
+            ticketId: listing.ticketId,
             seatInfo: listing.seatInfo,
             price: listing.listingPrice,
          };


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #186
  <!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->

  <br/>

  ## 🔎 개요

  마이페이지 구매 내역에서 리셀 구매 티켓의 QR 확인 흐름과 예매 취소 안내 동작을 보완했습니다.
  리셀 구매는 현재 mock 기반으로 동작하므로 QR 확인 버튼 클릭 시 실서버 QR 토큰 발급 API를 호출하지 않고도 QR 화면이 정상적으로 표시되도록 처리했습니다.
  또한 일반 예매 티켓은 취소 버튼을 유지하되, 경기 시작 4시간 전 이후에는 취소 진행 대신 안내 다이얼로그를 노출하도록 변경했습니다.

  <br/>

  ## 📋 작업 내용

  - 리셀 구매 티켓의 QR 확인 버튼 클릭 시 mock QR 값으로 다이얼로그가 정상 동작하도록 수정
  - 리셀 mock 결제 완료 데이터에 `ticketId`를 포함하도록 보강
  - 기존 세션 저장 데이터에 `ticketId`가 없어도 마이페이지에서 mock 티켓 ID를 생성해 QR 표시가 가능하도록 처리
  - 마이페이지 구매 내역 카드와 구매 상세에서 일반 티켓의 예매 취소 버튼을 계속 노출하도록 복구
  - 경기 시작 4시간 전 이후에는 실제 취소 다이얼로그 대신 안내 다이얼로그를 노출하도록 변경
  - 취소 요청 실패 시 서버 에러 메시지를 취소 확인 다이얼로그에 그대로 표시하도록 보완
  - 취소 가능 기한 계산을 공통 helper로 정리해 목록/상세에서 동일하게 사용하도록 정리